### PR TITLE
docs(cloud): fix deep-dive/arch-patterns route coherence + Azure/AKS nav (#2184 #2185 #2186)

### DIFF
--- a/src/content/docs/cloud/aks-deep-dive/module-7.1-aks-architecture.md
+++ b/src/content/docs/cloud/aks-deep-dive/module-7.1-aks-architecture.md
@@ -4,7 +4,7 @@ slug: cloud/aks-deep-dive/module-7.1-aks-architecture
 sidebar:
   order: 2
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2h | **Prerequisites**: Azure Essentials, Cloud Architecture Patterns, and basic `kubectl` familiarity
+**Complexity**: [MEDIUM] | **Time to Complete**: 2h | **Prerequisites**: Azure Essentials and basic `kubectl` familiarity. [Cloud Architecture Patterns](../../architecture-patterns/) is a recommended companion, not required first.
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/aks-deep-dive/module-7.4-aks-production.md
+++ b/src/content/docs/cloud/aks-deep-dive/module-7.4-aks-production.md
@@ -1516,7 +1516,7 @@ echo "az group delete --name rg-aks-prod --yes --no-wait"
 
 ## Next Module
 
-This is the final module in the AKS Deep Dive series. You now have the knowledge to architect, secure, network, observe, and scale production AKS clusters using industry-standard features from Kubernetes v1.35. Carry forward the habit of validating storage IOPS, log ingestion, and scaler thresholds in staging with the same observability stack you run in production — gates pass in CI only when those signals exist before traffic arrives. 
+Continue to [AKS Fleet Manager](../module-7.5-aks-fleet-manager/) to manage multiple AKS clusters as a fleet. You now have the knowledge to architect, secure, network, observe, and scale production AKS clusters using industry-standard features from Kubernetes v1.35. Carry forward the habit of validating storage IOPS, log ingestion, and scaler thresholds in staging with the same observability stack you run in production — gates pass in CI only when those signals exist before traffic arrives. 
 
 For further learning, explore the [Platform Engineering Track](/platform/) to deepen your understanding of continuous deployment configurations, advanced SRE resilience strategies, and cutting-edge DevSecOps pipelines that continue to build on this powerful infrastructure foundation.
 

--- a/src/content/docs/cloud/architecture-patterns/index.md
+++ b/src/content/docs/cloud/architecture-patterns/index.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 **Vendor-neutral theory for designing Kubernetes on any cloud provider.**
 
-Before diving into EKS, GKE, or AKS, you need to understand the architectural decisions that apply everywhere: managed vs self-managed trade-offs, multi-cluster strategies, cloud IAM integration patterns, and VPC network topologies. These concepts transfer across all three hyperscalers.
+This section covers the architectural decisions that apply across every cloud: managed vs self-managed trade-offs, multi-cluster strategies, cloud IAM integration patterns, and VPC network topologies. These concepts transfer across all three hyperscalers — and they land best once you have already worked through at least one provider's essentials and managed-Kubernetes deep dive (EKS, GKE, or AKS), so you can recognize each pattern in concrete form before generalizing it across clouds.
 
 ---
 

--- a/src/content/docs/cloud/architecture-patterns/index.md
+++ b/src/content/docs/cloud/architecture-patterns/index.md
@@ -27,11 +27,12 @@ Before diving into EKS, GKE, or AKS, you need to understand the architectural de
 
 - [Cloud Native 101](../../prerequisites/cloud-native-101/) -- containers, Docker basics
 - Basic Kubernetes knowledge (Pods, Deployments, Services)
+- At least one provider path first -- a Provider Essentials section plus its managed-Kubernetes deep dive ([AWS Essentials](../aws-essentials/) -> [EKS](../eks-deep-dive/), [GCP Essentials](../gcp-essentials/) -> [GKE](../gke-deep-dive/), or [Azure Essentials](../azure-essentials/) -> [AKS](../aks-deep-dive/)). Architecture & Enterprise reasons about cross-provider tradeoffs and assumes you already understand one provider's primitives.
 
 ## What's Next
 
-After Architecture Patterns, pick your cloud provider deep dive:
+Continue along the Architecture & Enterprise route:
 
-- [AWS EKS Deep Dive](../eks-deep-dive/)
-- [GCP GKE Deep Dive](../gke-deep-dive/)
-- [Azure AKS Deep Dive](../aks-deep-dive/)
+- [Advanced Operations](../advanced-operations/) -- multi-account strategies, transit hubs, cross-cluster networking, DR, and active-active at enterprise scale
+
+(The provider deep dives -- [EKS](../eks-deep-dive/), [GKE](../gke-deep-dive/), [AKS](../aks-deep-dive/) -- come *before* this section, not after: they produce the provider primitives Architecture & Enterprise assumes.)

--- a/src/content/docs/cloud/aws-essentials/module-1.3-ec2.md
+++ b/src/content/docs/cloud/aws-essentials/module-1.3-ec2.md
@@ -1023,7 +1023,7 @@ echo "Cleanup complete!"
 
 ## Next Module
 
-Now that you have stateless compute, you need a place to store massive amounts of unstructured data. Head to [Module 1.4: S3 & Object Storage](./module-1.4-s3/).
+Now that you have stateless compute, you need a place to store massive amounts of unstructured data. Head to [Module 1.4: S3 & Object Storage](../module-1.4-s3/).
 
 ## Sources
 

--- a/src/content/docs/cloud/azure-essentials/module-3.14-app-service.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.14-app-service.md
@@ -515,4 +515,4 @@ Before you call the exercise complete, write one "first five minutes" incident n
 
 ## Next Module
 
-This closes the Azure Essentials application-hosting decision path: App Service for slot-centered web apps, Container Apps for revision-centered container services and workers, and AKS for Kubernetes platforms. Next, carry these decisions into enterprise and hybrid cloud governance, where plan isolation, private endpoints, managed identities, diagnostics, and policy controls become reusable platform guardrails.
+This closes the Azure Essentials application-hosting decision path: App Service for slot-centered web apps, Container Apps for revision-centered container services and workers, and AKS for Kubernetes platforms. Continue to [Event Hubs & Event Grid](../module-3.15-event-hub-event-grid/) to add event-driven and streaming service boundaries to your Azure toolkit.

--- a/src/content/docs/cloud/azure-essentials/module-3.15-event-hub-event-grid.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.15-event-hub-event-grid.md
@@ -15,8 +15,7 @@ sidebar:
 
 ## What You'll Be Able to Do
 
-After completing this module, you will be
-able to:
+After completing this module, you will be able to:
 
 - **Compare** Event Hubs, Event Grid, Service Bus, Storage Queues, and Apache Kafka on AKS by matching each service to ordering, replay, fan-out, transaction, and ownership requirements.
 - **Design** a secure Azure event pipeline with managed identity, RBAC, private endpoints, Capture, delivery retry, dead-lettering, and CloudEvents payloads.
@@ -24,73 +23,15 @@ able to:
 - **Implement** an end-to-end Event Hubs Capture plus Event Grid notification flow with Azure CLI, a Python producer, and a webhook test endpoint.
 - **Evaluate** the cost impact of throughput units, processing units, capture windows, retained blobs, Event Grid operations, namespace throughput, and cross-region replication.
 
-The operator path is about choosing the
-right event service before an incident
-chooses it for you. Azure has several
-queues, brokers, and event routers because
-event-driven systems are not one shape. A
-telemetry firehose from thousands of
-devices, a storage-account blob-created
-notification, a command that must be
-processed once in order, and a
-developer-platform audit event all look
-like "messages" from far away. From close
-range they are different operational
-contracts, and the wrong contract creates
-expensive ambiguity.
+The operator path is about choosing the right event service before an incident chooses it for you. Azure has several queues, brokers, and event routers because event-driven systems are not one shape. A telemetry firehose from thousands of devices, a storage-account blob-created notification, a command that must be processed once in order, and a developer-platform audit event all look like "messages" from far away. From close range they are different operational contracts, and the wrong contract creates expensive ambiguity.
 
 ## Why This Module Matters
 
-Exercise scenario: a platform team
-receives three requests in the same
-planning meeting. The data team wants to
-ingest ten thousand telemetry records per
-second and replay a failed analytics job
-from yesterday. The application team wants
-a storage-account notification to call a
-webhook whenever a report blob lands. The
-finance team wants invoice commands
-processed exactly once, in order, with a
-dead-letter queue and manual replay. All
-three teams say they need "events", but
-only the first request naturally belongs
-on Event Hubs, only the second is a clean
-Event Grid fit, and the third is closer to
-Service Bus.
+Exercise scenario: a platform team receives three requests in the same planning meeting. The data team wants to ingest ten thousand telemetry records per second and replay a failed analytics job from yesterday. The application team wants a storage-account notification to call a webhook whenever a report blob lands. The finance team wants invoice commands processed exactly once, in order, with a dead-letter queue and manual replay. All three teams say they need "events", but only the first request naturally belongs on Event Hubs, only the second is a clean Event Grid fit, and the third is closer to Service Bus.
 
-This distinction matters because managed
-event services fail in different ways.
-Event Hubs fails operationally when
-partitions are undersized, throughput
-units are capped too low, consumer groups
-are overloaded, checkpoints stall, or
-retention is shorter than the replay
-window. Event Grid fails operationally
-when a handler is down, filters match too
-broadly, validation is not handled,
-retries multiply delivery operations, or
-dead-letter storage is missing. Service
-Bus fails operationally when lock
-duration, sessions, duplicate detection,
-transactions, or dead-letter handling are
-misunderstood. The right service makes the
-incident obvious; the wrong service turns
-every event into a forensic puzzle.
+This distinction matters because managed event services fail in different ways. Event Hubs fails operationally when partitions are undersized, throughput units are capped too low, consumer groups are overloaded, checkpoints stall, or retention is shorter than the replay window. Event Grid fails operationally when a handler is down, filters match too broadly, validation is not handled, retries multiply delivery operations, or dead-letter storage is missing. Service Bus fails operationally when lock duration, sessions, duplicate detection, transactions, or dead-letter handling are misunderstood. The right service makes the incident obvious; the wrong service turns every event into a forensic puzzle.
 
-The [Event Hubs
-overview](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-about)
-describes Event Hubs as a scalable event
-ingestion service, while the [Event Grid
-overview](https://learn.microsoft.com/en-us/azure/event-grid/overview)
-describes Event Grid as a highly scalable
-event routing service. Those words are
-easy to skim past, but they are the first
-split in the operator mental model. Event
-Hubs is where a stream lives long enough
-to be read, replayed, partitioned, and
-analyzed. Event Grid is where an event is
-routed to interested handlers and retried
-if delivery fails.
+The [Event Hubs overview](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-about) describes Event Hubs as a scalable event ingestion service, while the [Event Grid overview](https://learn.microsoft.com/en-us/azure/event-grid/overview) describes Event Grid as a highly scalable event routing service. Those words are easy to skim past, but they are the first split in the operator mental model. Event Hubs is where a stream lives long enough to be read, replayed, partitioned, and analyzed. Event Grid is where an event is routed to interested handlers and retried if delivery fails.
 
 Use this picture as the simplest map:
 
@@ -112,94 +53,23 @@ replay from retention                                  no stream replay contract
        Capture, Stream Analytics                 Event Hubs, Service Bus
 ```
 
-> **Pause and predict:** a producer emits one million sensor readings each minute, and a downstream job must replay the last six hours after a bug fix.
-> Would Event Grid or Event Hubs make the operator's recovery easier, and what property drives the answer?
+> **Pause and predict:** a producer emits one million sensor readings each minute, and a downstream job must replay the last six hours after a bug fix. Would Event Grid or Event Hubs make the operator's recovery easier, and what property drives the answer?
 
-The rest of the module treats Event Hubs
-and Event Grid side by side. That is
-deliberate. Operators do not receive
-tickets that say "please create the
-correct service". They receive workload
-requirements, cost constraints, security
-rules, and incident symptoms. Your job is
-to translate those signals into the right
-managed event contract.
+The rest of the module treats Event Hubs and Event Grid side by side. That is deliberate. Operators do not receive tickets that say "please create the correct service". They receive workload requirements, cost constraints, security rules, and incident symptoms. Your job is to translate those signals into the right managed event contract.
 
 ## Why Event-Driven Azure Has More Than One Service
 
-Event-driven architecture is not only
-about decoupling. It is about choosing
-where time, order, pressure, and
-responsibility live. If the producer
-writes faster than the consumer reads,
-someone must absorb that pressure. If a
-handler is offline, someone must decide
-how long to retry. If a record is
-malformed, someone must keep enough
-evidence to debug it. If a consumer
-deploys a bad version, someone must decide
-whether replay is available.
+Event-driven architecture is not only about decoupling. It is about choosing where time, order, pressure, and responsibility live. If the producer writes faster than the consumer reads, someone must absorb that pressure. If a handler is offline, someone must decide how long to retry. If a record is malformed, someone must keep enough evidence to debug it. If a consumer deploys a bad version, someone must decide whether replay is available.
 
-Event Hubs and Event Grid answer those
-questions differently. Event Hubs gives
-producers a durable append path and gives
-consumers a pull-based stream. Consumers
-read from partitions, maintain
-checkpoints, and can fall behind without
-forcing the producer to wait. Event Grid
-gives publishers a routing layer and gives
-subscribers delivery attempts. Subscribers
-receive discrete notifications through
-handlers such as Azure Functions, Logic
-Apps, webhooks, Event Hubs, Service Bus,
-Storage Queues, and Hybrid Connections.
+Event Hubs and Event Grid answer those questions differently. Event Hubs gives producers a durable append path and gives consumers a pull-based stream. Consumers read from partitions, maintain checkpoints, and can fall behind without forcing the producer to wait. Event Grid gives publishers a routing layer and gives subscribers delivery attempts. Subscribers receive discrete notifications through handlers such as Azure Functions, Logic Apps, webhooks, Event Hubs, Service Bus, Storage Queues, and Hybrid Connections.
 
-The [Azure messaging
-comparison](https://learn.microsoft.com/en-us/azure/service-bus-messaging/compare-messaging-services)
-is worth reading because it prevents a
-common mistake: treating every
-message-shaped problem as Event Grid.
-Service Bus exists because enterprise
-commands need ordering, sessions,
-transactions, duplicate detection, lock
-renewal, scheduled delivery, and a
-first-class dead-letter queue. Storage
-Queues exist because some workloads need a
-simple, low-cost queue with huge storage
-capacity and fewer broker semantics. Event
-Grid exists because many systems only need
-a small event to say "something happened
-over there". Event Hubs exists because
-streams need ingestion, retention,
-partitioned reads, replay, and analytics
-integration.
+The [Azure messaging comparison](https://learn.microsoft.com/en-us/azure/service-bus-messaging/compare-messaging-services) is worth reading because it prevents a common mistake: treating every message-shaped problem as Event Grid. Service Bus exists because enterprise commands need ordering, sessions, transactions, duplicate detection, lock renewal, scheduled delivery, and a first-class dead-letter queue. Storage Queues exist because some workloads need a simple, low-cost queue with huge storage capacity and fewer broker semantics. Event Grid exists because many systems only need a small event to say "something happened over there". Event Hubs exists because streams need ingestion, retention, partitioned reads, replay, and analytics integration.
 
 ### Streaming Versus Eventing
 
-Streaming is a time-ordered flow of
-records. The data often has analytic value
-as a sequence, not just as individual
-messages. You care about partition keys
-because order is only guaranteed inside a
-partition. You care about retention
-because the stream is a recovery tool. You
-care about consumer lag because a reader
-can be healthy but behind. You care about
-throughput because one weak namespace can
-throttle every producer.
+Streaming is a time-ordered flow of records. The data often has analytic value as a sequence, not just as individual messages. You care about partition keys because order is only guaranteed inside a partition. You care about retention because the stream is a recovery tool. You care about consumer lag because a reader can be healthy but behind. You care about throughput because one weak namespace can throttle every producer.
 
-Eventing is a notification pattern. The
-event usually says that a resource
-changed, a workflow step completed, or an
-integration point should react. You care
-about filters because a handler should
-receive only relevant events. You care
-about delivery retries because the router
-pushes to subscribers. You care about
-validation because webhook endpoints must
-prove they own the address. You care about
-dead-lettering because a handler outage
-should not erase evidence.
+Eventing is a notification pattern. The event usually says that a resource changed, a workflow step completed, or an integration point should react. You care about filters because a handler should receive only relevant events. You care about delivery retries because the router pushes to subscribers. You care about validation because webhook endpoints must prove they own the address. You care about dead-lettering because a handler outage should not erase evidence.
 
 ```text
 +---------------------+------------------------------+------------------------------+
@@ -215,110 +85,31 @@ should not erase evidence.
 
 ### Where Service Bus and Storage Queues Fit
 
-Service Bus is not a footnote. It is the
-first candidate when the unit is a
-business command rather than a telemetry
-record or notification. If a payment
-command, invoice command, or provisioning
-command must be processed once with lock
-renewal, sessions, transaction boundaries,
-and a dead-letter queue, Service Bus is
-the safer default. Event Grid can route a
-notification to Service Bus, but Event
-Grid should not be asked to become Service
-Bus by convention.
+Service Bus is not a footnote. It is the first candidate when the unit is a business command rather than a telemetry record or notification. If a payment command, invoice command, or provisioning command must be processed once with lock renewal, sessions, transaction boundaries, and a dead-letter queue, Service Bus is the safer default. Event Grid can route a notification to Service Bus, but Event Grid should not be asked to become Service Bus by convention.
 
-Storage Queues are useful when the message
-contract is simple and cost or storage
-capacity matters more than broker
-features. They are common in
-low-complexity worker patterns, simple
-retry loops, or systems that already
-depend heavily on Azure Storage. They do
-not replace Event Hubs for replayable
-streams or Event Grid for native Azure
-event routing.
+Storage Queues are useful when the message contract is simple and cost or storage capacity matters more than broker features. They are common in low-complexity worker patterns, simple retry loops, or systems that already depend heavily on Azure Storage. They do not replace Event Hubs for replayable streams or Event Grid for native Azure event routing.
 
 ### Worked Example: Four Requirements, Four Choices
 
-A fleet of point-of-sale devices emits
-one-kilobyte telemetry records
-continuously. The analytics team wants to
-replay yesterday's records after fixing a
-parsing bug. Choose Event Hubs because
-retention, partitions, consumer groups,
-and replay are core to the service.
+A fleet of point-of-sale devices emits one-kilobyte telemetry records continuously. The analytics team wants to replay yesterday's records after fixing a parsing bug. Choose Event Hubs because retention, partitions, consumer groups, and replay are core to the service.
 
-A storage account receives a nightly
-export file and must notify a compliance
-workflow. Choose Event Grid because the
-storage service already emits a
-blob-created event, and the workflow only
-needs a discrete notification.
+A storage account receives a nightly export file and must notify a compliance workflow. Choose Event Grid because the storage service already emits a blob-created event, and the workflow only needs a discrete notification.
 
-An order command must preserve
-customer-level order and must move to a
-dead-letter queue after repeated
-processing failures. Choose Service Bus
-because sessions, lock renewal, and DLQ
-handling are the operational contract.
+An order command must preserve customer-level order and must move to a dead-letter queue after repeated processing failures. Choose Service Bus because sessions, lock renewal, and DLQ handling are the operational contract.
 
-A research platform already runs Strimzi
-on AKS, requires custom Kafka broker
-configuration, and has a team that owns
-broker upgrades. Kafka on AKS may be
-justified because control and ecosystem
-compatibility matter more than
-managed-service convenience.
+A research platform already runs Strimzi on AKS, requires custom Kafka broker configuration, and has a team that owns broker upgrades. Kafka on AKS may be justified because control and ecosystem compatibility matter more than managed-service convenience.
 
-Now you solve it: your platform receives a
-request for "events" from a team that
-needs webhook fan-out to three SaaS
-endpoints, no replay, low message volume,
-and detailed failure evidence when an
-endpoint is down. Which service would you
-start with, and which feature must be
-configured before production?
+Now you solve it: your platform receives a request for "events" from a team that needs webhook fan-out to three SaaS endpoints, no replay, low message volume, and detailed failure evidence when an endpoint is down. Which service would you start with, and which feature must be configured before production?
 
 ## Event Hubs Deep Dive
 
-Event Hubs is easiest to operate when you
-stop thinking of it as a queue. It is a
-partitioned commit log with managed
-ingestion, retention, and consumer
-coordination. Producers append events.
-Consumers read from partitions. Each
-consumer group has its own view of
-progress. Checkpoint storage records where
-a reader stopped so it can continue after
-a restart.
+Event Hubs is easiest to operate when you stop thinking of it as a queue. It is a partitioned commit log with managed ingestion, retention, and consumer coordination. Producers append events. Consumers read from partitions. Each consumer group has its own view of progress. Checkpoint storage records where a reader stopped so it can continue after a restart.
 
-The [Event Hubs scalability
-guidance](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-scalability)
-ties the model to throughput units,
-processing units, and capacity units.
-Those units matter because Event Hubs is
-often placed at the front door of a data
-system. If the front door throttles,
-downstream services may look idle while
-producers fail.
+The [Event Hubs scalability guidance](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-scalability) ties the model to throughput units, processing units, and capacity units. Those units matter because Event Hubs is often placed at the front door of a data system. If the front door throttles, downstream services may look idle while producers fail.
 
 ### Partitions and Partition Keys
 
-A partition is an ordered sequence inside
-an event hub. Event Hubs guarantees
-ordering within a partition, not across
-the entire event hub. That means a
-partition key is an operational decision,
-not a cosmetic field. If all records for
-`device-123` use the same partition key,
-those records stay ordered relative to
-each other. If every record uses the same
-key, one partition becomes hot while other
-partitions sit idle. If no key is used,
-Event Hubs distributes records across
-partitions, which is often good for
-throughput but removes affinity.
+A partition is an ordered sequence inside an event hub. Event Hubs guarantees ordering within a partition, not across the entire event hub. That means a partition key is an operational decision, not a cosmetic field. If all records for `device-123` use the same partition key, those records stay ordered relative to each other. If every record uses the same key, one partition becomes hot while other partitions sit idle. If no key is used, Event Hubs distributes records across partitions, which is often good for throughput but removes affinity.
 
 ```text
 event hub: telemetry
@@ -335,58 +126,17 @@ consumer group: analytics-prod
   checkpoint store says partition 3 offset Q
 ```
 
-Choose partition count before production
-with care. More partitions can improve
-parallelism, but they also increase reader
-coordination and may complicate per-key
-ordering assumptions. You cannot fix a
-poor partition-key strategy only by buying
-more throughput. If all writes land on one
-hot partition, the namespace can have
-spare capacity while one partition creates
-latency and throttling symptoms.
+Choose partition count before production with care. More partitions can improve parallelism, but they also increase reader coordination and may complicate per-key ordering assumptions. You cannot fix a poor partition-key strategy only by buying more throughput. If all writes land on one hot partition, the namespace can have spare capacity while one partition creates latency and throttling symptoms.
 
 ### Consumer Groups and Checkpoint Store
 
-A consumer group is an independent view
-over the same stream. The analytics team,
-fraud team, and archive verifier can each
-have their own consumer group. One team
-falling behind does not move another
-team's checkpoint. That independence is
-valuable, but it also means every new
-consumer group can multiply outbound read
-load.
+A consumer group is an independent view over the same stream. The analytics team, fraud team, and archive verifier can each have their own consumer group. One team falling behind does not move another team's checkpoint. That independence is valuable, but it also means every new consumer group can multiply outbound read load.
 
-The checkpoint store is where the client
-records progress. Most Azure SDK examples
-use Blob Storage for checkpoints because
-it is durable, cheap, and easy to
-coordinate across multiple reader
-instances. The checkpoint is not the event
-data. It is the bookmark. If the
-checkpoint store is unavailable or
-permissions are wrong, readers may
-repeatedly reprocess events or fail to
-coordinate partition ownership.
+The checkpoint store is where the client records progress. Most Azure SDK examples use Blob Storage for checkpoints because it is durable, cheap, and easy to coordinate across multiple reader instances. The checkpoint is not the event data. It is the bookmark. If the checkpoint store is unavailable or permissions are wrong, readers may repeatedly reprocess events or fail to coordinate partition ownership.
 
 ### Tiers: Basic, Standard, Premium, Dedicated
 
-The [Event Hubs quotas and tiers
-page](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-quotas)
-is the source you check before committing
-a design. The short version is that Basic
-is a low-cost ingestion tier with fewer
-features, Standard is the common
-shared-capacity production tier, Premium
-gives isolated resources and larger limits
-through processing units, and Dedicated
-gives single-tenant capacity through
-capacity units. Do not choose the tier
-from a feature name alone. Choose it from
-throughput, isolation, event size, Capture
-needs, private networking, schema
-registry, and operational blast radius.
+The [Event Hubs quotas and tiers page](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-quotas) is the source you check before committing a design. The short version is that Basic is a low-cost ingestion tier with fewer features, Standard is the common shared-capacity production tier, Premium gives isolated resources and larger limits through processing units, and Dedicated gives single-tenant capacity through capacity units. Do not choose the tier from a feature name alone. Choose it from throughput, isolation, event size, Capture needs, private networking, schema registry, and operational blast radius.
 
 | Tier | Capacity unit | Operator fit | Main tradeoff |
 |---|---|---|---|
@@ -397,257 +147,57 @@ registry, and operational blast radius.
 
 ### Throughput Units, Processing Units, and Capacity Units
 
-In Standard, a throughput unit is the
-planning unit. The commonly used mental
-model is one TU for up to one megabyte per
-second or one thousand events per second
-ingress, and up to two megabytes per
-second egress. The exact current limits
-and tier details belong in the Microsoft
-quota page, not in a runbook copied once
-and forgotten. The operator point is that
-both event count and bytes matter.
+In Standard, a throughput unit is the planning unit. The commonly used mental model is one TU for up to one megabyte per second or one thousand events per second ingress, and up to two megabytes per second egress. The exact current limits and tier details belong in the Microsoft quota page, not in a runbook copied once and forgotten. The operator point is that both event count and bytes matter.
 
-Worked sizing example: a telemetry
-workload sends ten thousand events per
-second, with one kilobyte average
-payloads, and the team wants eighty
-percent headroom. The event-rate
-requirement is ten thousand divided by one
-thousand divided by 0.8, which rounds up
-to thirteen TUs. The byte-rate requirement
-is about ten megabytes per second divided
-by one megabyte per second divided by 0.8,
-which also rounds up to thirteen TUs. The
-namespace should start at thirteen TUs or
-use auto-inflate with a ceiling above that
-value.
+Worked sizing example: a telemetry workload sends ten thousand events per second, with one kilobyte average payloads, and the team wants eighty percent headroom. The event-rate requirement is ten thousand divided by one thousand divided by 0.8, which rounds up to thirteen TUs. The byte-rate requirement is about ten megabytes per second divided by one megabyte per second divided by 0.8, which also rounds up to thirteen TUs. The namespace should start at thirteen TUs or use auto-inflate with a ceiling above that value.
 
-Using the public East US retail meters
-observed while writing this module,
-Standard Throughput Unit pricing was
-`$0.03` per hour and Standard ingress
-events were `$0.028` per million events.
-Thirteen TUs for a thirty-day month at
-seven hundred thirty hours is about
-`$284.70`. Ten thousand events per second
-for that month is about twenty-five
-billion nine hundred twenty million
-events, so the ingress-events meter is
-about `$725.76`. If Standard Capture is
-enabled on the namespace and billed at
-`$0.10` per hour, thirteen TUs add about
-`$949.00` before storage, reads, and
-regional data transfer. The rough monthly
-service subtotal is about `$1,959.46`, and
-the bill still needs blob storage,
-analytics readers, and Log Analytics
-ingestion.
+Using the public East US retail meters observed while writing this module, Standard Throughput Unit pricing was `$0.03` per hour and Standard ingress events were `$0.028` per million events. Thirteen TUs for a thirty-day month at seven hundred thirty hours is about `$284.70`. Ten thousand events per second for that month is about twenty-five billion nine hundred twenty million events, so the ingress-events meter is about `$725.76`. If Standard Capture is enabled on the namespace and billed at `$0.10` per hour, thirteen TUs add about `$949.00` before storage, reads, and regional data transfer. The rough monthly service subtotal is about `$1,959.46`, and the bill still needs blob storage, analytics readers, and Log Analytics ingestion.
 
-That example is intentionally plain. It
-shows why a stream that sounds "small"
-because each record is one kilobyte can
-still have a meaningful monthly bill when
-the rate is continuous. Cost is not a
-finance-only concern here. If you
-undersize TUs, you buy incidents. If you
-oversize without telemetry, you buy idle
-capacity. If you enable Capture and retain
-blobs forever, you buy storage growth that
-never pages anyone until the budget alert
-fires.
+That example is intentionally plain. It shows why a stream that sounds "small" because each record is one kilobyte can still have a meaningful monthly bill when the rate is continuous. Cost is not a finance-only concern here. If you undersize TUs, you buy incidents. If you oversize without telemetry, you buy idle capacity. If you enable Capture and retain blobs forever, you buy storage growth that never pages anyone until the budget alert fires.
 
 ### Auto-Inflate and Explicit Ceilings
 
-Auto-inflate lets a Standard namespace
-increase throughput units when ingress
-pressure rises. It is useful because
-traffic rarely respects the spreadsheet.
-It is also not a license to ignore
-capacity planning. Auto-inflate needs a
-maximum ceiling, and that ceiling is a
-cost and reliability decision. Set it too
-low and producers still throttle during
-spikes. Set it too high and one buggy
-producer can create an expensive month.
+Auto-inflate lets a Standard namespace increase throughput units when ingress pressure rises. It is useful because traffic rarely respects the spreadsheet. It is also not a license to ignore capacity planning. Auto-inflate needs a maximum ceiling, and that ceiling is a cost and reliability decision. Set it too low and producers still throttle during spikes. Set it too high and one buggy producer can create an expensive month.
 
-Use auto-inflate when traffic is bursty,
-producers are important, and the team has
-alerts on both throttling and capacity.
-Use fixed TUs when traffic is stable, cost
-ceilings are strict, and the producer
-behavior is controlled. For critical
-workloads, alert before the ceiling is
-reached so the operator has time to decide
-whether to raise the ceiling, shed load,
-tune partitions, or move to Premium.
+Use auto-inflate when traffic is bursty, producers are important, and the team has alerts on both throttling and capacity. Use fixed TUs when traffic is stable, cost ceilings are strict, and the producer behavior is controlled. For critical workloads, alert before the ceiling is reached so the operator has time to decide whether to raise the ceiling, shed load, tune partitions, or move to Premium.
 
 ### Premium and Dedicated Capacity
 
-Premium changes the conversation from
-shared throughput units to processing
-units. The [Event Hubs Premium
-overview](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-premium-overview)
-is the entry point for features such as
-stronger resource isolation, larger event
-sizes, private links, customer-managed
-keys, and included capabilities that are
-add-ons or constrained elsewhere. Premium
-often pays off when the workload is
-important enough that noisy-neighbor risk,
-larger events, private networking, schema
-registry, or predictable performance
-matter more than the lower Standard entry
-price.
+Premium changes the conversation from shared throughput units to processing units. The [Event Hubs Premium overview](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-premium-overview) is the entry point for features such as stronger resource isolation, larger event sizes, private links, customer-managed keys, and included capabilities that are add-ons or constrained elsewhere. Premium often pays off when the workload is important enough that noisy-neighbor risk, larger events, private networking, schema registry, or predictable performance matter more than the lower Standard entry price.
 
-Dedicated changes the conversation again.
-The [Event Hubs Dedicated
-overview](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-dedicated-overview)
-describes a single-tenant cluster model
-with capacity units. Dedicated is not the
-first stop for a normal application team.
-It is for organizations that have very
-high throughput, strict isolation
-requirements, or a platform team prepared
-to own capacity planning at a larger
-scale.
+Dedicated changes the conversation again. The [Event Hubs Dedicated overview](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-dedicated-overview) describes a single-tenant cluster model with capacity units. Dedicated is not the first stop for a normal application team. It is for organizations that have very high throughput, strict isolation requirements, or a platform team prepared to own capacity planning at a larger scale.
 
 ### Geo-Disaster Recovery Pairing
 
-The [Event Hubs geo-disaster recovery
-documentation](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-geo-dr)
-describes alias-based namespace pairing.
-The alias is the stable name clients use,
-while the primary and secondary namespaces
-sit behind it. Failover moves the alias,
-which means clients can reconnect without
-a full application reconfiguration.
+The [Event Hubs geo-disaster recovery documentation](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-geo-dr) describes alias-based namespace pairing. The alias is the stable name clients use, while the primary and secondary namespaces sit behind it. Failover moves the alias, which means clients can reconnect without a full application reconfiguration.
 
-Geo-DR is not magic replication of every
-operational concern. Operators still need
-to understand what metadata is replicated,
-what event data is not available after a
-failover, how producers reconnect, how
-consumers recover checkpoints, and how
-downstream systems handle duplicates. If
-the business requirement is cross-region
-data durability for the event stream
-itself, Capture to geo-redundant storage
-or a separate replication design may be
-needed. An alias helps with namespace
-failover; it does not replace a recovery
-architecture.
+Geo-DR is not magic replication of every operational concern. Operators still need to understand what metadata is replicated, what event data is not available after a failover, how producers reconnect, how consumers recover checkpoints, and how downstream systems handle duplicates. If the business requirement is cross-region data durability for the event stream itself, Capture to geo-redundant storage or a separate replication design may be needed. An alias helps with namespace failover; it does not replace a recovery architecture.
 
 ### Capture to Blob or ADLS Gen2
 
-The [Event Hubs Capture
-overview](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-capture-overview)
-explains how Event Hubs can write stream
-data to Azure Blob Storage or ADLS Gen2 in
-Avro format. Capture is a powerful
-operator feature because it decouples
-stream ingestion from batch analytics. The
-event hub can keep receiving data while
-downstream systems read files later. It is
-also a cost and data-lifecycle feature
-because those Avro blobs live in storage
-until lifecycle policy removes or tiers
-them.
+The [Event Hubs Capture overview](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-capture-overview) explains how Event Hubs can write stream data to Azure Blob Storage or ADLS Gen2 in Avro format. Capture is a powerful operator feature because it decouples stream ingestion from batch analytics. The event hub can keep receiving data while downstream systems read files later. It is also a cost and data-lifecycle feature because those Avro blobs live in storage until lifecycle policy removes or tiers them.
 
-Capture windows are configured by time and
-size. A short window creates smaller files
-and faster downstream visibility, but it
-can produce more objects and more listing
-overhead. A larger window produces fewer
-files, but it delays batch consumers. For
-many operational pipelines, a five-minute
-window is a practical starting point
-because it keeps the exercise observable
-without creating a file per event.
+Capture windows are configured by time and size. A short window creates smaller files and faster downstream visibility, but it can produce more objects and more listing overhead. A larger window produces fewer files, but it delays batch consumers. For many operational pipelines, a five-minute window is a practical starting point because it keeps the exercise observable without creating a file per event.
 
-Exactly-once language needs precision.
-Event Hubs can preserve order within a
-partition and Capture can write Avro files
-reliably, but end-to-end exactly-once
-processing depends on producers,
-consumers, checkpointing, idempotent
-sinks, and failure recovery. If a consumer
-writes to a database and checkpoints
-before the write is durable, data can be
-lost. If it writes to a database and
-crashes before checkpointing, data can be
-processed twice. Design idempotent
-consumers and use deterministic event IDs
-when the business cannot tolerate
-duplicate side effects.
+Exactly-once language needs precision. Event Hubs can preserve order within a partition and Capture can write Avro files reliably, but end-to-end exactly-once processing depends on producers, consumers, checkpointing, idempotent sinks, and failure recovery. If a consumer writes to a database and checkpoints before the write is durable, data can be lost. If it writes to a database and crashes before checkpointing, data can be processed twice. Design idempotent consumers and use deterministic event IDs when the business cannot tolerate duplicate side effects.
 
 ### Schema Registry
 
-The [Event Hubs Schema Registry
-overview](https://learn.microsoft.com/en-us/azure/event-hubs/schema-registry-overview)
-gives teams a managed place to store
-schemas for Avro, JSON, and Protobuf
-payloads. That matters because streams
-usually outlive one producer version. If
-every producer invents its own payload
-shape, consumers become archaeology
-projects. Compatibility modes give
-operators a way to control evolution, such
-as allowing additive fields while blocking
-changes that break old consumers.
+The [Event Hubs Schema Registry overview](https://learn.microsoft.com/en-us/azure/event-hubs/schema-registry-overview) gives teams a managed place to store schemas for Avro, JSON, and Protobuf payloads. That matters because streams usually outlive one producer version. If every producer invents its own payload shape, consumers become archaeology projects. Compatibility modes give operators a way to control evolution, such as allowing additive fields while blocking changes that break old consumers.
 
-Schema Registry also helps when Kafka
-clients use Event Hubs through the Kafka
-surface. The schema contract should be
-independent of the client library. Whether
-a producer uses an Azure SDK or a Kafka
-client, the platform still needs a clear
-rule for payload evolution, ownership, and
-breaking changes.
+Schema Registry also helps when Kafka clients use Event Hubs through the Kafka surface. The schema contract should be independent of the client library. Whether a producer uses an Azure SDK or a Kafka client, the platform still needs a clear rule for payload evolution, ownership, and breaking changes.
 
 ### Kafka Surface
 
-The [Event Hubs Kafka
-overview](https://learn.microsoft.com/en-us/azure/event-hubs/azure-event-hubs-apache-kafka-overview)
-explains how Event Hubs exposes an Apache
-Kafka-compatible endpoint for many Kafka
-clients. This is useful during migration
-or when an application already speaks the
-Kafka protocol. The operational benefit is
-that teams can use managed Event Hubs
-without running brokers, ZooKeeper-era
-components, or broker storage.
+The [Event Hubs Kafka overview](https://learn.microsoft.com/en-us/azure/event-hubs/azure-event-hubs-apache-kafka-overview) explains how Event Hubs exposes an Apache Kafka-compatible endpoint for many Kafka clients. This is useful during migration or when an application already speaks the Kafka protocol. The operational benefit is that teams can use managed Event Hubs without running brokers, ZooKeeper-era components, or broker storage.
 
-Compatibility is not the same as identical
-behavior. Event Hubs does not become a
-self-managed Kafka cluster with every
-broker-side feature, every admin API,
-every topic configuration knob, or every
-ecosystem expectation. Operators should
-test client versions, authentication,
-partition behavior, offset handling,
-transactions, idempotent producer
-requirements, and monitoring assumptions
-before promising a transparent migration.
-Kafka compatibility is a bridge, not a
-reason to ignore managed-service limits.
+Compatibility is not the same as identical behavior. Event Hubs does not become a self-managed Kafka cluster with every broker-side feature, every admin API, every topic configuration knob, or every ecosystem expectation. Operators should test client versions, authentication, partition behavior, offset handling, transactions, idempotent producer requirements, and monitoring assumptions before promising a transparent migration. Kafka compatibility is a bridge, not a reason to ignore managed-service limits.
 
 > **Pause and predict:** if a Kafka application depends on broker-level topic configuration and an admin API that Event Hubs does not support, what should the migration plan test before the cutover date?
 
 ## Event Grid Deep Dive
 
-Event Grid is an event router. It receives
-an event from a source, evaluates
-subscriptions and filters, and delivers
-matching events to handlers. The [Event
-Grid
-overview](https://learn.microsoft.com/en-us/azure/event-grid/overview)
-is the map for topics, event
-subscriptions, schemas, and handlers. The
-important operator idea is that Event Grid
-owns routing and delivery attempts, not a
-durable stream that consumers replay at
-will.
+Event Grid is an event router. It receives an event from a source, evaluates subscriptions and filters, and delivers matching events to handlers. The [Event Grid overview](https://learn.microsoft.com/en-us/azure/event-grid/overview) is the map for topics, event subscriptions, schemas, and handlers. The important operator idea is that Event Grid owns routing and delivery attempts, not a durable stream that consumers replay at will.
 
 ```text
 source service or app
@@ -669,88 +219,23 @@ source service or app
 
 ### Topics, System Topics, Custom Topics, Partner Topics, and Domains
 
-A topic is the endpoint where Event Grid
-receives events. System topics represent
-Azure resources that emit events, such as
-Storage Accounts. Custom topics are
-application-owned event entry points.
-Partner topics are used when a partner
-service publishes events into Azure.
-Domains group many topics under one
-management boundary, which is useful for
-SaaS-style multi-tenant publishing.
+A topic is the endpoint where Event Grid receives events. System topics represent Azure resources that emit events, such as Storage Accounts. Custom topics are application-owned event entry points. Partner topics are used when a partner service publishes events into Azure. Domains group many topics under one management boundary, which is useful for SaaS-style multi-tenant publishing.
 
-Use a system topic when the source is
-already an Azure resource that emits
-events. Use a custom topic when your
-application is the publisher. Use a domain
-when one publishing surface must serve
-many tenants or applications with
-topic-level isolation. Use a partner topic
-when the source is an integrated partner
-service. The question is not "which object
-can I create fastest"; it is "who owns the
-source, who owns the subscribers, and how
-many routing boundaries are needed?"
+Use a system topic when the source is already an Azure resource that emits events. Use a custom topic when your application is the publisher. Use a domain when one publishing surface must serve many tenants or applications with topic-level isolation. Use a partner topic when the source is an integrated partner service. The question is not "which object can I create fastest"; it is "who owns the source, who owns the subscribers, and how many routing boundaries are needed?"
 
 ### Subscribers and Event Handlers
 
-Event handlers include Azure Functions,
-Logic Apps, webhooks, Event Hubs, Service
-Bus, Storage Queues, Hybrid Connections,
-and other Azure endpoints. That list is
-the reason Event Grid is so useful as
-glue. An Event Grid subscription can call
-a serverless function, send to a queue, or
-bridge into Event Hubs for analytics. The
-handler choice should reflect the
-reliability contract.
+Event handlers include Azure Functions, Logic Apps, webhooks, Event Hubs, Service Bus, Storage Queues, Hybrid Connections, and other Azure endpoints. That list is the reason Event Grid is so useful as glue. An Event Grid subscription can call a serverless function, send to a queue, or bridge into Event Hubs for analytics. The handler choice should reflect the reliability contract.
 
-Choose Functions for code that reacts
-immediately and scales with events. Choose
-Logic Apps for workflow integration where
-connectors and human-readable steps
-matter. Choose a webhook for external
-systems, but treat validation,
-authentication, idempotency, and retry
-behavior as production requirements.
-Choose Event Hubs as a destination when
-discrete Azure events need to join an
-analytics stream. Choose Service Bus when
-the event should become a durable command
-for enterprise processing. Choose Storage
-Queues when the consumer is simple and the
-queue semantics are enough.
+Choose Functions for code that reacts immediately and scales with events. Choose Logic Apps for workflow integration where connectors and human-readable steps matter. Choose a webhook for external systems, but treat validation, authentication, idempotency, and retry behavior as production requirements. Choose Event Hubs as a destination when discrete Azure events need to join an analytics stream. Choose Service Bus when the event should become a durable command for enterprise processing. Choose Storage Queues when the consumer is simple and the queue semantics are enough.
 
 ### Event Grid Native Schema and CloudEvents
 
-Event Grid supports its native event
-schema and the CloudEvents 1.0 schema. The
-[Event Grid event schema
-documentation](https://learn.microsoft.com/en-us/azure/event-grid/event-schema)
-describes the native shape and CloudEvents
-support. The [CloudEvents 1.0
-specification](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md)
-exists because event producers and
-consumers need a common envelope for
-source, type, ID, time, subject, and data
-content.
+Event Grid supports its native event schema and the CloudEvents 1.0 schema. The [Event Grid event schema documentation](https://learn.microsoft.com/en-us/azure/event-grid/event-schema) describes the native shape and CloudEvents support. The [CloudEvents 1.0 specification](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md) exists because event producers and consumers need a common envelope for source, type, ID, time, subject, and data content.
 
-Use CloudEvents when events cross team,
-platform, or vendor boundaries. It gives
-integration partners a standard envelope
-and reduces custom adapter code. Use the
-native Event Grid schema when you are
-staying inside Azure examples, legacy
-handlers expect it, or the source and
-handler already use that shape. Do not mix
-schemas casually. Schema is an API
-contract, and changing it can break
-subscribers even if the event data itself
-is unchanged.
+Use CloudEvents when events cross team, platform, or vendor boundaries. It gives integration partners a standard envelope and reduces custom adapter code. Use the native Event Grid schema when you are staying inside Azure examples, legacy handlers expect it, or the source and handler already use that shape. Do not mix schemas casually. Schema is an API contract, and changing it can break subscribers even if the event data itself is unchanged.
 
-Example CloudEvents-shaped storage
-notification, trimmed for readability:
+Example CloudEvents-shaped storage notification, trimmed for readability:
 
 ```json
 {
@@ -770,96 +255,25 @@ notification, trimmed for readability:
 
 ### Filtering
 
-Filtering is where Event Grid becomes an
-operational tool instead of a noisy
-broadcast channel. The [Event Grid
-filtering
-documentation](https://learn.microsoft.com/en-us/azure/event-grid/event-filtering)
-covers event type filters, subject prefix
-and suffix filters, and advanced filters
-over event data. A good subscription is
-narrow enough that the handler can trust
-the incoming event stream. A broad
-subscription pushes filtering into code,
-increases delivery attempts, and makes
-incident triage harder.
+Filtering is where Event Grid becomes an operational tool instead of a noisy broadcast channel. The [Event Grid filtering documentation](https://learn.microsoft.com/en-us/azure/event-grid/event-filtering) covers event type filters, subject prefix and suffix filters, and advanced filters over event data. A good subscription is narrow enough that the handler can trust the incoming event stream. A broad subscription pushes filtering into code, increases delivery attempts, and makes incident triage harder.
 
-Use event type filters to subscribe only
-to events such as
-`Microsoft.Storage.BlobCreated`. Use
-subject prefix filters to narrow to a
-container or virtual path. Use subject
-suffix filters for file extensions such as
-`.avro` when the subject convention is
-stable. Use advanced filters when the
-decision depends on data fields, but keep
-them understandable enough that an
-operator can audit the match rule at 2 AM.
+Use event type filters to subscribe only to events such as `Microsoft.Storage.BlobCreated`. Use subject prefix filters to narrow to a container or virtual path. Use subject suffix filters for file extensions such as `.avro` when the subject convention is stable. Use advanced filters when the decision depends on data fields, but keep them understandable enough that an operator can audit the match rule at 2 AM.
 
 ### Delivery Retry and Dead-Lettering
 
-The [Event Grid delivery and retry
-documentation](https://learn.microsoft.com/en-us/azure/event-grid/delivery-and-retry)
-is required reading before production.
-Event Grid retries delivery when a handler
-fails or times out. Retries are valuable
-because transient failures should not drop
-events. Retries are dangerous when the
-handler is down for a long time,
-authentication is broken, or the endpoint
-returns repeated failures. In those cases,
-the retry policy can amplify traffic
-against an already unhealthy dependency.
+The [Event Grid delivery and retry documentation](https://learn.microsoft.com/en-us/azure/event-grid/delivery-and-retry) is required reading before production. Event Grid retries delivery when a handler fails or times out. Retries are valuable because transient failures should not drop events. Retries are dangerous when the handler is down for a long time, authentication is broken, or the endpoint returns repeated failures. In those cases, the retry policy can amplify traffic against an already unhealthy dependency.
 
-Dead-lettering sends undeliverable events
-to Storage after retry policy is exhausted
-or delivery is impossible. Configure it
-for production subscriptions unless the
-event is truly disposable. Dead-letter
-storage is not only for replay. It is
-evidence. It tells you what Event Grid
-tried to deliver, which subscription
-matched, and what payload the handler
-failed to process.
+Dead-lettering sends undeliverable events to Storage after retry policy is exhausted or delivery is impossible. Configure it for production subscriptions unless the event is truly disposable. Dead-letter storage is not only for replay. It is evidence. It tells you what Event Grid tried to deliver, which subscription matched, and what payload the handler failed to process.
 
 ### Event Grid Namespaces, MQTT, and Pull Delivery
 
-Event Grid Namespaces matter when Event
-Grid becomes more than a push-webhook
-router. The [Event Grid namespace
-concepts](https://learn.microsoft.com/en-us/azure/event-grid/concepts-event-grid-namespaces)
-describe namespace topics, clients, topic
-spaces, permission bindings, and pull
-delivery. Namespaces also support an MQTT
-v5 broker surface, which is important for
-IoT-style clients that speak MQTT and need
-brokered pub-sub behavior.
+Event Grid Namespaces matter when Event Grid becomes more than a push-webhook router. The [Event Grid namespace concepts](https://learn.microsoft.com/en-us/azure/event-grid/concepts-event-grid-namespaces) describe namespace topics, clients, topic spaces, permission bindings, and pull delivery. Namespaces also support an MQTT v5 broker surface, which is important for IoT-style clients that speak MQTT and need brokered pub-sub behavior.
 
-Use the namespace model when clients need
-MQTT v5, pull delivery, or a more explicit
-client/topic permission model. Do not
-choose namespaces just because they are
-newer. For a simple Azure Storage
-blob-created notification to an Azure
-Function, a system topic and event
-subscription are still the clearer shape.
-For many device clients publishing through
-MQTT topic spaces, namespaces may be the
-feature that makes Event Grid the right
-entry point.
+Use the namespace model when clients need MQTT v5, pull delivery, or a more explicit client/topic permission model. Do not choose namespaces just because they are newer. For a simple Azure Storage blob-created notification to an Azure Function, a system topic and event subscription are still the clearer shape. For many device clients publishing through MQTT topic spaces, namespaces may be the feature that makes Event Grid the right entry point.
 
 ## Decision Framework: Event Hubs, Event Grid, Service Bus, or Kafka on AKS
 
-Operators need a decision framework
-because service names are poor
-requirements. Start with the failure you
-need to survive. If a consumer is down, do
-you need replay from a stream, delivery
-retry from a router, a dead-letter queue
-with lock semantics, or broker control
-inside Kubernetes? The answer usually
-selects the service before any feature
-checklist does.
+Operators need a decision framework because service names are poor requirements. Start with the failure you need to survive. If a consumer is down, do you need replay from a stream, delivery retry from a router, a dead-letter queue with lock semantics, or broker control inside Kubernetes? The answer usually selects the service before any feature checklist does.
 
 ```text
 start
@@ -894,97 +308,29 @@ Need Kafka broker control, plugins, or self-managed compliance?
 
 ### Event Hubs Wins When
 
-Use Event Hubs when the workload is
-high-throughput ingestion, observability
-telemetry, clickstream data, device
-readings, security events, or analytics
-data. The key signals are continuous
-arrival, partition affinity, replay
-requirements, multiple independent
-readers, Kafka client compatibility, or
-downstream systems such as Stream
-Analytics, Azure Data Explorer,
-Databricks, or custom consumers. Event
-Hubs is also useful as the Event Grid
-destination when discrete Azure events
-need to become a stream for audit or
-analytics.
+Use Event Hubs when the workload is high-throughput ingestion, observability telemetry, clickstream data, device readings, security events, or analytics data. The key signals are continuous arrival, partition affinity, replay requirements, multiple independent readers, Kafka client compatibility, or downstream systems such as Stream Analytics, Azure Data Explorer, Databricks, or custom consumers. Event Hubs is also useful as the Event Grid destination when discrete Azure events need to become a stream for audit or analytics.
 
 ### Event Grid Wins When
 
-Use Event Grid when the workload is a
-discrete event notification. The key
-signals are fan-out, webhook integration,
-Azure resource events, SaaS-style
-integration, serverless handlers, low to
-moderate event rate, and push or pull
-delivery. Event Grid is the right mental
-model for "notify subscribers that
-something happened" rather than "store
-this stream so consumers can replay it
-later".
+Use Event Grid when the workload is a discrete event notification. The key signals are fan-out, webhook integration, Azure resource events, SaaS-style integration, serverless handlers, low to moderate event rate, and push or pull delivery. Event Grid is the right mental model for "notify subscribers that something happened" rather than "store this stream so consumers can replay it later".
 
 ### Service Bus Wins When
 
-Use Service Bus when messages are business
-commands and the handler must coordinate
-processing state. Sessions, duplicate
-detection, scheduled messages,
-transactions, lock renewal, and
-dead-letter queues are not optional
-details for many enterprise workflows.
-This module does not teach Service Bus in
-depth, but it must protect you from
-choosing Event Grid when the real
-requirement is command processing.
+Use Service Bus when messages are business commands and the handler must coordinate processing state. Sessions, duplicate detection, scheduled messages, transactions, lock renewal, and dead-letter queues are not optional details for many enterprise workflows. This module does not teach Service Bus in depth, but it must protect you from choosing Event Grid when the real requirement is command processing.
 
 ### Apache Kafka on AKS Wins When
 
-Use Kafka on AKS with an operator such as
-Strimzi only when the organization needs
-broker-level control and accepts
-broker-level responsibility. Valid reasons
-include regulatory constraints that block
-a managed service, custom broker plugins,
-strict network topology, specialized
-retention and compaction policies,
-ecosystem tools that require Kafka broker
-behavior, or a platform team already
-operating Kafka well. Invalid reasons
-include "we know Kafka" when no one wants
-to patch brokers, size disks, tune JVMs,
-test rolling upgrades, or own weekend
-incidents.
+Use Kafka on AKS with an operator such as Strimzi only when the organization needs broker-level control and accepts broker-level responsibility. Valid reasons include regulatory constraints that block a managed service, custom broker plugins, strict network topology, specialized retention and compaction policies, ecosystem tools that require Kafka broker behavior, or a platform team already operating Kafka well. Invalid reasons include "we know Kafka" when no one wants to patch brokers, size disks, tune JVMs, test rolling upgrades, or own weekend incidents.
 
 ## Identity, Networking, and Security
 
-Security for event systems is mostly about
-removing shared secrets, shrinking network
-paths, and making data-plane permissions
-explicit. The same lesson from Entra ID,
-VNet, Key Vault, and Monitor appears again
-here: production failures often come from
-identity and network assumptions that were
-invisible during a portal demo.
+Security for event systems is mostly about removing shared secrets, shrinking network paths, and making data-plane permissions explicit. The same lesson from Entra ID, VNet, Key Vault, and Monitor appears again here: production failures often come from identity and network assumptions that were invisible during a portal demo.
 
 ### Managed Identity and RBAC
 
-For Event Hubs data access, prefer managed
-identity with Azure RBAC when the producer
-or consumer runs in Azure. Use roles such
-as `Azure Event Hubs Data Sender`, `Azure
-Event Hubs Data Receiver`, and `Azure
-Event Hubs Data Owner`. Grant the
-narrowest useful scope, often the event
-hub or namespace rather than the
-subscription. For local development,
-`DefaultAzureCredential` can use a
-developer login, but production should run
-under a managed identity or workload
-identity.
+For Event Hubs data access, prefer managed identity with Azure RBAC when the producer or consumer runs in Azure. Use roles such as `Azure Event Hubs Data Sender`, `Azure Event Hubs Data Receiver`, and `Azure Event Hubs Data Owner`. Grant the narrowest useful scope, often the event hub or namespace rather than the subscription. For local development, `DefaultAzureCredential` can use a developer login, but production should run under a managed identity or workload identity.
 
-Example role assignment for the signed-in
-user during the lab:
+Example role assignment for the signed-in user during the lab:
 
 ```bash
 EVENTHUB_ID="$(az eventhubs eventhub show \
@@ -1002,64 +348,17 @@ az role assignment create \
   --scope "$EVENTHUB_ID"
 ```
 
-SAS tokens still exist because not every
-producer can use Entra ID. They are useful
-for external clients, constrained devices,
-legacy libraries, and integration points
-that understand connection strings but not
-managed identity. They also increase
-secret-management burden. If you use SAS,
-create separate policies for send and
-listen, rotate keys, store secrets in Key
-Vault, avoid namespace-wide root policies
-for applications, and prefer short-lived
-generated SAS tokens when possible.
+SAS tokens still exist because not every producer can use Entra ID. They are useful for external clients, constrained devices, legacy libraries, and integration points that understand connection strings but not managed identity. They also increase secret-management burden. If you use SAS, create separate policies for send and listen, rotate keys, store secrets in Key Vault, avoid namespace-wide root policies for applications, and prefer short-lived generated SAS tokens when possible.
 
 ### Private Endpoints, Firewalls, and Service Endpoints
 
-Network controls answer a different
-question than RBAC. RBAC says who can call
-the data plane. Private endpoints,
-firewalls, and service endpoints decide
-which network paths can reach the service
-endpoint. For Event Hubs Standard and
-Premium, private networking patterns are
-common when producers and consumers run in
-VNets. Private endpoints move access
-through Private Link. IP firewall rules
-restrict public ingress. VNet service
-endpoints can be useful in supported
-patterns, but private endpoints are
-usually the cleaner zero-public-path
-design for new production workloads.
+Network controls answer a different question than RBAC. RBAC says who can call the data plane. Private endpoints, firewalls, and service endpoints decide which network paths can reach the service endpoint. For Event Hubs Standard and Premium, private networking patterns are common when producers and consumers run in VNets. Private endpoints move access through Private Link. IP firewall rules restrict public ingress. VNet service endpoints can be useful in supported patterns, but private endpoints are usually the cleaner zero-public-path design for new production workloads.
 
-Event Grid has its own network realities.
-A webhook endpoint must be reachable by
-Event Grid unless you route through
-supported private or Azure-native
-handlers. External webhooks need
-validation, authentication, idempotency,
-and rate limits. When a private
-application needs to receive events,
-consider Azure-native handlers, private
-endpoints where supported, or queue-based
-indirection rather than exposing a fragile
-internal webhook.
+Event Grid has its own network realities. A webhook endpoint must be reachable by Event Grid unless you route through supported private or Azure-native handlers. External webhooks need validation, authentication, idempotency, and rate limits. When a private application needs to receive events, consider Azure-native handlers, private endpoints where supported, or queue-based indirection rather than exposing a fragile internal webhook.
 
 ### TLS and Customer-Managed Keys
 
-TLS should be table stakes for every path.
-The more interesting production decision
-is key ownership. Customer-managed keys
-for Event Hubs are available in higher
-tiers such as Premium and Dedicated, and
-they pull Key Vault operations into the
-availability path. That is not bad, but it
-must be designed deliberately. If a key is
-disabled, deleted, or blocked by
-networking, the event service can be
-affected. Treat CMK as a compliance and
-operational commitment, not a checkbox.
+TLS should be table stakes for every path. The more interesting production decision is key ownership. Customer-managed keys for Event Hubs are available in higher tiers such as Premium and Dedicated, and they pull Key Vault operations into the availability path. That is not bad, but it must be designed deliberately. If a key is disabled, deleted, or blocked by networking, the event service can be affected. Treat CMK as a compliance and operational commitment, not a checkbox.
 
 ### Security Review Checklist
 
@@ -1074,29 +373,11 @@ operational commitment, not a checkbox.
 
 ## Cost Lens: Capacity, Operations, and Hidden Spikes
 
-Cost belongs in the design review because
-event systems scale quietly. A stream can
-run every second of the month. A broken
-Event Grid handler can retry for hours.
-Capture can create storage that outlives
-the application. Geo-DR and replication
-can add cross-region data transfer. Log
-Analytics can ingest large diagnostic
-volumes if every event is logged by
-application code.
+Cost belongs in the design review because event systems scale quietly. A stream can run every second of the month. A broken Event Grid handler can retry for hours. Capture can create storage that outlives the application. Geo-DR and replication can add cross-region data transfer. Log Analytics can ingest large diagnostic volumes if every event is logged by application code.
 
 ### Event Hubs Standard Cost Model
 
-Standard Event Hubs has several cost
-surfaces. Throughput units are hourly
-capacity. Ingress events can be metered
-per million events. Capture can add an
-hourly meter and storage charges. Kafka
-endpoint usage can add a meter in some
-pricing models. Networking, cross-region
-transfer, storage transactions, and
-monitoring are outside the simple
-namespace price.
+Standard Event Hubs has several cost surfaces. Throughput units are hourly capacity. Ingress events can be metered per million events. Capture can add an hourly meter and storage charges. Kafka endpoint usage can add a meter in some pricing models. Networking, cross-region transfer, storage transactions, and monitoring are outside the simple namespace price.
 
 Worked example recap:
 
@@ -1113,150 +394,39 @@ Worked example recap:
 | Approx ingress event cost | `$725.76` |
 | Approx Standard Capture cost | `$949.00` |
 
-The important part is not the exact dollar
-total. Prices vary by region, currency,
-tier, reservation, and date, so the [Event
-Hubs pricing
-page](https://azure.microsoft.com/en-us/pricing/details/event-hubs/)
-is the source of truth before purchase.
-The important part is the method:
-calculate both event rate and byte rate,
-apply headroom, add retention and Capture
-costs, then model the downstream readers.
+The important part is not the exact dollar total. Prices vary by region, currency, tier, reservation, and date, so the [Event Hubs pricing page](https://azure.microsoft.com/en-us/pricing/details/event-hubs/) is the source of truth before purchase. The important part is the method: calculate both event rate and byte rate, apply headroom, add retention and Capture costs, then model the downstream readers.
 
 ### Event Hubs Premium Cost Model
 
-Premium uses processing units instead of
-Standard throughput units. The hourly
-baseline is higher, but Premium can pay
-off when it avoids throttling incidents,
-multi-tenant contention, larger-event
-workarounds, separate add-on costs, or
-private-network and schema requirements
-that would otherwise create complexity.
-Premium is usually a production decision
-for important streams, not a default for
-every small integration.
+Premium uses processing units instead of Standard throughput units. The hourly baseline is higher, but Premium can pay off when it avoids throttling incidents, multi-tenant contention, larger-event workarounds, separate add-on costs, or private-network and schema requirements that would otherwise create complexity. Premium is usually a production decision for important streams, not a default for every small integration.
 
-The inflection point is not only math. If
-a Standard namespace needs many TUs,
-constant auto-inflate, separate isolation
-per team, private networking, schema
-registry, and larger event sizes, Premium
-may be cheaper operationally even if the
-service line item is higher. That is the
-difference between cloud cost and
-engineering cost.
+The inflection point is not only math. If a Standard namespace needs many TUs, constant auto-inflate, separate isolation per team, private networking, schema registry, and larger event sizes, Premium may be cheaper operationally even if the service line item is higher. That is the difference between cloud cost and engineering cost.
 
 ### Event Grid Cost Model
 
-Event Grid charges around operations.
-Publishing, matching, delivery attempts,
-namespace throughput, and MQTT operations
-can all matter depending on the tier and
-feature set. The [Event Grid pricing
-page](https://azure.microsoft.com/en-us/pricing/details/event-grid/)
-should be checked during design because
-operation counting can surprise teams that
-think a single event is always a single
-billable unit.
+Event Grid charges around operations. Publishing, matching, delivery attempts, namespace throughput, and MQTT operations can all matter depending on the tier and feature set. The [Event Grid pricing page](https://azure.microsoft.com/en-us/pricing/details/event-grid/) should be checked during design because operation counting can surprise teams that think a single event is always a single billable unit.
 
-Example: one million storage blob-created
-events per month delivered to three
-subscribers is not only one million events
-in the system. There is a publish side,
-matching work, and delivery to each
-subscriber. If one webhook is unavailable
-and Event Grid retries repeatedly,
-delivery attempts increase. If
-dead-lettering is enabled, Storage costs
-also appear. Retry storms are therefore
-both reliability and cost incidents.
+Example: one million storage blob-created events per month delivered to three subscribers is not only one million events in the system. There is a publish side, matching work, and delivery to each subscriber. If one webhook is unavailable and Event Grid retries repeatedly, delivery attempts increase. If dead-lettering is enabled, Storage costs also appear. Retry storms are therefore both reliability and cost incidents.
 
 ### Where Costs Spike
 
-Undersized Event Hubs TUs spike cost and
-risk in two ways. If auto-inflate is
-enabled with a high ceiling, a sudden
-producer bug can increase hourly capacity.
-If auto-inflate is disabled or capped too
-low, producers throttle, retry, and push
-costs elsewhere. Set a ceiling, alert near
-the ceiling, and tie the alert to a
-runbook that distinguishes expected launch
-traffic from malformed producer loops.
+Undersized Event Hubs TUs spike cost and risk in two ways. If auto-inflate is enabled with a high ceiling, a sudden producer bug can increase hourly capacity. If auto-inflate is disabled or capped too low, producers throttle, retry, and push costs elsewhere. Set a ceiling, alert near the ceiling, and tie the alert to a runbook that distinguishes expected launch traffic from malformed producer loops.
 
-Capture costs spike when files are
-retained without lifecycle rules. Set
-storage lifecycle policies for raw Avro
-blobs. Move old data to cool or archive
-tiers only when downstream readers can
-tolerate access latency and retrieval
-charges. If compliance requires retention,
-record the owner and retention period in
-the module or Terraform variable, not in
-tribal memory.
+Capture costs spike when files are retained without lifecycle rules. Set storage lifecycle policies for raw Avro blobs. Move old data to cool or archive tiers only when downstream readers can tolerate access latency and retrieval charges. If compliance requires retention, record the owner and retention period in the module or Terraform variable, not in tribal memory.
 
-Geo-DR and replication costs spike when
-data crosses regions or when duplicate
-pipelines run hot. Namespace alias
-failover is not the same as free
-replicated analytics data. Plan
-cross-region data transfer, Capture
-storage replication, and duplicate
-consumer behavior before the disaster
-recovery exercise.
+Geo-DR and replication costs spike when data crosses regions or when duplicate pipelines run hot. Namespace alias failover is not the same as free replicated analytics data. Plan cross-region data transfer, Capture storage replication, and duplicate consumer behavior before the disaster recovery exercise.
 
-Event Grid costs spike when handlers are
-unavailable. Every failing delivery path
-creates retries until policy is exhausted.
-The operator response is not simply
-"increase retry duration". Fix
-authentication, scale the handler, reduce
-filter breadth, use a queue as a buffer,
-or dead-letter events so the retry loop
-does not punish a dependency that is
-already unhealthy.
+Event Grid costs spike when handlers are unavailable. Every failing delivery path creates retries until policy is exhausted. The operator response is not simply "increase retry duration". Fix authentication, scale the handler, reduce filter breadth, use a queue as a buffer, or dead-letter events so the retry loop does not punish a dependency that is already unhealthy.
 
 ## Observability and Operator Queries
 
-Observability for event systems has two
-sides. The broker or router tells you
-about capacity, delivery, and throttling.
-The application tells you whether it
-processed the event safely. Do not accept
-a dashboard that only shows producer
-success. A stream can ingest successfully
-while every consumer is a day behind. An
-Event Grid subscription can publish
-successfully while the webhook is failing
-validation.
+Observability for event systems has two sides. The broker or router tells you about capacity, delivery, and throttling. The application tells you whether it processed the event safely. Do not accept a dashboard that only shows producer success. A stream can ingest successfully while every consumer is a day behind. An Event Grid subscription can publish successfully while the webhook is failing validation.
 
 ### Event Hubs Metrics
 
-The [Event Hubs monitoring
-reference](https://learn.microsoft.com/en-us/azure/event-hubs/monitor-event-hubs-reference)
-is the metric source to use when building
-dashboards. Operators commonly watch
-incoming bytes, incoming messages or
-requests, outgoing bytes, outgoing
-messages, throttled requests, server
-errors, user errors, connections, and
-captured bytes. For Capture, watch whether
-captured bytes move when events are
-flowing. For consumers, Azure Monitor does
-not magically know every checkpoint store,
-so lag often requires comparing last
-enqueued sequence numbers with stored
-checkpoints.
+The [Event Hubs monitoring reference](https://learn.microsoft.com/en-us/azure/event-hubs/monitor-event-hubs-reference) is the metric source to use when building dashboards. Operators commonly watch incoming bytes, incoming messages or requests, outgoing bytes, outgoing messages, throttled requests, server errors, user errors, connections, and captured bytes. For Capture, watch whether captured bytes move when events are flowing. For consumers, Azure Monitor does not magically know every checkpoint store, so lag often requires comparing last enqueued sequence numbers with stored checkpoints.
 
-Practical Event Hubs dashboard panels
-should answer the questions an on-call
-operator asks before opening the portal
-blades one by one. Each panel needs an
-owner, an expected range, and a runbook
-link so the dashboard becomes an operating
-surface rather than a wall of charts.
+Practical Event Hubs dashboard panels should answer the questions an on-call operator asks before opening the portal blades one by one. Each panel needs an owner, an expected range, and a runbook link so the dashboard becomes an operating surface rather than a wall of charts.
 
 | Panel | Signal | Operator question |
 |---|---|---|
@@ -1267,12 +437,7 @@ surface rather than a wall of charts.
 | Server errors and user errors | Service and client failures | Is the problem Azure-side or caller-side? |
 | Active connections | Client behavior | Did a deploy drop or multiply connections? |
 
-Example KQL for Event Hubs metrics in
-Azure Monitor can start with the
-namespace-level pressure signals, then
-drill into a specific event hub or
-consumer application once you know whether
-the broker is throttling:
+Example KQL for Event Hubs metrics in Azure Monitor can start with the namespace-level pressure signals, then drill into a specific event hub or consumer application once you know whether the broker is throttling:
 
 ```kusto
 AzureMetrics
@@ -1283,11 +448,7 @@ AzureMetrics
 | order by TimeGenerated asc
 ```
 
-Example KQL for a throttling view should
-be used as an alert investigation query
-because any nonzero throttling means
-producers are already experiencing
-backpressure or retries:
+Example KQL for a throttling view should be used as an alert investigation query because any nonzero throttling means producers are already experiencing backpressure or retries:
 
 ```kusto
 AzureMetrics
@@ -1298,40 +459,13 @@ AzureMetrics
 | order by TimeGenerated desc
 ```
 
-Consumer lag is harder because the
-checkpoint store is application-owned. One
-practical approach is to emit application
-metrics that record the last processed
-sequence number per partition and compare
-it with the last enqueued sequence number
-from Event Hubs runtime properties. If the
-difference grows, the consumer is behind.
-If the difference shrinks, it is catching
-up. If it is flat while incoming volume
-continues, the consumer is stuck.
+Consumer lag is harder because the checkpoint store is application-owned. One practical approach is to emit application metrics that record the last processed sequence number per partition and compare it with the last enqueued sequence number from Event Hubs runtime properties. If the difference grows, the consumer is behind. If the difference shrinks, it is catching up. If it is flat while incoming volume continues, the consumer is stuck.
 
 ### Event Grid Metrics
 
-The [Event Grid metrics reference for
-topics](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-eventgrid-topics-metrics)
-includes delivery and failure signals such
-as successful delivery, failed delivery
-attempts, dropped events, and publish
-success or failure. For production
-subscriptions, alert on failed attempts
-before dropped events. Dropped events mean
-the system has already exhausted delivery
-or could not deliver. Failed attempts mean
-the operator still has time to fix the
-handler, authentication, filter, or
-network path.
+The [Event Grid metrics reference for topics](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-eventgrid-topics-metrics) includes delivery and failure signals such as successful delivery, failed delivery attempts, dropped events, and publish success or failure. For production subscriptions, alert on failed attempts before dropped events. Dropped events mean the system has already exhausted delivery or could not deliver. Failed attempts mean the operator still has time to fix the handler, authentication, filter, or network path.
 
-Example KQL for Event Grid delivery
-failures should compare successful
-delivery, failed attempts, and dropped
-events so the operator can separate a
-transient endpoint issue from actual event
-loss:
+Example KQL for Event Grid delivery failures should compare successful delivery, failed attempts, and dropped events so the operator can separate a transient endpoint issue from actual event loss:
 
 ```kusto
 AzureMetrics
@@ -1341,11 +475,7 @@ AzureMetrics
 | order by TimeGenerated desc
 ```
 
-Example KQL for a handler outage pattern
-should focus on the failure rate over time
-because raw failure counts can look
-alarming during a traffic spike and quiet
-during a low-volume outage:
+Example KQL for a handler outage pattern should focus on the failure rate over time because raw failure counts can look alarming during a traffic spike and quiet during a low-volume outage:
 
 ```kusto
 AzureMetrics
@@ -1361,47 +491,15 @@ AzureMetrics
 
 ### Operational Runbook: Event Hubs Throttling
 
-When producers report throttling, first
-verify whether the namespace is at its
-capacity ceiling. Check incoming bytes,
-incoming requests, throttled requests, and
-TU or PU settings. Then check partition
-distribution. If one partition is hot
-because of a bad partition key, adding TUs
-may not fix the real problem. Next check
-producer retry behavior. Aggressive
-retries can multiply pressure. Finally
-decide whether to raise the TU ceiling,
-enable auto-inflate, tune partition keys,
-add partitions for new hubs, or move to
-Premium.
+When producers report throttling, first verify whether the namespace is at its capacity ceiling. Check incoming bytes, incoming requests, throttled requests, and TU or PU settings. Then check partition distribution. If one partition is hot because of a bad partition key, adding TUs may not fix the real problem. Next check producer retry behavior. Aggressive retries can multiply pressure. Finally decide whether to raise the TU ceiling, enable auto-inflate, tune partition keys, add partitions for new hubs, or move to Premium.
 
 ### Operational Runbook: Event Grid Delivery Failure
 
-When Event Grid delivery fails, start with
-the subscription. Verify endpoint
-validation, authentication, filter rules,
-endpoint DNS, TLS certificate, and handler
-response codes. Then check retry policy
-and dead-letter configuration. If the
-handler is a webhook, confirm it returns
-success only after durable acceptance. If
-the handler does real work synchronously
-and times out, put a queue or Function in
-front of the slow work. Event Grid should
-not be forced to wait while a downstream
-batch job runs.
+When Event Grid delivery fails, start with the subscription. Verify endpoint validation, authentication, filter rules, endpoint DNS, TLS certificate, and handler response codes. Then check retry policy and dead-letter configuration. If the handler is a webhook, confirm it returns success only after durable acceptance. If the handler does real work synchronously and times out, put a queue or Function in front of the slow work. Event Grid should not be forced to wait while a downstream batch job runs.
 
 ## Patterns & Anti-Patterns
 
-Patterns and anti-patterns are where
-service knowledge becomes operational
-judgment. Most production mistakes are not
-because a team never heard of Event Hubs
-or Event Grid. They happen because the
-team used the right feature in the wrong
-place, or ignored the cost and failure
-mode attached to it.
+Patterns and anti-patterns are where service knowledge becomes operational judgment. Most production mistakes are not because a team never heard of Event Hubs or Event Grid. They happen because the team used the right feature in the wrong place, or ignored the cost and failure mode attached to it.
 
 | Pattern | When to use it | Why it works | Scaling consideration |
 |---|---|---|---|
@@ -1443,119 +541,36 @@ mode attached to it.
 ## Quiz
 
 <details><summary>Your telemetry producer sends steady one-kilobyte records at a rate that sometimes doubles during business events. Consumers must replay the stream after a failed deployment. Which Azure service is the first candidate, and what two capacity signals do you check?</summary>
-Event Hubs is the first candidate because
-the workload is continuous,
-high-throughput, and replayable. Check
-event rate and byte rate because Standard
-throughput planning can be constrained by
-either messages per second or megabytes
-per second. You should also watch
-throttled requests and consumer lag during
-the business event. Event Grid would be a
-poor fit because the requirement is a
-retained stream, not only push
-notification fan-out.
+Event Hubs is the first candidate because the workload is continuous, high-throughput, and replayable. Check event rate and byte rate because Standard throughput planning can be constrained by either messages per second or megabytes per second. You should also watch throttled requests and consumer lag during the business event. Event Grid would be a poor fit because the requirement is a retained stream, not only push notification fan-out.
 </details>
 
 <details><summary>A storage account writes Avro Capture files, and three teams want notification when new blobs land. One team wants a webhook, one wants a Function, and one wants messages in Service Bus. What design keeps the source simple?</summary>
-Use an Event Grid system topic on the
-Storage Account with separate event
-subscriptions for each handler. Filter the
-subscriptions to the capture container and
-blob path so unrelated storage events do
-not reach the handlers. The Service Bus
-subscriber can turn the notification into
-durable command processing if that team
-needs queue semantics. Keep dead-letter
-storage configured because webhook and
-Function failures should leave evidence.
+Use an Event Grid system topic on the Storage Account with separate event subscriptions for each handler. Filter the subscriptions to the capture container and blob path so unrelated storage events do not reach the handlers. The Service Bus subscriber can turn the notification into durable command processing if that team needs queue semantics. Keep dead-letter storage configured because webhook and Function failures should leave evidence.
 </details>
 
 <details><summary>A payment workflow requires per-customer ordering, duplicate detection, transactions, and a dead-letter queue for manual repair. A developer proposes Event Grid because the messages are called events. How do you respond?</summary>
-The requirements point to Service Bus, not
-Event Grid. Event Grid is an event router
-with delivery attempts; it is not the
-right primitive for transactional command
-handling with sessions and broker-managed
-dead-letter queues. You can still use
-Event Grid upstream to notify that a
-resource changed, but the payment command
-itself belongs on a messaging service
-built for that contract. The design review
-should name the failure mode: a duplicate
-or out-of-order payment command is a
-business incident.
+The requirements point to Service Bus, not Event Grid. Event Grid is an event router with delivery attempts; it is not the right primitive for transactional command handling with sessions and broker-managed dead-letter queues. You can still use Event Grid upstream to notify that a resource changed, but the payment command itself belongs on a messaging service built for that contract. The design review should name the failure mode: a duplicate or out-of-order payment command is a business incident.
 </details>
 
 <details><summary>Consumers are behind by several hours even though Event Hubs incoming metrics look normal and producers are not throttled. What do you inspect next?</summary>
-Inspect outgoing bytes or messages,
-consumer application health, checkpoint
-ownership, and the checkpoint store
-permissions. Event Hubs can ingest
-successfully while a consumer is stuck or
-repeatedly reprocessing the same
-partition. Compare last processed sequence
-numbers with last enqueued sequence
-numbers per partition if the application
-emits that telemetry. Adding throughput
-units may not help if the reader has a
-code, identity, or checkpoint problem.
+Inspect outgoing bytes or messages, consumer application health, checkpoint ownership, and the checkpoint store permissions. Event Hubs can ingest successfully while a consumer is stuck or repeatedly reprocessing the same partition. Compare last processed sequence numbers with last enqueued sequence numbers per partition if the application emits that telemetry. Adding throughput units may not help if the reader has a code, identity, or checkpoint problem.
 </details>
 
 <details><summary>An Event Grid webhook subscription shows rising failed delivery attempts after a certificate rotation. What operator actions come before increasing the retry duration?</summary>
-First validate the endpoint TLS chain,
-DNS, authentication, and webhook response
-status. Then check the Event Grid
-subscription validation and dead-letter
-configuration so failed events are not
-lost. Increasing retry duration can
-multiply pressure against a broken
-endpoint, so it is not the first fix. If
-the handler does slow work, put a queue or
-Function in front of it and acknowledge
-receipt quickly.
+First validate the endpoint TLS chain, DNS, authentication, and webhook response status. Then check the Event Grid subscription validation and dead-letter configuration so failed events are not lost. Increasing retry duration can multiply pressure against a broken endpoint, so it is not the first fix. If the handler does slow work, put a queue or Function in front of it and acknowledge receipt quickly.
 </details>
 
 <details><summary>A Kafka application team wants to move to Event Hubs through the Kafka endpoint. They use admin APIs and broker-specific topic settings in their deployment scripts. What should the migration plan prove?</summary>
-The plan must prove that the specific
-Kafka client version, authentication mode,
-offset behavior, producer settings, and
-admin operations work against Event Hubs.
-Kafka protocol compatibility does not mean
-every broker feature or configuration knob
-exists. Scripts that assume self-managed
-broker control may need to change or
-remain on Kafka. If those broker controls
-are mandatory, Kafka on AKS with Strimzi
-may be the more honest platform choice.
+The plan must prove that the specific Kafka client version, authentication mode, offset behavior, producer settings, and admin operations work against Event Hubs. Kafka protocol compatibility does not mean every broker feature or configuration knob exists. Scripts that assume self-managed broker control may need to change or remain on Kafka. If those broker controls are mandatory, Kafka on AKS with Strimzi may be the more honest platform choice.
 </details>
 
 <details><summary>A team enables Capture for a busy event hub and celebrates that analytics now has raw files. Two months later storage cost grows faster than expected. What design gap caused the surprise?</summary>
-Capture created durable Avro blobs, but
-the team did not define lifecycle policy,
-retention ownership, or downstream access
-patterns. Capture is not only an ingestion
-feature; it is a storage lifecycle
-commitment. The fix is to set tiering and
-deletion rules that match compliance and
-analytics needs, and to alert on captured
-bytes and storage growth. The cost review
-should include both Event Hubs meters and
-storage meters.
+Capture created durable Avro blobs, but the team did not define lifecycle policy, retention ownership, or downstream access patterns. Capture is not only an ingestion feature; it is a storage lifecycle commitment. The fix is to set tiering and deletion rules that match compliance and analytics needs, and to alert on captured bytes and storage growth. The cost review should include both Event Hubs meters and storage meters.
 </details>
 
 ## Hands-On Exercise: Event Hubs Capture to Event Grid Webhook
 
-Exercise scenario: you will build a small
-event pipeline without AKS. The flow is
-Event Hubs ingestion, Capture to Storage
-as Avro files, Event Grid notification
-from the Storage Account, and a webhook
-test endpoint that receives
-CloudEvents-shaped blob-created events.
-Use a non-production subscription or a
-short-lived resource group. Delete the
-resource group when you finish.
+Exercise scenario: you will build a small event pipeline without AKS. The flow is Event Hubs ingestion, Capture to Storage as Avro files, Event Grid notification from the Storage Account, and a webhook test endpoint that receives CloudEvents-shaped blob-created events. Use a non-production subscription or a short-lived resource group. Delete the resource group when you finish.
 
 Success criteria:
 
@@ -1570,12 +585,7 @@ Success criteria:
 
 ### Step One: Set Variables and Create the Resource Group
 
-Pick a short unique suffix because Storage
-Account and Event Hubs namespace names are
-globally constrained. The commands use
-`eastus` for consistency with the cost
-examples, but you can choose a closer
-supported region.
+Pick a short unique suffix because Storage Account and Event Hubs namespace names are globally constrained. The commands use `eastus` for consistency with the cost examples, but you can choose a closer supported region.
 
 ```bash
 export LOCATION="eastus"
@@ -1593,19 +603,11 @@ az group create \
   --location "$LOCATION"
 ```
 
-Expected result: the resource group
-exists, and every later resource lands in
-the same region unless the command says
-otherwise.
+Expected result: the resource group exists, and every later resource lands in the same region unless the command says otherwise.
 
 ### Step Two: Create Storage for Capture and Dead-Letter Evidence
 
-The lab uses one Storage Account for
-Capture output and Event Grid dead-letter
-examples. In production, you may separate
-archive and dead-letter storage so
-retention, access, and incident review
-permissions are clearer.
+The lab uses one Storage Account for Capture output and Event Grid dead-letter examples. In production, you may separate archive and dead-letter storage so retention, access, and incident review permissions are clearer.
 
 ```bash
 az storage account create \
@@ -1636,23 +638,11 @@ az storage container create \
   --auth-mode login
 ```
 
-If the container creation fails
-immediately after role assignment, wait a
-minute and retry. Azure RBAC propagation
-is not instant, and the failure is usually
-an authorization delay rather than a
-storage problem.
+If the container creation fails immediately after role assignment, wait a minute and retry. Azure RBAC propagation is not instant, and the failure is usually an authorization delay rather than a storage problem.
 
 ### Step Three: Create Event Hubs Namespace and Event Hub with Capture
 
-Create a Standard namespace with two
-throughput units. Then create one event
-hub with four partitions and Capture
-enabled to the container. The archive
-naming format keeps namespace, hub,
-partition, and time in the path so
-operators can inspect Capture output
-without opening every file.
+Create a Standard namespace with two throughput units. Then create one event hub with four partitions and Capture enabled to the container. The archive naming format keeps namespace, hub, partition, and time in the path so operators can inspect Capture output without opening every file.
 
 ```bash
 az eventhubs namespace create \
@@ -1677,21 +667,11 @@ az eventhubs eventhub create \
   --archive-name-format "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}"
 ```
 
-Expected result: the event hub exists with
-four partitions, and the Capture settings
-point to your storage container. If your
-installed Azure CLI uses slightly
-different parameter names for Capture, run
-`az eventhubs eventhub create --help` and
-keep the same values.
+Expected result: the event hub exists with four partitions, and the Capture settings point to your storage container. If your installed Azure CLI uses slightly different parameter names for Capture, run `az eventhubs eventhub create --help` and keep the same values.
 
 ### Step Four: Grant Send Permission and Install Producer Dependencies
 
-The producer uses
-`DefaultAzureCredential`, so it can use
-your Azure CLI login locally and managed
-identity in Azure. This avoids putting an
-Event Hubs connection string in a script.
+The producer uses `DefaultAzureCredential`, so it can use your Azure CLI login locally and managed identity in Azure. This avoids putting an Event Hubs connection string in a script.
 
 ```bash
 EVENTHUB_ID="$(az eventhubs eventhub show \
@@ -1709,12 +689,7 @@ az role assignment create \
 .venv/bin/python -m pip install azure-eventhub azure-identity
 ```
 
-Create `send_events.py` in a temporary lab
-directory outside the repo or paste it
-into your shell with an editor. The
-snippet is intentionally complete and
-runnable as-is after the environment
-variables are set.
+Create `send_events.py` in a temporary lab directory outside the repo or paste it into your shell with an editor. The snippet is intentionally complete and runnable as-is after the environment variables are set.
 
 ```python
 import json
@@ -1784,18 +759,11 @@ export EVENTHUB_NAME
 .venv/bin/python send_events.py
 ```
 
-Expected result: the script prints
-`sent=100` and exits without a connection
-string. If authentication fails, run `az
-login`, verify the RBAC assignment scope,
-and wait for propagation.
+Expected result: the script prints `sent=100` and exits without a connection string. If authentication fails, run `az login`, verify the RBAC assignment scope, and wait for propagation.
 
 ### Step Five: Verify Capture Wrote Avro Blobs
 
-Capture writes on a time or size window,
-so wait at least five minutes unless your
-event volume reaches the size limit first.
-Then list blobs in the capture container.
+Capture writes on a time or size window, so wait at least five minutes unless your event volume reaches the size limit first. Then list blobs in the capture container.
 
 ```bash
 az storage blob list \
@@ -1806,20 +774,11 @@ az storage blob list \
   --output table
 ```
 
-Expected result: at least one path appears
-with the namespace, event hub name,
-partition ID, and time components. If no
-blobs appear, check `CapturedBytes`, the
-Capture configuration, Storage
-permissions, and whether enough time has
-passed for the Capture window.
+Expected result: at least one path appears with the namespace, event hub name, partition ID, and time components. If no blobs appear, check `CapturedBytes`, the Capture configuration, Storage permissions, and whether enough time has passed for the Capture window.
 
 ### Step Six: Create the Event Grid System Topic
 
-Create a system topic for the Storage
-Account. This makes the Storage Account
-the Event Grid source for blob-created
-notifications.
+Create a system topic for the Storage Account. This makes the Storage Account the Event Grid source for blob-created notifications.
 
 ```bash
 az eventgrid system-topic create \
@@ -1830,16 +789,11 @@ az eventgrid system-topic create \
   --source "$STORAGE_ID"
 ```
 
-Expected result: the system topic exists
-and points to the Storage Account resource
-ID.
+Expected result: the system topic exists and points to the Storage Account resource ID.
 
 ### Step Seven: Subscribe a Webhook to Capture BlobCreated Events
 
-Create a temporary endpoint at a service
-such as `https://webhook.site`. Copy the
-unique URL into `WEBHOOK_URL`. Do not use
-a production webhook for this lab.
+Create a temporary endpoint at a service such as `https://webhook.site`. Copy the unique URL into `WEBHOOK_URL`. Do not use a production webhook for this lab.
 
 ```bash
 export WEBHOOK_URL="https://webhook.site/your-temporary-id"
@@ -1855,38 +809,19 @@ az eventgrid system-topic event-subscription create \
   --subject-begins-with "/blobServices/default/containers/${CAPTURE_CONTAINER}/blobs/${EH_NAMESPACE}/${EVENTHUB_NAME}/"
 ```
 
-Event Grid sends a validation event when
-you create a webhook subscription. Webhook
-test sites usually record the validation
-request but may not automatically echo the
-validation code. If the portal or CLI
-shows validation pending, open the
-captured validation event and use the
-`validationUrl` if present. That step
-proves why production webhooks need
-explicit validation handling.
+Event Grid sends a validation event when you create a webhook subscription. Webhook test sites usually record the validation request but may not automatically echo the validation code. If the portal or CLI shows validation pending, open the captured validation event and use the `validationUrl` if present. That step proves why production webhooks need explicit validation handling.
 
-Run the producer again and wait for
-another Capture window:
+Run the producer again and wait for another Capture window:
 
 ```bash
 EVENT_COUNT=200 EVENT_BATCH_SIZE=25 EVENT_SLEEP_MS=25 .venv/bin/python send_events.py
 ```
 
-Expected result: the webhook site receives
-a CloudEvents payload with `type` equal to
-`Microsoft.Storage.BlobCreated`, and the
-`subject` points into your Capture
-container.
+Expected result: the webhook site receives a CloudEvents payload with `type` equal to `Microsoft.Storage.BlobCreated`, and the `subject` points into your Capture container.
 
 ### Step Eight: Trigger and Interpret Backpressure
 
-Lower the namespace from two throughput
-units to one. Then run a larger producer
-burst with bigger payloads. The goal is to
-observe throttling or understand why your
-local producer cannot generate enough
-pressure.
+Lower the namespace from two throughput units to one. Then run a larger producer burst with bigger payloads. The goal is to observe throttling or understand why your local producer cannot generate enough pressure.
 
 ```bash
 az eventhubs namespace update \
@@ -1912,26 +847,11 @@ az monitor metrics list \
   --output table
 ```
 
-Expected result: if your producer exceeds
-the namespace capacity,
-`ThrottledRequests` rises. If it does not
-rise, record the measured producer rate
-and explain that the workstation did not
-exceed the one-TU envelope. The operator
-response is still the same decision tree:
-enable auto-inflate with a ceiling, raise
-explicit TUs, reduce producer retry
-pressure, tune partition keys, increase
-partitions for new hubs, or move to
-Premium when isolation and features
-justify it.
+Expected result: if your producer exceeds the namespace capacity, `ThrottledRequests` rises. If it does not rise, record the measured producer rate and explain that the workstation did not exceed the one-TU envelope. The operator response is still the same decision tree: enable auto-inflate with a ceiling, raise explicit TUs, reduce producer retry pressure, tune partition keys, increase partitions for new hubs, or move to Premium when isolation and features justify it.
 
 ### Cleanup
 
-Delete the resource group when you are
-done. This removes the namespace, storage,
-system topic, event subscription, and
-captured blobs.
+Delete the resource group when you are done. This removes the namespace, storage, system topic, event subscription, and captured blobs.
 
 ```bash
 az group delete \
@@ -1965,8 +885,4 @@ az group delete \
 
 ## Next Module
 
-Continue to [AWS
-Essentials](../../aws-essentials/) to
-compare how another hyperscaler approaches
-identity, networking, compute, storage,
-and event-driven service boundaries.
+Continue to [Azure SQL Database](../module-3.16-azure-sql/) to add a managed relational data tier to the Azure services you have been assembling.

--- a/src/content/docs/cloud/azure-essentials/module-3.16-azure-sql.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.16-azure-sql.md
@@ -16,8 +16,7 @@ sidebar:
 
 ## What You'll Be Able to Do
 
-After completing this module, you will
-be able to:
+After completing this module, you will be able to:
 
 - **Compare** Azure SQL Database, Azure SQL Managed Instance, and SQL Server on Azure VM by control boundary, scaling unit, networking model, restore granularity, and feature fit.
 - **Design** an Azure SQL Database compute and storage model that separates DTU, vCore, General Purpose, Business Critical, Hyperscale, Serverless, replicas, and IO limits.
@@ -27,170 +26,23 @@ be able to:
 
 ## Why This Module Matters
 
-Hypothetical scenario: an application
-team opens an incident because
-checkout latency tripled after a
-release, the database CPU chart is at
-the top of the graph, and the only
-person on call is a platform engineer
-rather than a DBA. The service owner
-asks whether to scale the database,
-fail over to the secondary region,
-roll back the application, change a
-firewall rule, or call the database
-team. The wrong first move can turn a
-contained performance incident into an
-expensive outage because Azure SQL
-Database combines database-engine
-behavior, cloud networking, identity,
-backup policy, and capacity billing in
-one managed surface. The operator does
-not need to tune every index from
-memory, but the operator does need to
-know which Azure SQL product is
-running, which tier limits it, which
-metric proves throttling, which
-security control blocks a client, and
-which restore path meets the promised
-RPO.
+Hypothetical scenario: an application team opens an incident because checkout latency tripled after a release, the database CPU chart is at the top of the graph, and the only person on call is a platform engineer rather than a DBA. The service owner asks whether to scale the database, fail over to the secondary region, roll back the application, change a firewall rule, or call the database team. The wrong first move can turn a contained performance incident into an expensive outage because Azure SQL Database combines database-engine behavior, cloud networking, identity, backup policy, and capacity billing in one managed surface. The operator does not need to tune every index from memory, but the operator does need to know which Azure SQL product is running, which tier limits it, which metric proves throttling, which security control blocks a client, and which restore path meets the promised RPO.
 
-Azure SQL is not one service with one
-operating model. Microsoft uses the
-Azure SQL family name for Azure SQL
-Database, Azure SQL Managed Instance,
-and SQL Server on Azure VM, each with
-a different line between what Azure
-operates and what your team operates.
-Azure SQL Database is a
-database-as-a-service for single
-databases and elastic pools, Azure SQL
-Managed Instance is closer to an
-instance-scoped SQL Server migration
-target, and SQL Server on Azure VM
-gives you OS-level control with IaaS
-responsibilities. Operators who
-collapse those three into "SQL in
-Azure" usually discover the difference
-during incidents, especially when they
-ask for SQL Agent, cross-database
-behavior, custom networking, full OS
-control, or a restore workflow that
-the chosen service does not support.
+Azure SQL is not one service with one operating model. Microsoft uses the Azure SQL family name for Azure SQL Database, Azure SQL Managed Instance, and SQL Server on Azure VM, each with a different line between what Azure operates and what your team operates. Azure SQL Database is a database-as-a-service for single databases and elastic pools, Azure SQL Managed Instance is closer to an instance-scoped SQL Server migration target, and SQL Server on Azure VM gives you OS-level control with IaaS responsibilities. Operators who collapse those three into "SQL in Azure" usually discover the difference during incidents, especially when they ask for SQL Agent, cross-database behavior, custom networking, full OS control, or a restore workflow that the chosen service does not support.
 
-This module teaches the daily operator
-path. You will compare the managed SQL
-choices, choose compute and storage
-models, reason about HA and disaster
-recovery, configure identity and
-network access, model cost, read Azure
-Monitor and Query Performance Insight,
-run targeted SQL diagnostic queries,
-and perform a point-in-time restore in
-a hands-on exercise. The module
-deliberately stays out of deep T-SQL
-internals because the audience is a
-platform, SRE, or DevOps engineer
-responsible for production
-reliability. When a problem crosses
-into schema design, query plans,
-statistics, isolation levels, or
-application data modeling, you will
-learn when to call a DBA and what
-evidence to bring.
+This module teaches the daily operator path. You will compare the managed SQL choices, choose compute and storage models, reason about HA and disaster recovery, configure identity and network access, model cost, read Azure Monitor and Query Performance Insight, run targeted SQL diagnostic queries, and perform a point-in-time restore in a hands-on exercise. The module deliberately stays out of deep T-SQL internals because the audience is a platform, SRE, or DevOps engineer responsible for production reliability. When a problem crosses into schema design, query plans, statistics, isolation levels, or application data modeling, you will learn when to call a DBA and what evidence to bring.
 
 ## 1. What Azure SQL Actually Means Today
 
-The first operator question is not
-"how do I connect?" The first question
-is "which Azure SQL product am I
-operating?" Azure SQL Database, Azure
-SQL Managed Instance, and SQL Server
-on Azure VM all use the SQL Server
-engine lineage, but they differ in
-control boundary, deployment shape,
-networking, scale behavior, restore
-model, and feature surface.
-Microsoft's Azure SQL overview
-describes the family as managed
-products built on SQL Server
-technology, with SQL Database and
-Managed Instance as PaaS options and
-SQL Server on Azure VM as IaaS [Azure
-SQL
-overview](https://learn.microsoft.com/en-us/azure/azure-sql/azure-sql-iaas-vs-paas-what-is-overview?view=azuresql).
+The first operator question is not "how do I connect?" The first question is "which Azure SQL product am I operating?" Azure SQL Database, Azure SQL Managed Instance, and SQL Server on Azure VM all use the SQL Server engine lineage, but they differ in control boundary, deployment shape, networking, scale behavior, restore model, and feature surface. Microsoft's Azure SQL overview describes the family as managed products built on SQL Server technology, with SQL Database and Managed Instance as PaaS options and SQL Server on Azure VM as IaaS [Azure SQL overview](https://learn.microsoft.com/en-us/azure/azure-sql/azure-sql-iaas-vs-paas-what-is-overview?view=azuresql).
 
-Azure SQL Database is the most managed
-option. You deploy a single database
-or an elastic pool behind a logical
-server, choose a purchasing model and
-service tier, and let Azure handle
-engine patching, backups, high
-availability mechanics, and most
-infrastructure work. The logical
-server is not a SQL Server instance in
-the traditional DBA sense. It is an
-Azure management boundary for
-databases, firewall rules, identity
-configuration, private endpoints,
-auditing settings, and failover group
-participation.
+Azure SQL Database is the most managed option. You deploy a single database or an elastic pool behind a logical server, choose a purchasing model and service tier, and let Azure handle engine patching, backups, high availability mechanics, and most infrastructure work. The logical server is not a SQL Server instance in the traditional DBA sense. It is an Azure management boundary for databases, firewall rules, identity configuration, private endpoints, auditing settings, and failover group participation.
 
-Azure SQL Managed Instance is the
-migration-friendly PaaS option. It
-gives you an instance-scoped surface
-that is much closer to SQL Server,
-including broader compatibility for
-instance-level features, native VNet
-placement, and migration patterns that
-assume existing SQL Server
-applications. It reduces
-operating-system and engine
-maintenance, but it has a bigger
-deployment footprint and a different
-networking model than Azure SQL
-Database. Operators usually choose it
-when the application is too
-instance-shaped for Azure SQL Database
-but the team still wants PaaS
-patching, automated backups, and
-managed availability.
+Azure SQL Managed Instance is the migration-friendly PaaS option. It gives you an instance-scoped surface that is much closer to SQL Server, including broader compatibility for instance-level features, native VNet placement, and migration patterns that assume existing SQL Server applications. It reduces operating-system and engine maintenance, but it has a bigger deployment footprint and a different networking model than Azure SQL Database. Operators usually choose it when the application is too instance-shaped for Azure SQL Database but the team still wants PaaS patching, automated backups, and managed availability.
 
-SQL Server on Azure VM is IaaS. You
-run SQL Server on a Windows or Linux
-VM, choose the SQL Server version and
-edition, configure disks, patch the
-OS, decide how backups run, and
-implement SQL Server HA patterns such
-as availability groups when the
-application requires them. Azure can
-help with the SQL IaaS Agent
-extension, automated backup, patching
-windows, and portal integration, but
-the control and responsibility
-boundary is fundamentally different.
-This is the choice when legacy
-features, third-party agents,
-file-system access, kernel-level
-control, or strict SQL Server
-compatibility matter more than PaaS
-simplicity.
+SQL Server on Azure VM is IaaS. You run SQL Server on a Windows or Linux VM, choose the SQL Server version and edition, configure disks, patch the OS, decide how backups run, and implement SQL Server HA patterns such as availability groups when the application requires them. Azure can help with the SQL IaaS Agent extension, automated backup, patching windows, and portal integration, but the control and responsibility boundary is fundamentally different. This is the choice when legacy features, third-party agents, file-system access, kernel-level control, or strict SQL Server compatibility matter more than PaaS simplicity.
 
-Azure Database for PostgreSQL and
-Azure Database for MySQL are not Azure
-SQL Database variants. They are
-managed relational database services
-for different engines, drivers,
-extensions, operational metrics,
-backup semantics, and tuning habits.
-An operator may run them on the same
-platform and monitor them through
-Azure Monitor, but this module does
-not cover their engine behavior. Point
-teams that need PostgreSQL or MySQL
-toward the managed open-source
-database tracks instead of trying to
-transfer SQL Server assumptions across
-engines.
+Azure Database for PostgreSQL and Azure Database for MySQL are not Azure SQL Database variants. They are managed relational database services for different engines, drivers, extensions, operational metrics, backup semantics, and tuning habits. An operator may run them on the same platform and monitor them through Azure Monitor, but this module does not cover their engine behavior. Point teams that need PostgreSQL or MySQL toward the managed open-source database tracks instead of trying to transfer SQL Server assumptions across engines.
 
 ```text
 +----------------------+--------------------------+---------------------------+
@@ -213,124 +65,23 @@ engines.
 | Max DB size | Tier-dependent; Hyperscale reaches the largest single-database size | Tier-dependent managed-instance limits | Limited by SQL edition, disk design, VM limits, and operational design |
 | Eligible features | Most database-level features, no full instance control | Many instance-level SQL Server features without OS control | Full SQL Server surface when you install and operate it |
 
-Worked example: a team is moving a
-vendor application that uses SQL Agent
-jobs, cross-database queries, CLR
-integration, and linked-server
-assumptions. Azure SQL Database may
-look attractive because it is the most
-managed option, but those
-instance-level assumptions are the
-warning sign. Managed Instance is the
-first PaaS candidate because it
-preserves more SQL Server instance
-behavior while still removing OS and
-engine patching from the team. SQL
-Server on Azure VM remains the
-fallback when the vendor requires OS
-access, unsupported features, custom
-agents, or a certified deployment
-matrix that excludes PaaS.
+Worked example: a team is moving a vendor application that uses SQL Agent jobs, cross-database queries, CLR integration, and linked-server assumptions. Azure SQL Database may look attractive because it is the most managed option, but those instance-level assumptions are the warning sign. Managed Instance is the first PaaS candidate because it preserves more SQL Server instance behavior while still removing OS and engine patching from the team. SQL Server on Azure VM remains the fallback when the vendor requires OS access, unsupported features, custom agents, or a certified deployment matrix that excludes PaaS.
 
-Now you solve it: your team owns a new
-SaaS API with one database per tenant,
-modest data size, no SQL Agent, and a
-requirement to isolate noisy tenants
-later. Would you start with Azure SQL
-Database single databases, an elastic
-pool, Managed Instance, or SQL Server
-on Azure VM? Write down the unit you
-want to scale and the unit you want to
-restore before choosing, because those
-two answers usually expose the right
-managed surface.
+Now you solve it: your team owns a new SaaS API with one database per tenant, modest data size, no SQL Agent, and a requirement to isolate noisy tenants later. Would you start with Azure SQL Database single databases, an elastic pool, Managed Instance, or SQL Server on Azure VM? Write down the unit you want to scale and the unit you want to restore before choosing, because those two answers usually expose the right managed surface.
 
 > **Pause and predict:** If a production incident says "the Azure SQL server is down," what three questions should you ask before any remediation command?
 
-The strongest first questions are:
-which Azure SQL product, which
-database or instance, and which
-connection path. "Server" can mean a
-logical server for Azure SQL Database,
-a managed instance, or a VM host, and
-each answer changes the runbook. A
-firewall rule on a logical server will
-not fix a VM disk saturation incident,
-and resizing a VM will not help a
-serverless Azure SQL Database that is
-resuming from pause. Clear naming in
-dashboards, alerts, and runbooks
-prevents the team from debugging the
-wrong abstraction.
+The strongest first questions are: which Azure SQL product, which database or instance, and which connection path. "Server" can mean a logical server for Azure SQL Database, a managed instance, or a VM host, and each answer changes the runbook. A firewall rule on a logical server will not fix a VM disk saturation incident, and resizing a VM will not help a serverless Azure SQL Database that is resuming from pause. Clear naming in dashboards, alerts, and runbooks prevents the team from debugging the wrong abstraction.
 
 ## 2. Compute and Storage Models
 
-Azure SQL Database has two major
-purchasing models: DTU and vCore. The
-DTU model bundles CPU, memory, reads,
-and writes into database transaction
-units, with Basic, Standard, and
-Premium tiers [DTU purchasing
-model](https://learn.microsoft.com/en-us/azure/azure-sql/database/service-tiers-dtu?view=azuresql).
-The vCore model exposes logical CPU,
-memory, hardware family, storage,
-backup storage, and service tier more
-explicitly, and Microsoft recommends
-it for flexibility, transparency, and
-Azure Hybrid Benefit alignment
-[purchasing
-models](https://learn.microsoft.com/en-us/azure/azure-sql/database/purchasing-models?view=azuresql).
-Operators should understand both
-because many small or older databases
-still run on DTU, while production
-architecture reviews usually land on
-vCore.
+Azure SQL Database has two major purchasing models: DTU and vCore. The DTU model bundles CPU, memory, reads, and writes into database transaction units, with Basic, Standard, and Premium tiers [DTU purchasing model](https://learn.microsoft.com/en-us/azure/azure-sql/database/service-tiers-dtu?view=azuresql). The vCore model exposes logical CPU, memory, hardware family, storage, backup storage, and service tier more explicitly, and Microsoft recommends it for flexibility, transparency, and Azure Hybrid Benefit alignment [purchasing models](https://learn.microsoft.com/en-us/azure/azure-sql/database/purchasing-models?view=azuresql). Operators should understand both because many small or older databases still run on DTU, while production architecture reviews usually land on vCore.
 
-DTU is useful when the workload is
-simple, small, and not worth detailed
-sizing. If a development database or
-low-traffic internal app fits
-comfortably in Standard and has no
-licensing optimization requirement,
-DTU can be a practical way to buy a
-bundle without arguing about vCores.
-The danger is that DTU hides which
-resource is saturated. When a DTU
-database throttles, the operator still
-has to look at CPU percentage, data IO
-percentage, log IO percentage,
-workers, sessions, waits, and query
-behavior to know whether more bundled
-DTUs are the right fix.
+DTU is useful when the workload is simple, small, and not worth detailed sizing. If a development database or low-traffic internal app fits comfortably in Standard and has no licensing optimization requirement, DTU can be a practical way to buy a bundle without arguing about vCores. The danger is that DTU hides which resource is saturated. When a DTU database throttles, the operator still has to look at CPU percentage, data IO percentage, log IO percentage, workers, sessions, waits, and query behavior to know whether more bundled DTUs are the right fix.
 
-vCore is the operator-friendly model
-for serious production. General
-Purpose, Business Critical, and
-Hyperscale are not just price tiers.
-They describe different storage
-architectures, IO ceilings, failover
-behavior, read-scale options, and
-maximum database sizes. The service
-tier is an availability and
-performance decision as much as a cost
-decision.
+vCore is the operator-friendly model for serious production. General Purpose, Business Critical, and Hyperscale are not just price tiers. They describe different storage architectures, IO ceilings, failover behavior, read-scale options, and maximum database sizes. The service tier is an availability and performance decision as much as a cost decision.
 
-General Purpose is the balanced
-default for many production systems.
-It uses remote storage, keeps cost
-lower, and works well when latency
-requirements are normal and the app
-can tolerate the tier's IO limits.
-Business Critical is for low-latency
-OLTP and higher transaction rates,
-with local SSD-backed storage and
-multiple replicas behind the service
-tier. Hyperscale separates compute and
-storage so large databases can grow
-far beyond the ordinary
-single-database storage ceiling and
-can scale compute and replicas
-differently.
+General Purpose is the balanced default for many production systems. It uses remote storage, keeps cost lower, and works well when latency requirements are normal and the app can tolerate the tier's IO limits. Business Critical is for low-latency OLTP and higher transaction rates, with local SSD-backed storage and multiple replicas behind the service tier. Hyperscale separates compute and storage so large databases can grow far beyond the ordinary single-database storage ceiling and can scale compute and replicas differently.
 
 | Model | Operator reads it as | Best fit | Watch for |
 |---|---|---|---|
@@ -340,45 +91,9 @@ differently.
 | vCore Hyperscale | Cloud-native storage and compute split | Very large DBs, fast scale, many read replicas | Replica billing, page-server behavior, unsupported edge cases, migration planning |
 | Serverless | Autoscaling vCore range with possible pause | Intermittent single DB workloads | Resume delay, min vCore floor, memory trimming, unpredictable warm-up |
 
-Provisioned compute means you choose a
-fixed amount of compute and pay for it
-while it exists. That is the right
-default for steady production
-workloads because capacity is ready
-when traffic arrives. Serverless means
-you configure a minimum and maximum
-vCore range, and the database can
-automatically scale within that range
-while billing for used compute;
-General Purpose serverless can also
-auto-pause so only storage is billed
-during inactivity [serverless compute
-tier](https://learn.microsoft.com/en-us/azure/azure-sql/database/serverless-tier-overview?view=azuresql).
-Serverless is compelling for
-intermittent workloads, but it is not
-a free production autoscaler when
-resume latency or cold memory affects
-user traffic.
+Provisioned compute means you choose a fixed amount of compute and pay for it while it exists. That is the right default for steady production workloads because capacity is ready when traffic arrives. Serverless means you configure a minimum and maximum vCore range, and the database can automatically scale within that range while billing for used compute; General Purpose serverless can also auto-pause so only storage is billed during inactivity [serverless compute tier](https://learn.microsoft.com/en-us/azure/azure-sql/database/serverless-tier-overview?view=azuresql). Serverless is compelling for intermittent workloads, but it is not a free production autoscaler when resume latency or cold memory affects user traffic.
 
-Hyperscale deserves its own mental
-model. Traditional database storage
-often feels like one engine process
-managing local data files, but
-Hyperscale splits the work into
-compute nodes, page servers, a log
-service, and Azure Storage [Hyperscale
-architecture](https://learn.microsoft.com/en-us/azure/azure-sql/database/hyperscale-architecture?view=azuresql).
-The primary compute replica handles
-read-write workload, page servers own
-ranges of database pages and keep SSD
-caches, the log service processes
-transaction log records, and durable
-page storage sits in Azure Storage.
-That design is why Hyperscale can
-support very large databases, fast
-snapshot-style backups, rapid scale
-operations, and named replicas for
-read-heavy patterns.
+Hyperscale deserves its own mental model. Traditional database storage often feels like one engine process managing local data files, but Hyperscale splits the work into compute nodes, page servers, a log service, and Azure Storage [Hyperscale architecture](https://learn.microsoft.com/en-us/azure/azure-sql/database/hyperscale-architecture?view=azuresql). The primary compute replica handles read-write workload, page servers own ranges of database pages and keep SSD caches, the log service processes transaction log records, and durable page storage sits in Azure Storage. That design is why Hyperscale can support very large databases, fast snapshot-style backups, rapid scale operations, and named replicas for read-heavy patterns.
 
 ```text
 +--------------------------- Hyperscale database ---------------------------+
@@ -406,173 +121,25 @@ read-heavy patterns.
 +--------------------------------------------------------------------------+
 ```
 
-Read replicas are not one universal
-feature with one billing model.
-Business Critical includes a
-read-scale secondary pattern that can
-serve read-only workloads with
-`ApplicationIntent=ReadOnly`.
-Hyperscale can add HA replicas and
-named replicas, and those replicas
-have cost and resource implications.
-Active geo-replication creates
-readable secondary databases in
-another region for Azure SQL Database,
-while failover groups wrap one or more
-databases with listener endpoints and
-failover policy.
+Read replicas are not one universal feature with one billing model. Business Critical includes a read-scale secondary pattern that can serve read-only workloads with `ApplicationIntent=ReadOnly`. Hyperscale can add HA replicas and named replicas, and those replicas have cost and resource implications. Active geo-replication creates readable secondary databases in another region for Azure SQL Database, while failover groups wrap one or more databases with listener endpoints and failover policy.
 
-When a workload exceeds an SKU's IO
-limit, Azure SQL Database does not
-become magically faster because the
-query is important. Throughput is
-governed, operations wait, latency
-rises, and clients may see timeouts or
-retry storms. On DTU, the symptom may
-be high DTU percentage with one of
-CPU, data IO, or log IO driving the
-blended limit. On vCore, the operator
-can usually see the pressure more
-directly through CPU percentage, data
-IO percentage, log IO percentage,
-workers percentage, sessions
-percentage, waits, and Query
-Performance Insight.
+When a workload exceeds an SKU's IO limit, Azure SQL Database does not become magically faster because the query is important. Throughput is governed, operations wait, latency rises, and clients may see timeouts or retry storms. On DTU, the symptom may be high DTU percentage with one of CPU, data IO, or log IO driving the blended limit. On vCore, the operator can usually see the pressure more directly through CPU percentage, data IO percentage, log IO percentage, workers percentage, sessions percentage, waits, and Query Performance Insight.
 
-Worked example: a service runs on
-General Purpose with 2 vCores and
-shows CPU at moderate levels, data IO
-near the limit, and log IO spiking
-during batch imports. Scaling to 4
-vCores may help if the tier gives more
-IO with more vCores, but the real
-question is whether the workload is
-write-log limited, data-read limited,
-or query-plan inefficient. If the
-import is business-critical and
-latency-sensitive, Business Critical
-may be the right tier because the
-storage architecture changes. If the
-database is already several terabytes
-and restore or scale time dominates
-the decision, Hyperscale may be the
-better architecture even if the
-immediate symptom is IO.
+Worked example: a service runs on General Purpose with 2 vCores and shows CPU at moderate levels, data IO near the limit, and log IO spiking during batch imports. Scaling to 4 vCores may help if the tier gives more IO with more vCores, but the real question is whether the workload is write-log limited, data-read limited, or query-plan inefficient. If the import is business-critical and latency-sensitive, Business Critical may be the right tier because the storage architecture changes. If the database is already several terabytes and restore or scale time dominates the decision, Hyperscale may be the better architecture even if the immediate symptom is IO.
 
-Now you solve it: a database is slow
-only during a nightly import, CPU
-remains below half of the limit, log
-IO reaches the top of the chart, and
-client retries amplify the problem.
-Would you first raise vCores, reduce
-batch size, move to Business Critical,
-change application retry policy, or
-call a DBA for indexing and
-transaction design? The operator
-answer is to reduce blast radius and
-collect proof: cap or schedule the
-import, confirm log IO saturation,
-check waits, then decide whether tier
-movement or database design is the
-durable fix.
+Now you solve it: a database is slow only during a nightly import, CPU remains below half of the limit, log IO reaches the top of the chart, and client retries amplify the problem. Would you first raise vCores, reduce batch size, move to Business Critical, change application retry policy, or call a DBA for indexing and transaction design? The operator answer is to reduce blast radius and collect proof: cap or schedule the import, confirm log IO saturation, check waits, then decide whether tier movement or database design is the durable fix.
 
 ## 3. High Availability and Disaster Recovery
 
-Azure SQL Database gives you built-in
-high availability before you configure
-any cross-region disaster recovery.
-The service is designed so Azure can
-patch and recover infrastructure
-without asking you to maintain SQL
-Server failover clustering. That
-built-in HA protects against many
-local infrastructure failures, but it
-is not the same as a cross-region
-recovery plan. Operators must separate
-local high availability, zone
-redundancy, geo-replication, failover
-groups, automatic backups,
-point-in-time restore, geo-restore,
-and long-term retention.
+Azure SQL Database gives you built-in high availability before you configure any cross-region disaster recovery. The service is designed so Azure can patch and recover infrastructure without asking you to maintain SQL Server failover clustering. That built-in HA protects against many local infrastructure failures, but it is not the same as a cross-region recovery plan. Operators must separate local high availability, zone redundancy, geo-replication, failover groups, automatic backups, point-in-time restore, geo-restore, and long-term retention.
 
-Zone redundancy is a regional
-availability design. For supported
-tiers and regions, Azure can place
-database replicas across availability
-zones so a zone failure does not imply
-a database outage. Business Critical
-and Hyperscale are the common
-production tiers where operators
-discuss zone-redundant HA, while
-General Purpose zone redundancy is
-also available in supported vCore
-configurations. The decision belongs
-in the same conversation as
-application zone architecture, private
-endpoint DNS, regional dependencies,
-and whether the app is ready for
-transient connection drops.
+Zone redundancy is a regional availability design. For supported tiers and regions, Azure can place database replicas across availability zones so a zone failure does not imply a database outage. Business Critical and Hyperscale are the common production tiers where operators discuss zone-redundant HA, while General Purpose zone redundancy is also available in supported vCore configurations. The decision belongs in the same conversation as application zone architecture, private endpoint DNS, regional dependencies, and whether the app is ready for transient connection drops.
 
-Backups solve a different problem.
-Automated backups support
-point-in-time restore for short-term
-retention, with retention generally
-configured in the 7 to 35 day range
-for most production tiers and lower
-limits for some small DTU choices
-[automated
-backups](https://learn.microsoft.com/en-us/azure/azure-sql/database/automated-backups-overview?view=azuresql-db).
-Long-term retention copies selected
-full backups into long-retention
-storage for compliance and can retain
-backups for up to 10 years [long-term
-retention](https://learn.microsoft.com/en-us/azure/azure-sql/database/long-term-retention-overview?view=azuresql).
-Backups are for data recovery after
-deletion, corruption, bad deployments,
-bad writes, and compliance evidence;
-they are not a low-latency failover
-mechanism.
+Backups solve a different problem. Automated backups support point-in-time restore for short-term retention, with retention generally configured in the 7 to 35 day range for most production tiers and lower limits for some small DTU choices [automated backups](https://learn.microsoft.com/en-us/azure/azure-sql/database/automated-backups-overview?view=azuresql-db). Long-term retention copies selected full backups into long-retention storage for compliance and can retain backups for up to 10 years [long-term retention](https://learn.microsoft.com/en-us/azure/azure-sql/database/long-term-retention-overview?view=azuresql). Backups are for data recovery after deletion, corruption, bad deployments, bad writes, and compliance evidence; they are not a low-latency failover mechanism.
 
-Point-in-time restore creates a new
-database from backups at a selected
-timestamp. It is the operator's path
-after a mistaken migration, accidental
-delete, application bug, or data
-corruption event where the original
-database should not be overwritten
-blindly. Geo-restore creates a
-database from geo-replicated backups
-in another region when the source
-region is unavailable or when you need
-regional recovery without
-preconfigured active geo-replication.
-Restore workflows should be rehearsed
-because permission, naming, firewall,
-identity, connection-string, and DNS
-assumptions often fail during a real
-incident.
+Point-in-time restore creates a new database from backups at a selected timestamp. It is the operator's path after a mistaken migration, accidental delete, application bug, or data corruption event where the original database should not be overwritten blindly. Geo-restore creates a database from geo-replicated backups in another region when the source region is unavailable or when you need regional recovery without preconfigured active geo-replication. Restore workflows should be rehearsed because permission, naming, firewall, identity, connection-string, and DNS assumptions often fail during a real incident.
 
-Active geo-replication is per-database
-asynchronous replication to readable
-secondary databases. It can support
-regional redundancy and manual
-geo-failover for individual databases,
-but applications must understand the
-connection path and possible data loss
-because replication is asynchronous
-[active
-geo-replication](https://learn.microsoft.com/en-us/azure/azure-sql/database/active-geo-replication-overview?view=azuresql-db).
-Failover groups build on
-geo-replication and manage one or more
-databases as a group with stable
-listener endpoints for read-write and
-read-only connections [failover
-groups](https://learn.microsoft.com/en-us/azure/azure-sql/database/auto-failover-group-sql-db?view=azuresql-db).
-For operators, failover groups are
-usually the safer application
-abstraction because the connection
-string can point at a listener instead
-of a specific regional server.
+Active geo-replication is per-database asynchronous replication to readable secondary databases. It can support regional redundancy and manual geo-failover for individual databases, but applications must understand the connection path and possible data loss because replication is asynchronous [active geo-replication](https://learn.microsoft.com/en-us/azure/azure-sql/database/active-geo-replication-overview?view=azuresql-db). Failover groups build on geo-replication and manage one or more databases as a group with stable listener endpoints for read-write and read-only connections [failover groups](https://learn.microsoft.com/en-us/azure/azure-sql/database/auto-failover-group-sql-db?view=azuresql-db). For operators, failover groups are usually the safer application abstraction because the connection string can point at a listener instead of a specific regional server.
 
 | Recovery question | Use this feature | Operator warning |
 |---|---|---|
@@ -598,98 +165,19 @@ flowchart TD
     J -->|No| L[Escalate business continuity gap and restore from available exports]
 ```
 
-RPO is the amount of data loss the
-business can tolerate. RTO is the
-amount of time the business can
-tolerate before the service is usable
-again. Those numbers should drive the
-feature choice, not the other way
-around. If the RPO is near zero and
-RTO is minutes, relying only on
-geo-restore is not a serious design;
-if the workload is internal and can
-wait, a failover group may be
-unnecessary cost and complexity.
+RPO is the amount of data loss the business can tolerate. RTO is the amount of time the business can tolerate before the service is usable again. Those numbers should drive the feature choice, not the other way around. If the RPO is near zero and RTO is minutes, relying only on geo-restore is not a serious design; if the workload is internal and can wait, a failover group may be unnecessary cost and complexity.
 
-Worked example: a customer-facing API
-promises a 15 minute RTO and accepts
-up to 5 seconds of data loss during a
-regional disaster. PITR alone cannot
-meet that RTO because a restore
-creates a new database and requires
-application reconnection work.
-Geo-restore is also too slow and too
-manual for the promise. The operator
-should design a failover group, test
-planned failover, verify the
-read-write listener, keep security
-settings aligned on the secondary
-server, and document the expected
-data-loss window from asynchronous
-replication.
+Worked example: a customer-facing API promises a 15 minute RTO and accepts up to 5 seconds of data loss during a regional disaster. PITR alone cannot meet that RTO because a restore creates a new database and requires application reconnection work. Geo-restore is also too slow and too manual for the promise. The operator should design a failover group, test planned failover, verify the read-write listener, keep security settings aligned on the secondary server, and document the expected data-loss window from asynchronous replication.
 
-> **Pause and predict:** A failover group exists, but after failover the app cannot connect from its private subnet in the secondary region.
-> Which resource is most likely missing: the database, the login, the private DNS link, or the backup retention policy?
+> **Pause and predict:** A failover group exists, but after failover the app cannot connect from its private subnet in the secondary region. Which resource is most likely missing: the database, the login, the private DNS link, or the backup retention policy?
 
-The most likely missing piece is the
-network path, especially private DNS
-and private endpoint alignment in the
-target region. Authentication and
-database existence can also fail, but
-private endpoint designs are regional
-and DNS-dependent. Good DR runbooks
-include a secondary server access
-checklist: Entra admin, contained
-users, firewall state, private
-endpoint, private DNS zone links,
-application connection string, Key
-Vault access, monitoring, and audit
-destination. Do not treat failover as
-only a database command.
+The most likely missing piece is the network path, especially private DNS and private endpoint alignment in the target region. Authentication and database existence can also fail, but private endpoint designs are regional and DNS-dependent. Good DR runbooks include a secondary server access checklist: Entra admin, contained users, firewall state, private endpoint, private DNS zone links, application connection string, Key Vault access, monitoring, and audit destination. Do not treat failover as only a database command.
 
 ## 4. Identity, Networking, and Security
 
-Azure SQL Database access has two
-planes. The Azure control plane
-creates servers, databases, private
-endpoints, firewall rules, identities,
-diagnostic settings, Defender plans,
-and backup policies through Azure
-Resource Manager. The SQL data plane
-accepts database connections,
-authenticates users or applications,
-enforces permissions, runs queries,
-writes audit events, and exposes DMVs.
-Operators need both planes because a
-user can have Azure Contributor
-permission and still be unable to
-query a database, or have database
-permission and still be blocked by
-networking.
+Azure SQL Database access has two planes. The Azure control plane creates servers, databases, private endpoints, firewall rules, identities, diagnostic settings, Defender plans, and backup policies through Azure Resource Manager. The SQL data plane accepts database connections, authenticates users or applications, enforces permissions, runs queries, writes audit events, and exposes DMVs. Operators need both planes because a user can have Azure Contributor permission and still be unable to query a database, or have database permission and still be blocked by networking.
 
-Microsoft Entra authentication is the
-preferred identity direction for
-humans and services because it
-centralizes identity, conditional
-access, group management, and service
-principal patterns [configure
-Microsoft Entra
-authentication](https://learn.microsoft.com/en-us/azure/azure-sql/database/authentication-aad-configure?view=azuresql).
-An Azure SQL logical server can have a
-Microsoft Entra administrator, and
-that administrator can create
-contained database users from external
-provider identities. Managed
-identities can connect to Azure SQL
-using Entra authentication when the
-database has a corresponding user and
-permission set [managed
-identities](https://learn.microsoft.com/en-us/azure/azure-sql/database/authentication-azure-ad-user-assigned-managed-identity?view=azuresql-db).
-This is the clean operator pattern for
-App Service, Functions, AKS workload
-identity, and automation jobs because
-it avoids long-lived SQL passwords in
-application settings.
+Microsoft Entra authentication is the preferred identity direction for humans and services because it centralizes identity, conditional access, group management, and service principal patterns [configure Microsoft Entra authentication](https://learn.microsoft.com/en-us/azure/azure-sql/database/authentication-aad-configure?view=azuresql). An Azure SQL logical server can have a Microsoft Entra administrator, and that administrator can create contained database users from external provider identities. Managed identities can connect to Azure SQL using Entra authentication when the database has a corresponding user and permission set [managed identities](https://learn.microsoft.com/en-us/azure/azure-sql/database/authentication-azure-ad-user-assigned-managed-identity?view=azuresql-db). This is the clean operator pattern for App Service, Functions, AKS workload identity, and automation jobs because it avoids long-lived SQL passwords in application settings.
 
 ```sql
 -- Run as the Microsoft Entra administrator in the target database.
@@ -698,39 +186,9 @@ ALTER ROLE db_datareader ADD MEMBER [app-orders-prod];
 ALTER ROLE db_datawriter ADD MEMBER [app-orders-prod];
 ```
 
-That snippet is intentionally small.
-The operator decision is not "grant
-db_owner so the app works." The
-operator decision is to map an Entra
-identity to the least database roles
-the application needs, then make the
-application use managed identity in
-its connection string. If the app
-needs schema migrations, use a
-separate deployment identity with
-controlled permissions rather than
-giving the runtime identity ownership
-of the database.
+That snippet is intentionally small. The operator decision is not "grant db_owner so the app works." The operator decision is to map an Entra identity to the least database roles the application needs, then make the application use managed identity in its connection string. If the app needs schema migrations, use a separate deployment identity with controlled permissions rather than giving the runtime identity ownership of the database.
 
-Networking is a separate gate. Azure
-SQL Database can expose a public
-endpoint guarded by IP firewall rules,
-use virtual network service endpoints
-in older patterns, or use private
-endpoints through Azure Private Link
-[private endpoint
-overview](https://learn.microsoft.com/en-us/azure/azure-sql/database/private-endpoint-overview?view=azuresql).
-Server-level firewall rules apply to
-all databases on the logical server,
-while database-level firewall rules
-are created through T-SQL and apply
-only to one database [firewall
-rules](https://learn.microsoft.com/en-us/azure/azure-sql/database/firewall-configure?view=azuresql).
-Private endpoints are usually the
-production target for private
-workloads, but they add DNS and
-routing responsibilities that must be
-tested from every caller network.
+Networking is a separate gate. Azure SQL Database can expose a public endpoint guarded by IP firewall rules, use virtual network service endpoints in older patterns, or use private endpoints through Azure Private Link [private endpoint overview](https://learn.microsoft.com/en-us/azure/azure-sql/database/private-endpoint-overview?view=azuresql). Server-level firewall rules apply to all databases on the logical server, while database-level firewall rules are created through T-SQL and apply only to one database [firewall rules](https://learn.microsoft.com/en-us/azure/azure-sql/database/firewall-configure?view=azuresql). Private endpoints are usually the production target for private workloads, but they add DNS and routing responsibilities that must be tested from every caller network.
 
 | Access pattern | When it is reasonable | Operator risk |
 |---|---|---|
@@ -740,140 +198,21 @@ tested from every caller network.
 | Database-level firewall rule | Rare per-database exception | Harder inventory because it is not managed like server-level firewall |
 | Allow Azure services toggle | Emergency or legacy integration only | Broad Azure-origin access, poor least-privilege story |
 
-Encryption controls protect different
-layers. Transparent Data Encryption
-protects data at rest by encrypting
-database files and backups, and
-customer-managed TDE keys let the
-customer control the TDE protector
-through Azure Key Vault or Managed HSM
-[TDE with customer-managed
-keys](https://learn.microsoft.com/en-us/azure/azure-sql/database/transparent-data-encryption-byok-overview?view=azuresql).
-Always Encrypted protects selected
-sensitive columns so encryption keys
-are not exposed to the database engine
-in ordinary operation [Always
-Encrypted](https://learn.microsoft.com/en-us/sql/relational-databases/security/encryption/always-encrypted-database-engine?view=sql-server-ver17).
-Dynamic Data Masking and Row-Level
-Security are data-access controls, not
-substitutes for permission design, and
-they require application and DBA
-review before production rollout.
+Encryption controls protect different layers. Transparent Data Encryption protects data at rest by encrypting database files and backups, and customer-managed TDE keys let the customer control the TDE protector through Azure Key Vault or Managed HSM [TDE with customer-managed keys](https://learn.microsoft.com/en-us/azure/azure-sql/database/transparent-data-encryption-byok-overview?view=azuresql). Always Encrypted protects selected sensitive columns so encryption keys are not exposed to the database engine in ordinary operation [Always Encrypted](https://learn.microsoft.com/en-us/sql/relational-databases/security/encryption/always-encrypted-database-engine?view=sql-server-ver17). Dynamic Data Masking and Row-Level Security are data-access controls, not substitutes for permission design, and they require application and DBA review before production rollout.
 
-Always Encrypted is a great example of
-an operator-DBA boundary. The operator
-can make sure Key Vault access,
-managed identity, deployment pipeline
-permissions, and driver support exist.
-The DBA and application team must
-decide which columns can be encrypted
-without breaking query patterns,
-indexing assumptions, sorting,
-equality searches, or operational
-support workflows. If the operator
-turns it on as a checkbox without
-application design, the incident may
-be a broken release rather than a
-safer database.
+Always Encrypted is a great example of an operator-DBA boundary. The operator can make sure Key Vault access, managed identity, deployment pipeline permissions, and driver support exist. The DBA and application team must decide which columns can be encrypted without breaking query patterns, indexing assumptions, sorting, equality searches, or operational support workflows. If the operator turns it on as a checkbox without application design, the incident may be a broken release rather than a safer database.
 
-Auditing and Defender answer different
-questions. Azure SQL auditing tracks
-database events and can write audit
-logs to Azure Storage, Log Analytics,
-or Event Hubs [SQL
-auditing](https://learn.microsoft.com/en-us/azure/azure-sql/database/auditing-overview?view=azuresql).
-Microsoft Defender for SQL adds
-vulnerability assessment and advanced
-threat protection, including alerts
-for possible SQL injection and
-anomalous access patterns [Defender
-for
-SQL](https://learn.microsoft.com/en-us/azure/azure-sql/database/azure-defender-for-sql?view=azuresql).
-Auditing is the durable trail;
-Defender is detection and
-recommendation; neither is a
-replacement for least-privilege
-identity, private networking, secure
-coding, or patch discipline.
+Auditing and Defender answer different questions. Azure SQL auditing tracks database events and can write audit logs to Azure Storage, Log Analytics, or Event Hubs [SQL auditing](https://learn.microsoft.com/en-us/azure/azure-sql/database/auditing-overview?view=azuresql). Microsoft Defender for SQL adds vulnerability assessment and advanced threat protection, including alerts for possible SQL injection and anomalous access patterns [Defender for SQL](https://learn.microsoft.com/en-us/azure/azure-sql/database/azure-defender-for-sql?view=azuresql). Auditing is the durable trail; Defender is detection and recommendation; neither is a replacement for least-privilege identity, private networking, secure coding, or patch discipline.
 
-Hypothetical scenario: Defender raises
-a possible SQL injection alert after a
-new search endpoint goes live. The
-operator should not dismiss it because
-the service is behind private
-networking; SQL injection is an
-application input problem, not only an
-internet exposure problem. The first
-response is to preserve the alert,
-identify the database and principal,
-check audit logs and application logs
-around the timestamp, confirm the
-endpoint and query pattern, and pull
-in the application team. If the alert
-matches expected synthetic testing,
-tune the alert process; if it matches
-untrusted input reaching dynamic SQL,
-escalate as a security incident.
+Hypothetical scenario: Defender raises a possible SQL injection alert after a new search endpoint goes live. The operator should not dismiss it because the service is behind private networking; SQL injection is an application input problem, not only an internet exposure problem. The first response is to preserve the alert, identify the database and principal, check audit logs and application logs around the timestamp, confirm the endpoint and query pattern, and pull in the application team. If the alert matches expected synthetic testing, tune the alert process; if it matches untrusted input reaching dynamic SQL, escalate as a security incident.
 
 ## 5. Observability and Day-Two Operations
 
-The operator's first slow-database
-screen is Azure Monitor, not a
-query-plan deep dive. Azure SQL
-Database exposes metrics such as CPU
-percentage, Data IO percentage, Log IO
-percentage, Workers percentage,
-Sessions percentage, DTU percentage
-for DTU databases, storage percentage,
-successful connections, failed
-connections, and blocked connections
-[monitoring
-metrics](https://learn.microsoft.com/en-us/azure/azure-sql/database/monitoring-metrics-alerts?view=azuresql).
-These metrics tell you whether the
-database is near a service-tier limit,
-whether the incident is
-connection-related, whether worker or
-session limits are involved, and
-whether storage is becoming a capacity
-risk. They do not tell you by
-themselves which query or schema
-design caused the pressure.
+The operator's first slow-database screen is Azure Monitor, not a query-plan deep dive. Azure SQL Database exposes metrics such as CPU percentage, Data IO percentage, Log IO percentage, Workers percentage, Sessions percentage, DTU percentage for DTU databases, storage percentage, successful connections, failed connections, and blocked connections [monitoring metrics](https://learn.microsoft.com/en-us/azure/azure-sql/database/monitoring-metrics-alerts?view=azuresql). These metrics tell you whether the database is near a service-tier limit, whether the incident is connection-related, whether worker or session limits are involved, and whether storage is becoming a capacity risk. They do not tell you by themselves which query or schema design caused the pressure.
 
-Query Performance Insight is the
-operator's first stop for "why slow?"
-It uses Query Store data to show top
-resource-consuming and long-running
-queries, CPU, duration, execution
-count, query text where permitted, and
-performance recommendations [Query
-Performance
-Insight](https://learn.microsoft.com/en-us/azure/azure-sql/database/query-performance-insight-use?view=azuresql).
-The point is not that the operator
-becomes the query tuner. The point is
-that the operator can identify whether
-one query, many chatty queries,
-blocking, or a tier limit is the
-dominant shape before escalating with
-useful evidence.
+Query Performance Insight is the operator's first stop for "why slow?" It uses Query Store data to show top resource-consuming and long-running queries, CPU, duration, execution count, query text where permitted, and performance recommendations [Query Performance Insight](https://learn.microsoft.com/en-us/azure/azure-sql/database/query-performance-insight-use?view=azuresql). The point is not that the operator becomes the query tuner. The point is that the operator can identify whether one query, many chatty queries, blocking, or a tier limit is the dominant shape before escalating with useful evidence.
 
-Extended Events and automatic tuning
-recommendations live one layer deeper.
-Extended Events can capture targeted
-diagnostic events with lower overhead
-than older tracing habits, but it
-still requires discipline because
-"capture everything" is not an
-incident strategy. Automatic tuning
-recommendations can suggest index
-creation, index drops, and plan
-correction, but production teams
-should treat automated changes as
-policy decisions with rollback
-awareness. For many teams, the
-operator collects recommendations,
-checks whether automatic tuning is
-enabled, and brings the evidence to
-the DBA or data platform owner.
+Extended Events and automatic tuning recommendations live one layer deeper. Extended Events can capture targeted diagnostic events with lower overhead than older tracing habits, but it still requires discipline because "capture everything" is not an incident strategy. Automatic tuning recommendations can suggest index creation, index drops, and plan correction, but production teams should treat automated changes as policy decisions with rollback awareness. For many teams, the operator collects recommendations, checks whether automatic tuning is enabled, and brings the evidence to the DBA or data platform owner.
 
 ```kusto
 AzureMetrics
@@ -884,19 +223,7 @@ AzureMetrics
 | order by TimeGenerated desc
 ```
 
-That KQL query is the Azure Monitor
-metrics view of the same pressure
-operators often inspect with
-`sys.dm_db_resource_stats`. The DMV
-itself is still useful when you are
-connected to the database and need a
-quick recent view. It returns CPU, IO,
-and memory consumption rows for recent
-intervals, with values expressed as
-percentages of service-tier limits.
-Use it like a database-local `top`
-command, not as a permanent telemetry
-store.
+That KQL query is the Azure Monitor metrics view of the same pressure operators often inspect with `sys.dm_db_resource_stats`. The DMV itself is still useful when you are connected to the database and need a quick recent view. It returns CPU, IO, and memory consumption rows for recent intervals, with values expressed as percentages of service-tier limits. Use it like a database-local `top` command, not as a permanent telemetry store.
 
 ```sql
 SELECT TOP (20)
@@ -910,19 +237,7 @@ FROM sys.dm_db_resource_stats
 ORDER BY end_time DESC;
 ```
 
-Database waits are the next operator
-clue. The DMV `sys.dm_db_wait_stats`
-shows completed waits for the current
-database, and high lock waits, IO
-waits, log waits, or worker-related
-waits can point the investigation in
-the right direction. The counters
-reset after failover or database
-movement, so do not compare them as if
-they were a forever ledger. Use waits
-to shape the next question: blocking,
-IO, log pressure, worker starvation,
-or application round trips.
+Database waits are the next operator clue. The DMV `sys.dm_db_wait_stats` shows completed waits for the current database, and high lock waits, IO waits, log waits, or worker-related waits can point the investigation in the right direction. The counters reset after failover or database movement, so do not compare them as if they were a forever ledger. Use waits to shape the next question: blocking, IO, log pressure, worker starvation, or application round trips.
 
 ```sql
 SELECT TOP (15)
@@ -936,25 +251,7 @@ WHERE wait_type NOT LIKE 'SLEEP%'
 ORDER BY wait_time_ms DESC;
 ```
 
-For a more telemetry-native KQL
-approach, Database Watcher can stream
-Azure SQL monitoring datasets into
-Azure Data Explorer or Fabric
-Real-Time Analytics. Its SQL database
-datasets include resource utilization,
-query wait statistics, and wait
-statistics tables such as
-`sqldb_database_resource_utilization`,
-`sqldb_database_query_wait_stats`, and
-`sqldb_database_wait_stats` [database
-watcher
-datasets](https://learn.microsoft.com/en-us/azure/azure-sql/database-watcher-data?view=azuresql).
-That makes KQL the right place for
-fleet-level questions that do not
-belong in one database connection. The
-sample below assumes Database Watcher
-is configured and data is landing in a
-KQL database.
+For a more telemetry-native KQL approach, Database Watcher can stream Azure SQL monitoring datasets into Azure Data Explorer or Fabric Real-Time Analytics. Its SQL database datasets include resource utilization, query wait statistics, and wait statistics tables such as `sqldb_database_resource_utilization`, `sqldb_database_query_wait_stats`, and `sqldb_database_wait_stats` [database watcher datasets](https://learn.microsoft.com/en-us/azure/azure-sql/database-watcher-data?view=azuresql). That makes KQL the right place for fleet-level questions that do not belong in one database connection. The sample below assumes Database Watcher is configured and data is landing in a KQL database.
 
 ```kusto
 sqldb_database_resource_utilization
@@ -979,59 +276,13 @@ sqldb_database_wait_stats
 | top 10 by wait_ms desc
 ```
 
-Defender alerts add security context
-to day-two operations. A possible SQL
-injection alert asks whether untrusted
-input reached a dangerous query
-pattern. An unusual location or
-unfamiliar principal alert asks
-whether access behavior changed
-because of a real deployment, a
-compromised credential, or a
-misconfigured integration. Operators
-should route these alerts to the same
-incident discipline as infrastructure
-alerts: preserve evidence, identify
-scope, correlate with deployment and
-identity changes, and escalate with a
-precise timeline.
+Defender alerts add security context to day-two operations. A possible SQL injection alert asks whether untrusted input reached a dangerous query pattern. An unusual location or unfamiliar principal alert asks whether access behavior changed because of a real deployment, a compromised credential, or a misconfigured integration. Operators should route these alerts to the same incident discipline as infrastructure alerts: preserve evidence, identify scope, correlate with deployment and identity changes, and escalate with a precise timeline.
 
-Call in a DBA when the investigation
-points to query plans, indexing,
-locking design, isolation levels,
-transaction shape, schema design,
-statistics, parameter sensitivity, or
-data distribution. Handle inline when
-the issue is firewall, private
-endpoint DNS, connection-string
-target, tier saturation, runaway
-non-production workload, backup
-retention policy, diagnostic setting,
-identity mapping, or a known platform
-failover. The boundary is not ego; it
-is risk management. A good operator
-brings the DBA the timeline, metrics,
-waits, top queries, recent
-deployments, tier, connection path,
-and user impact instead of a vague
-"SQL is slow" ticket.
+Call in a DBA when the investigation points to query plans, indexing, locking design, isolation levels, transaction shape, schema design, statistics, parameter sensitivity, or data distribution. Handle inline when the issue is firewall, private endpoint DNS, connection-string target, tier saturation, runaway non-production workload, backup retention policy, diagnostic setting, identity mapping, or a known platform failover. The boundary is not ego; it is risk management. A good operator brings the DBA the timeline, metrics, waits, top queries, recent deployments, tier, connection path, and user impact instead of a vague "SQL is slow" ticket.
 
 ## Patterns and Anti-Patterns
 
-Patterns turn managed database
-operations into repeatable decisions.
-The goal is not to create a perfect
-database platform on day one. The goal
-is to make the common failure paths
-boring: access changes are reviewed,
-failover has been rehearsed, capacity
-graphs have owners, backup retention
-has a business reason, and cost
-increases can be explained before
-finance opens a surprise ticket. Use
-the patterns below as production
-defaults unless your workload gives
-you a concrete reason to diverge.
+Patterns turn managed database operations into repeatable decisions. The goal is not to create a perfect database platform on day one. The goal is to make the common failure paths boring: access changes are reviewed, failover has been rehearsed, capacity graphs have owners, backup retention has a business reason, and cost increases can be explained before finance opens a surprise ticket. Use the patterns below as production defaults unless your workload gives you a concrete reason to diverge.
 
 | Pattern | When to use it | Why it works | Scaling considerations |
 |---|---|---|---|
@@ -1042,15 +293,7 @@ you a concrete reason to diverge.
 | Query Performance Insight before scaling | Slow queries or capacity alarms with unclear root cause | Shows whether one query, many queries, or tier limits dominate | Query Store retention and permissions must be healthy |
 | PITR to new database before repair | Bad write, bad migration, accidental delete | Preserves evidence and gives a safe comparison target | Application repair scripts and data reconciliation may need DBA ownership |
 
-Anti-patterns are usually attractive
-because they work once. A broad
-firewall rule fixes the developer
-demo. Scaling up hides a bad import
-for a week. One shared SQL admin
-password gets the application online.
-Each of those shortcuts transfers risk
-to the next incident, where the team
-has less context and more pressure.
+Anti-patterns are usually attractive because they work once. A broad firewall rule fixes the developer demo. Scaling up hides a bad import for a week. One shared SQL admin password gets the application online. Each of those shortcuts transfers risk to the next incident, where the team has less context and more pressure.
 
 | Anti-pattern | What goes wrong | Better alternative |
 |---|---|---|
@@ -1063,21 +306,7 @@ has less context and more pressure.
 
 ## Decision Framework
 
-Start with the operational ownership
-model. If the team wants a managed
-database and the application fits
-database-scoped features, Azure SQL
-Database is the default. If the
-application is SQL Server
-instance-shaped and needs broader
-compatibility without OS ownership,
-Managed Instance is the default
-migration candidate. If the
-application requires full SQL Server
-control, a certified VM deployment,
-custom agents, unsupported instance
-features, or OS access, SQL Server on
-Azure VM is the honest choice.
+Start with the operational ownership model. If the team wants a managed database and the application fits database-scoped features, Azure SQL Database is the default. If the application is SQL Server instance-shaped and needs broader compatibility without OS ownership, Managed Instance is the default migration candidate. If the application requires full SQL Server control, a certified VM deployment, custom agents, unsupported instance features, or OS access, SQL Server on Azure VM is the honest choice.
 
 ```mermaid
 flowchart TD
@@ -1092,47 +321,11 @@ flowchart TD
     H -->|No| J[Re-check requirements with DBA and app team]
 ```
 
-Choose DTU only when simplicity is the
-real goal. DTU is fine for small,
-predictable, low-risk databases where
-a bundled capacity choice is easier
-than independent compute and storage
-sizing. Move to vCore when you need
-transparent CPU and storage sizing,
-Azure Hybrid Benefit, reserved
-capacity, serious production modeling,
-Business Critical, Hyperscale, or
-Serverless. Do not let "DTU is
-simpler" become "we cannot explain why
-this database throttles."
+Choose DTU only when simplicity is the real goal. DTU is fine for small, predictable, low-risk databases where a bundled capacity choice is easier than independent compute and storage sizing. Move to vCore when you need transparent CPU and storage sizing, Azure Hybrid Benefit, reserved capacity, serious production modeling, Business Critical, Hyperscale, or Serverless. Do not let "DTU is simpler" become "we cannot explain why this database throttles."
 
-Choose Serverless when the workload is
-intermittent and can tolerate resume
-behavior. Development, test,
-occasional reporting, low-traffic
-internal tools, and unpredictable new
-databases are good candidates. Steady
-user-facing APIs, latency-sensitive
-services, and workloads with constant
-background activity usually belong on
-provisioned compute. Serverless saves
-money when idle periods are real; it
-disappoints when the database never
-pauses or when cold-start behavior
-violates the user experience.
+Choose Serverless when the workload is intermittent and can tolerate resume behavior. Development, test, occasional reporting, low-traffic internal tools, and unpredictable new databases are good candidates. Steady user-facing APIs, latency-sensitive services, and workloads with constant background activity usually belong on provisioned compute. Serverless saves money when idle periods are real; it disappoints when the database never pauses or when cold-start behavior violates the user experience.
 
-Choose Hyperscale when the
-architecture solves a real problem.
-Very large databases, fast scale up or
-down independent of data size, rapid
-snapshot-style backups, and read-scale
-patterns are strong reasons. Do not
-choose Hyperscale only because the
-name sounds safer. Its replicas and
-storage model change the cost surface,
-and some migration or feature
-limitations may matter for legacy
-applications.
+Choose Hyperscale when the architecture solves a real problem. Very large databases, fast scale up or down independent of data size, rapid snapshot-style backups, and read-scale patterns are strong reasons. Do not choose Hyperscale only because the name sounds safer. Its replicas and storage model change the cost surface, and some migration or feature limitations may matter for legacy applications.
 
 | Decision | Choose this | Avoid this |
 |---|---|---|
@@ -1145,119 +338,21 @@ applications.
 | Low-latency OLTP with high write rate | Business Critical | General Purpose if IO latency is the recurring incident |
 | Legacy on-prem pattern with strict control | SQL Server on Azure VM | PaaS if kernel, agent, file, or edition control is mandatory |
 
-Worked example: a customer database is
-100 GB, serves a steady API, has
-ordinary latency needs, and peaks
-during business hours. General Purpose
-vCore is a sensible first design
-because the workload is not huge, not
-obviously low-latency OLTP, and not
-intermittent enough for Serverless. If
-the team later sees sustained log IO
-pressure and low-latency requirements,
-Business Critical becomes a
-performance architecture discussion
-rather than a panic scale button. If
-the database grows into many terabytes
-and restore time becomes a product
-risk, Hyperscale becomes a storage
-architecture discussion.
+Worked example: a customer database is 100 GB, serves a steady API, has ordinary latency needs, and peaks during business hours. General Purpose vCore is a sensible first design because the workload is not huge, not obviously low-latency OLTP, and not intermittent enough for Serverless. If the team later sees sustained log IO pressure and low-latency requirements, Business Critical becomes a performance architecture discussion rather than a panic scale button. If the database grows into many terabytes and restore time becomes a product risk, Hyperscale becomes a storage architecture discussion.
 
-Now you solve it: a reporting workload
-runs for two hours each weekday, can
-wait after idle periods, and is
-inactive most nights and weekends.
-Would Serverless or Provisioned
-compute be the first cost model you
-test? The correct operator instinct is
-to test Serverless with a realistic
-resume and query schedule, then
-compare the bill against provisioned
-compute plus any scheduling or pause
-strategy the team can actually
-operate.
+Now you solve it: a reporting workload runs for two hours each weekday, can wait after idle periods, and is inactive most nights and weekends. Would Serverless or Provisioned compute be the first cost model you test? The correct operator instinct is to test Serverless with a realistic resume and query schedule, then compare the bill against provisioned compute plus any scheduling or pause strategy the team can actually operate.
 
 ## Cost Lens
 
-Azure SQL Database cost is a design
-input, not a finance afterthought. For
-DTU, you pay for the chosen DTU
-service objective and bundled storage
-behavior. For vCore, the main bill is
-compute hours, provisioned or
-allocated data storage, backup storage
-beyond the included amount, optional
-long-term retention, replicas,
-Defender, and network or monitoring
-costs around the database. Reserved
-capacity, Dev/Test pricing, and Azure
-Hybrid Benefit can materially change
-the compute line, but they do not
-erase poor tier selection or unlimited
-retention.
+Azure SQL Database cost is a design input, not a finance afterthought. For DTU, you pay for the chosen DTU service objective and bundled storage behavior. For vCore, the main bill is compute hours, provisioned or allocated data storage, backup storage beyond the included amount, optional long-term retention, replicas, Defender, and network or monitoring costs around the database. Reserved capacity, Dev/Test pricing, and Azure Hybrid Benefit can materially change the compute line, but they do not erase poor tier selection or unlimited retention.
 
-The vCore pricing surface is usually
-easiest to explain as a formula.
-Provisioned compute is vCore-hour rate
-multiplied by hours in the month. Data
-storage is GB-month multiplied by the
-selected tier's storage rate. PITR
-backup storage has an included amount
-tied to database size, with excess
-backup storage charged by GB-month,
-while LTR storage is separate.
-Geo-replication and failover groups
-add secondary compute and storage
-because the secondary database is a
-real database, not a free checkbox.
+The vCore pricing surface is usually easiest to explain as a formula. Provisioned compute is vCore-hour rate multiplied by hours in the month. Data storage is GB-month multiplied by the selected tier's storage rate. PITR backup storage has an included amount tied to database size, with excess backup storage charged by GB-month, while LTR storage is separate. Geo-replication and failover groups add secondary compute and storage because the secondary database is a real database, not a free checkbox.
 
-Hyperscale changes the mental model.
-Compute is charged per replica,
-storage is charged for allocated data
-storage that grows in increments, and
-additional replicas change the monthly
-number. Page servers and Azure Storage
-are part of the architecture, so the
-operator should read Hyperscale cost
-as "primary compute plus replica
-compute plus allocated storage plus
-backup storage," not as "one database
-price." Hyperscale can be
-cost-effective for the right workload,
-but it punishes vague replica habits.
+Hyperscale changes the mental model. Compute is charged per replica, storage is charged for allocated data storage that grows in increments, and additional replicas change the monthly number. Page servers and Azure Storage are part of the architecture, so the operator should read Hyperscale cost as "primary compute plus replica compute plus allocated storage plus backup storage," not as "one database price." Hyperscale can be cost-effective for the right workload, but it punishes vague replica habits.
 
-Reserved capacity is a commitment
-discount for steady production.
-One-year and three-year reservations
-can reduce compute cost when the
-database is expected to run
-continuously. Azure Hybrid Benefit can
-apply existing SQL Server licenses to
-eligible vCore Azure SQL Database
-deployments, reducing compute cost
-when licensing terms are met. Dev/Test
-pricing can reduce non-production cost
-for eligible subscriptions, but it
-should not be used to hide production
-workloads in the wrong subscription.
+Reserved capacity is a commitment discount for steady production. One-year and three-year reservations can reduce compute cost when the database is expected to run continuously. Azure Hybrid Benefit can apply existing SQL Server licenses to eligible vCore Azure SQL Database deployments, reducing compute cost when licensing terms are met. Dev/Test pricing can reduce non-production cost for eligible subscriptions, but it should not be used to hide production workloads in the wrong subscription.
 
-Worked pricing example, using East US
-Pay-As-You-Go retail prices sampled
-from the Azure pricing page and Retail
-Prices API on May 19, 2026. Assume a
-730-hour month, 100 GB maximum data
-size, no LTR, and PITR backup
-consumption within the included 100
-percent database-size allowance. The
-numbers are rounded and should be
-recalculated in the Azure Pricing
-Calculator for your region, currency,
-reservation, licensing, backup
-redundancy, and support plan. The
-example compares General Purpose and
-Business Critical because the tier
-choice is often the biggest
-operator-controlled difference.
+Worked pricing example, using East US Pay-As-You-Go retail prices sampled from the Azure pricing page and Retail Prices API on May 19, 2026. Assume a 730-hour month, 100 GB maximum data size, no LTR, and PITR backup consumption within the included 100 percent database-size allowance. The numbers are rounded and should be recalculated in the Azure Pricing Calculator for your region, currency, reservation, licensing, backup redundancy, and support plan. The example compares General Purpose and Business Critical because the tier choice is often the biggest operator-controlled difference.
 
 | Example shape | Compute assumption | Compute monthly | Data storage monthly | PITR backup monthly | Approximate total |
 |---|---:|---:|---:|---:|---:|
@@ -1266,50 +361,11 @@ operator-controlled difference.
 
 Zone-redundant configuration (where supported, including General Purpose and Business Critical) adds a premium of roughly 20-30% on the compute meter to account for the redundant deployment across availability zones. Use the [Azure Pricing Calculator](https://azure.microsoft.com/en-us/pricing/calculator/) to model the exact ZR rate for your chosen hardware family — published per-hour rates vary across Standard-series, Fsv2-series, and DC-series options and the public meter names change as new hardware families are introduced.
 
-Read the table above carefully. It is not a
-universal quote, and it does not
-include Defender for SQL, cross-region
-replicas, excess backup storage, LTR,
-Log Analytics ingestion, support,
-private endpoint data processing, or
-reservations. It shows the operator
-method: list the tier, compute hours,
-storage GB-month, backup assumption,
-and optional features separately. If
-the bill is surprising, break it back
-into those lines before changing the
-database.
+Read the table above carefully. It is not a universal quote, and it does not include Defender for SQL, cross-region replicas, excess backup storage, LTR, Log Analytics ingestion, support, private endpoint data processing, or reservations. It shows the operator method: list the tier, compute hours, storage GB-month, backup assumption, and optional features separately. If the bill is surprising, break it back into those lines before changing the database.
 
-Cost spikes usually come from
-operational shortcuts. An under-sized
-DTU or vCore database causes
-throttling, so the team
-over-provisions to silence alerts
-instead of fixing query shape or batch
-timing. Unbounded LTR retains backups
-for years without a named compliance
-owner. Cross-region geo-replication
-doubles much of the database footprint
-because the secondary exists and runs.
-Hyperscale replicas multiply compute
-cost when teams add read replicas
-without retiring experiments.
+Cost spikes usually come from operational shortcuts. An under-sized DTU or vCore database causes throttling, so the team over-provisions to silence alerts instead of fixing query shape or batch timing. Unbounded LTR retains backups for years without a named compliance owner. Cross-region geo-replication doubles much of the database footprint because the secondary exists and runs. Hyperscale replicas multiply compute cost when teams add read replicas without retiring experiments.
 
-Defender for SQL is valuable, but it
-is still a billable plan. For a small
-low-risk development database, leaving
-Defender enabled may be less important
-than using a cheaper dev/test pattern
-and stronger subscription policy. For
-production data, the security signal
-is often worth the cost, especially
-when audit logs and incident response
-are mature enough to use the alerts.
-The operator decision is not "security
-costs too much"; it is "which
-subscriptions and data classes require
-this control, and who reviews the
-findings?"
+Defender for SQL is valuable, but it is still a billable plan. For a small low-risk development database, leaving Defender enabled may be less important than using a cheaper dev/test pattern and stronger subscription policy. For production data, the security signal is often worth the cost, especially when audit logs and incident response are mature enough to use the alerts. The operator decision is not "security costs too much"; it is "which subscriptions and data classes require this control, and who reviews the findings?"
 
 ## Did You Know?
 
@@ -1335,170 +391,53 @@ findings?"
 
 <details><summary>Your team runs a new checkout API on Azure SQL Database General Purpose. CPU is moderate, log IO is consistently near the service limit during imports, and the app sees timeout spikes. What do you check before scaling?</summary>
 
-Start by confirming the pressure shape
-with Azure Monitor metrics and
-`sys.dm_db_resource_stats`, then look
-at waits and Query Performance Insight
-for the import workload. If log IO is
-the dominant limit, scaling vCores may
-help only if the tier provides more
-log throughput at the new size. You
-should also check batch size,
-transaction scope, retry behavior, and
-whether the import should be scheduled
-or redesigned. Call in a DBA if
-transaction design, indexing, or query
-plans are part of the sustained
-problem.
+Start by confirming the pressure shape with Azure Monitor metrics and `sys.dm_db_resource_stats`, then look at waits and Query Performance Insight for the import workload. If log IO is the dominant limit, scaling vCores may help only if the tier provides more log throughput at the new size. You should also check batch size, transaction scope, retry behavior, and whether the import should be scheduled or redesigned. Call in a DBA if transaction design, indexing, or query plans are part of the sustained problem.
 
 </details>
 
 <details><summary>A vendor app requires SQL Agent jobs, linked-server behavior, and a certification matrix that names SQL Server on Windows. Which Azure SQL option is the safest starting point and why?</summary>
 
-SQL Server on Azure VM is the safest
-starting point when the vendor
-requires OS-level or full SQL Server
-control. Azure SQL Managed Instance
-may be worth evaluating if the vendor
-supports it and the feature set fits,
-but certification language matters in
-production. Azure SQL Database is
-likely the wrong first choice because
-it is database-scoped and does not
-provide a full SQL Server instance
-surface. The operator should document
-which features force IaaS so the
-decision is not dismissed as
-preference.
+SQL Server on Azure VM is the safest starting point when the vendor requires OS-level or full SQL Server control. Azure SQL Managed Instance may be worth evaluating if the vendor supports it and the feature set fits, but certification language matters in production. Azure SQL Database is likely the wrong first choice because it is database-scoped and does not provide a full SQL Server instance surface. The operator should document which features force IaaS so the decision is not dismissed as preference.
 
 </details>
 
 <details><summary>A failover group test succeeds, but the application cannot connect from the secondary region after failover. The database exists and the listener resolves. What is your next investigation path?</summary>
 
-Check the secondary-region network and
-identity path, not only database
-replication. Private endpoints,
-private DNS zone links, firewall
-rules, Entra admin, contained users,
-Key Vault access, and application
-configuration all need to work after
-failover. The listener can point to
-the new primary while the client
-subnet still resolves or routes
-incorrectly. A good failover test
-validates application writes, reads,
-secrets, audit, and monitoring, not
-just the Azure failover operation.
+Check the secondary-region network and identity path, not only database replication. Private endpoints, private DNS zone links, firewall rules, Entra admin, contained users, Key Vault access, and application configuration all need to work after failover. The listener can point to the new primary while the client subnet still resolves or routes incorrectly. A good failover test validates application writes, reads, secrets, audit, and monitoring, not just the Azure failover operation.
 
 </details>
 
 <details><summary>A development database is used a few hours per week and has no latency-sensitive users. The monthly bill is mostly idle compute. Which compute model do you evaluate first?</summary>
 
-Evaluate Serverless first because the
-workload is intermittent and can
-likely tolerate resume delay. Set a
-realistic minimum and maximum vCore
-range, test auto-pause and resume
-behavior, and compare billed active
-compute against provisioned compute.
-If background jobs keep the database
-active all month, Serverless may not
-save much. The operator should measure
-real idle periods rather than assuming
-the service will pause.
+Evaluate Serverless first because the workload is intermittent and can likely tolerate resume delay. Set a realistic minimum and maximum vCore range, test auto-pause and resume behavior, and compare billed active compute against provisioned compute. If background jobs keep the database active all month, Serverless may not save much. The operator should measure real idle periods rather than assuming the service will pause.
 
 </details>
 
 <details><summary>A security team asks you to enable Always Encrypted for customer identifiers by Friday. What is the operator response?</summary>
 
-Treat it as a joint application, DBA,
-and platform change rather than a
-simple portal toggle. The operator can
-prepare Key Vault access, managed
-identity, driver compatibility checks,
-and deployment permissions, but the
-application and DBA teams must
-validate query patterns, indexing,
-encryption type, and release safety.
-Always Encrypted changes how the
-application handles protected columns.
-Rushing it without a test plan can
-create an availability incident while
-trying to solve a confidentiality
-requirement.
+Treat it as a joint application, DBA, and platform change rather than a simple portal toggle. The operator can prepare Key Vault access, managed identity, driver compatibility checks, and deployment permissions, but the application and DBA teams must validate query patterns, indexing, encryption type, and release safety. Always Encrypted changes how the application handles protected columns. Rushing it without a test plan can create an availability incident while trying to solve a confidentiality requirement.
 
 </details>
 
 <details><summary>An executive asks why a 100 GB database costs much more after adding geo-replication. How do you explain it?</summary>
 
-Geo-replication creates a secondary
-database that consumes compute and
-storage, so it is not a free backup
-copy. The bill can roughly double
-major database lines depending on
-tier, region, replicas, backup
-redundancy, and configuration. Explain
-the cost in terms of primary compute,
-secondary compute, data storage,
-backup storage, and any monitoring or
-Defender charges. Then tie the added
-spend to the RPO and RTO that
-geo-replication or failover groups are
-meant to satisfy.
+Geo-replication creates a secondary database that consumes compute and storage, so it is not a free backup copy. The bill can roughly double major database lines depending on tier, region, replicas, backup redundancy, and configuration. Explain the cost in terms of primary compute, secondary compute, data storage, backup storage, and any monitoring or Defender charges. Then tie the added spend to the RPO and RTO that geo-replication or failover groups are meant to satisfy.
 
 </details>
 
 <details><summary>An alert shows high workers percentage and blocked connections, but CPU is not saturated. Should the operator immediately move to Business Critical?</summary>
 
-No, not immediately. High workers and
-blocked connections can come from
-blocking, long-running transactions,
-connection storms, poor pooling, or
-workload shape rather than storage
-architecture. The operator should
-inspect sessions, waits, Query
-Performance Insight, application
-connection behavior, and recent
-deployments. Business Critical may be
-appropriate later, but moving tiers
-before identifying blocking or worker
-exhaustion can increase cost without
-fixing the cause.
+No, not immediately. High workers and blocked connections can come from blocking, long-running transactions, connection storms, poor pooling, or workload shape rather than storage architecture. The operator should inspect sessions, waits, Query Performance Insight, application connection behavior, and recent deployments. Business Critical may be appropriate later, but moving tiers before identifying blocking or worker exhaustion can increase cost without fixing the cause.
 
 </details>
 
 ## Hands-On Exercise
 
-In this exercise you will create an
-Azure SQL Database, configure access,
-load data, generate pressure, observe
-metrics, scale compute, and perform
-point-in-time restore. The exercise is
-designed for a solo operator with an
-Azure subscription, Azure CLI,
-`sqlcmd`, and permission to create a
-resource group, SQL logical server,
-database, firewall rule, and optional
-private endpoint. Use a disposable
-subscription or lab resource group,
-because even short-lived databases can
-cost money. Delete the resource group
-at the end unless your instructor
-tells you to keep it for review.
+In this exercise you will create an Azure SQL Database, configure access, load data, generate pressure, observe metrics, scale compute, and perform point-in-time restore. The exercise is designed for a solo operator with an Azure subscription, Azure CLI, `sqlcmd`, and permission to create a resource group, SQL logical server, database, firewall rule, and optional private endpoint. Use a disposable subscription or lab resource group, because even short-lived databases can cost money. Delete the resource group at the end unless your instructor tells you to keep it for review.
 
 ### Setup assumptions
 
-Use East US in the examples so the
-commands are concrete. Change the
-region if your subscription policy
-requires another location. The private
-endpoint step is optional because not
-every learner has an existing VNet;
-the exercise still works with a narrow
-client IP firewall rule. For
-production, private endpoint plus
-correct DNS should replace workstation
-public access.
+Use East US in the examples so the commands are concrete. Change the region if your subscription policy requires another location. The private endpoint step is optional because not every learner has an existing VNet; the exercise still works with a narrow client IP firewall rule. For production, private endpoint plus correct DNS should replace workstation public access.
 
 ```bash
 az account show --query "{subscription:name, tenant:tenantId}" -o table
@@ -1507,17 +446,7 @@ sqlcmd -?
 
 ### Step 1: Create the resource group, logical server, and database
 
-This step creates the management
-boundary and a small provisioned vCore
-database. The server name must be
-globally unique under
-`database.windows.net`, so the command
-includes random shell values. Do not
-paste a real production password into
-the module or a ticket. Read it into
-an environment variable and let the
-shell keep it out of command history
-where possible.
+This step creates the management boundary and a small provisioned vCore database. The server name must be globally unique under `database.windows.net`, so the command includes random shell values. Do not paste a real production password into the module or a ticket. Read it into an environment variable and let the shell keep it out of command history where possible.
 
 ```bash
 export RG="rg-kubedojo-sql"
@@ -1558,34 +487,13 @@ az sql db create \
 
 <details><summary>Solution notes for Step 1</summary>
 
-Use `az sql db show --resource-group
-"$RG" --server "$SQL_SERVER" --name
-"$SQL_DB" -o table` to confirm the
-database. If server creation fails,
-check global name uniqueness, password
-complexity, and subscription policy.
-If database creation fails because the
-selected region or family is
-unavailable, choose an allowed region
-or use the portal to identify
-available Azure SQL Database options.
-Do not continue until the database
-reaches Online state.
+Use `az sql db show --resource-group "$RG" --server "$SQL_SERVER" --name "$SQL_DB" -o table` to confirm the database. If server creation fails, check global name uniqueness, password complexity, and subscription policy. If database creation fails because the selected region or family is unavailable, choose an allowed region or use the portal to identify available Azure SQL Database options. Do not continue until the database reaches Online state.
 
 </details>
 
 ### Step 2: Configure access with a narrow firewall rule and optional private endpoint
 
-The fastest solo path is to allow your
-current public client IP. That is
-acceptable for a lab and poor as a
-permanent production pattern. The
-optional private endpoint commands
-show the production direction when you
-already have a VNet and subnet.
-Private endpoint DNS must resolve the
-SQL server FQDN to the private address
-from the calling network.
+The fastest solo path is to allow your current public client IP. That is acceptable for a lab and poor as a permanent production pattern. The optional private endpoint commands show the production direction when you already have a VNet and subnet. Private endpoint DNS must resolve the SQL server FQDN to the private address from the calling network.
 
 ```bash
 CLIENT_IP="$(curl -fsS https://api.ipify.org)"
@@ -1598,9 +506,7 @@ az sql server firewall-rule create \
   --end-ip-address "$CLIENT_IP"
 ```
 
-Optional private endpoint path, only
-if you have a VNet and a dedicated
-subnet available:
+Optional private endpoint path, only if you have a VNet and a dedicated subnet available:
 
 ```bash
 export VNET_RG="rg-existing-network"
@@ -1650,35 +556,13 @@ az network private-endpoint dns-zone-group create \
 
 <details><summary>Solution notes for Step 2</summary>
 
-Use `az sql server firewall-rule list
---resource-group "$RG" --server
-"$SQL_SERVER" -o table` to confirm the
-rule. For private endpoints, test DNS
-from a VM or runner inside the VNet
-with `nslookup
-"$SQL_SERVER.database.windows.net"`.
-If DNS still returns public addresses
-from the private network, fix the
-private DNS zone link before blaming
-SQL authentication. If you are working
-only from your laptop, continue with
-the narrow firewall rule.
+Use `az sql server firewall-rule list --resource-group "$RG" --server "$SQL_SERVER" -o table` to confirm the rule. For private endpoints, test DNS from a VM or runner inside the VNet with `nslookup "$SQL_SERVER.database.windows.net"`. If DNS still returns public addresses from the private network, fix the private DNS zone link before blaming SQL authentication. If you are working only from your laptop, continue with the narrow firewall rule.
 
 </details>
 
 ### Step 3: Connect with sqlcmd and load a small schema
 
-This step verifies that data-plane
-authentication and network access
-work. It also creates enough data to
-make metrics and query views
-interesting. The insert uses a
-recursive CTE pattern to generate rows
-without needing an external data file.
-If `sqlcmd` cannot connect, fix that
-before loading data because the rest
-of the exercise depends on a stable
-connection path.
+This step verifies that data-plane authentication and network access work. It also creates enough data to make metrics and query views interesting. The insert uses a recursive CTE pattern to generate rows without needing an external data file. If `sqlcmd` cannot connect, fix that before loading data because the rest of the exercise depends on a stable connection path.
 
 ```bash
 sqlcmd \
@@ -1739,32 +623,13 @@ sqlcmd \
 
 <details><summary>Solution notes for Step 3</summary>
 
-If `sqlcmd` reports a login failure,
-confirm the admin user, password, and
-database name. If it reports a network
-error, check the firewall rule,
-private endpoint DNS, and whether your
-current public IP changed. If the
-insert fails because an object already
-exists, rerun the script because it
-drops and recreates the lab table. If
-the row count is lower than expected,
-check whether the script was
-interrupted.
+If `sqlcmd` reports a login failure, confirm the admin user, password, and database name. If it reports a network error, check the firewall rule, private endpoint DNS, and whether your current public IP changed. If the insert fails because an object already exists, rerun the script because it drops and recreates the lab table. If the row count is lower than expected, check whether the script was interrupted.
 
 </details>
 
 ### Step 4: Trigger load and watch database metrics
 
-The load script is intentionally
-blunt. It updates rows and runs
-aggregate reads in a loop so you can
-watch CPU, data IO, log IO, workers,
-and sessions move. The goal is not to
-benchmark Azure SQL Database. The goal
-is to connect workload behavior to
-Azure Monitor metrics and identify
-which limit appears first.
+The load script is intentionally blunt. It updates rows and runs aggregate reads in a loop so you can watch CPU, data IO, log IO, workers, and sessions move. The goal is not to benchmark Azure SQL Database. The goal is to connect workload behavior to Azure Monitor metrics and identify which limit appears first.
 
 ```bash
 cat > load-operator-events.sql <<'SQL'
@@ -1801,17 +666,7 @@ done
 wait
 ```
 
-Open the database in the Azure portal
-while the load runs. Go to Monitoring,
-Metrics, and chart CPU percentage,
-Data IO percentage, Log IO percentage,
-Workers percentage, Sessions
-percentage, and successful or failed
-connections. If the load completes too
-quickly, rerun it or increase the loop
-count modestly. If you see timeouts,
-keep the logs because they are part of
-the learning goal.
+Open the database in the Azure portal while the load runs. Go to Monitoring, Metrics, and chart CPU percentage, Data IO percentage, Log IO percentage, Workers percentage, Sessions percentage, and successful or failed connections. If the load completes too quickly, rerun it or increase the loop count modestly. If you see timeouts, keep the logs because they are part of the learning goal.
 
 - [ ] You generated concurrent SQL activity.
 - [ ] You observed at least CPU, data IO, and log IO metrics.
@@ -1820,33 +675,13 @@ the learning goal.
 
 <details><summary>Solution notes for Step 4</summary>
 
-Azure Monitor metrics may lag by a few
-minutes, and Query Performance Insight
-may need Query Store history before
-useful charts appear. If no metric
-changes, confirm that the load workers
-actually ran and inspect
-`load-worker-1.log`. If the database
-throttles, the visible symptom may be
-slower completion rather than a clean
-error. The important output is your
-observation of which metric saturates
-first.
+Azure Monitor metrics may lag by a few minutes, and Query Performance Insight may need Query Store history before useful charts appear. If no metric changes, confirm that the load workers actually ran and inspect `load-worker-1.log`. If the database throttles, the visible symptom may be slower completion rather than a clean error. The important output is your observation of which metric saturates first.
 
 </details>
 
 ### Step 5: Scale the database compute and compare signals
 
-Scaling is an operator action, not a
-permanent conclusion. You are testing
-whether more provisioned compute
-changes the observed pressure. In
-production, you would pair this with
-cost approval, a rollback plan, and a
-follow-up review of whether the
-workload should be tuned instead. For
-the lab, scale from 2 vCores to 4
-vCores and rerun the load.
+Scaling is an operator action, not a permanent conclusion. You are testing whether more provisioned compute changes the observed pressure. In production, you would pair this with cost approval, a rollback plan, and a follow-up review of whether the workload should be tuned instead. For the lab, scale from 2 vCores to 4 vCores and rerun the load.
 
 ```bash
 az sql db update \
@@ -1863,15 +698,7 @@ az sql db show \
   -o table
 ```
 
-Rerun the load after the update
-completes. Compare CPU, data IO, log
-IO, duration, and any timeout behavior
-against the first run. If the dominant
-bottleneck moved, write that down. If
-nothing improved, the bottleneck may
-be query shape, locking, log design,
-or another tier limit rather than raw
-compute.
+Rerun the load after the update completes. Compare CPU, data IO, log IO, duration, and any timeout behavior against the first run. If the dominant bottleneck moved, write that down. If nothing improved, the bottleneck may be query shape, locking, log design, or another tier limit rather than raw compute.
 
 - [ ] Database scale operation completed.
 - [ ] The database reports the larger service objective.
@@ -1880,35 +707,13 @@ compute.
 
 <details><summary>Solution notes for Step 5</summary>
 
-Some scale operations briefly
-disconnect sessions, so production
-applications need retry logic. If the
-update is blocked by subscription
-policy or regional limits, use the
-portal to select the next available
-size. If metrics improve, do not stop
-thinking; ask whether the new size is
-the right steady-state cost. If
-metrics do not improve, bring the top
-queries and waits to a DBA instead of
-repeatedly increasing size.
+Some scale operations briefly disconnect sessions, so production applications need retry logic. If the update is blocked by subscription policy or regional limits, use the portal to select the next available size. If metrics improve, do not stop thinking; ask whether the new size is the right steady-state cost. If metrics do not improve, bring the top queries and waits to a DBA instead of repeatedly increasing size.
 
 </details>
 
 ### Step 6: Perform point-in-time restore to a new database
 
-Point-in-time restore should create a
-new database, not overwrite the
-original during a live incident. This
-step restores the database to a
-timestamp five minutes in the past.
-The restore time must be inside the
-available PITR window, and very new
-databases may need a little time
-before an earlier restore point is
-available. If the restore time fails,
-wait several minutes and retry with a
-slightly later timestamp.
+Point-in-time restore should create a new database, not overwrite the original during a live incident. This step restores the database to a timestamp five minutes in the past. The restore time must be inside the available PITR window, and very new databases may need a little time before an earlier restore point is available. If the restore time fails, wait several minutes and retry with a slightly later timestamp.
 
 ```bash
 export SQL_DB_RESTORED="${SQL_DB}-restore"
@@ -1936,15 +741,7 @@ az sql db list \
   -o table
 ```
 
-Verify the restored database through
-`sqlcmd`. Use the restored database
-name and check that the table exists.
-The row count may differ depending on
-the restore timestamp and load timing.
-That difference is the point: PITR
-gives you a database at a prior point
-so you can compare, repair, or
-redirect safely.
+Verify the restored database through `sqlcmd`. Use the restored database name and check that the table exists. The row count may differ depending on the restore timestamp and load timing. That difference is the point: PITR gives you a database at a prior point so you can compare, repair, or redirect safely.
 
 ```bash
 sqlcmd \
@@ -1964,34 +761,13 @@ sqlcmd \
 
 <details><summary>Solution notes for Step 6</summary>
 
-If the restore fails because the
-timestamp is too early, wait until
-backups catch up and choose a later
-timestamp. If the restored database
-cannot be queried, confirm firewall
-and login access on the same logical
-server. If the restored database
-exists but lacks expected rows,
-compare the restore timestamp with
-when the seed and load scripts ran. In
-production, this restored copy becomes
-the safe analysis target for data
-repair.
+If the restore fails because the timestamp is too early, wait until backups catch up and choose a later timestamp. If the restored database cannot be queried, confirm firewall and login access on the same logical server. If the restored database exists but lacks expected rows, compare the restore timestamp with when the seed and load scripts ran. In production, this restored copy becomes the safe analysis target for data repair.
 
 </details>
 
 ### Cleanup
 
-Delete the resource group when you are
-done. This removes the logical server,
-databases, firewall rule, and lab
-artifacts in that resource group. If
-you created a private endpoint in a
-shared network resource group, remove
-that private endpoint and DNS zone
-group separately if your organization
-does not want to keep it. Do not leave
-scaled-up lab databases running.
+Delete the resource group when you are done. This removes the logical server, databases, firewall rule, and lab artifacts in that resource group. If you created a private endpoint in a shared network resource group, remove that private endpoint and DNS zone group separately if your organization does not want to keep it. Do not leave scaled-up lab databases running.
 
 ```bash
 az group delete \
@@ -2034,10 +810,4 @@ az group delete \
 
 ## Next Module
 
-Return to the [Azure Essentials
-index](../) until the next ordered
-module is assigned; the next
-operator-path topic should continue
-from managed data services into
-production integration and data
-movement.
+Continue to [Backup & Site Recovery](../module-3.17-backup-site-recovery/) to make the data and workloads you have deployed resilient to failure.

--- a/src/content/docs/cloud/azure-essentials/module-3.17-backup-site-recovery.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.17-backup-site-recovery.md
@@ -16,8 +16,7 @@ sidebar:
 
 ## What You'll Be Able to Do
 
-After completing this module, you will
-be able to:
+After completing this module, you will be able to:
 
 - **Compare** Azure Backup and Azure Site Recovery by recovery contract, RPO, RTO, workload scope, control plane, and failure mode.
 - **Design** a vault, policy, retention, immutability, encryption, and network-access model for production Azure backup operations.
@@ -27,149 +26,23 @@ be able to:
 
 ## Why This Module Matters
 
-Hypothetical scenario: a platform team
-receives two incident messages in the
-same hour. First, an application owner
-reports that a release script dropped
-the wrong table and the latest healthy
-copy of the data was from last night.
-Second, a regional service-health
-event begins affecting the primary
-Azure region that hosts a
-revenue-critical VM tier. The first
-incident needs a point-in-time restore
-of one workload. The second needs a
-secondary environment that can be
-started in another region. Both
-incidents are business-continuity
-incidents, but they are not the same
-operational contract.
+Hypothetical scenario: a platform team receives two incident messages in the same hour. First, an application owner reports that a release script dropped the wrong table and the latest healthy copy of the data was from last night. Second, a regional service-health event begins affecting the primary Azure region that hosts a revenue-critical VM tier. The first incident needs a point-in-time restore of one workload. The second needs a secondary environment that can be started in another region. Both incidents are business-continuity incidents, but they are not the same operational contract.
 
-Teams get into trouble when they use
-one recovery word for every failure.
-Backup is a restore contract: choose a
-recovery point, restore one workload
-or one dataset, and accept that the
-recovery time includes finding the
-point, provisioning restore resources,
-validating the result, and switching
-the application back. Disaster
-recovery is an availability contract:
-keep enough secondary state ready that
-a primary-site outage can be handled
-by failover rather than by rebuilding
-production from yesterday's copy.
-Microsoft describes Azure Backup as a
-service for protecting and recovering
-data, while Azure Site Recovery
-replicates machines to a secondary
-location and orchestrates failover and
-failback during outages [Azure Backup
-overview](https://learn.microsoft.com/en-us/azure/backup/backup-overview),
-[Site Recovery
-overview](https://learn.microsoft.com/en-us/azure/site-recovery/site-recovery-overview).
+Teams get into trouble when they use one recovery word for every failure. Backup is a restore contract: choose a recovery point, restore one workload or one dataset, and accept that the recovery time includes finding the point, provisioning restore resources, validating the result, and switching the application back. Disaster recovery is an availability contract: keep enough secondary state ready that a primary-site outage can be handled by failover rather than by rebuilding production from yesterday's copy. Microsoft describes Azure Backup as a service for protecting and recovering data, while Azure Site Recovery replicates machines to a secondary location and orchestrates failover and failback during outages [Azure Backup overview](https://learn.microsoft.com/en-us/azure/backup/backup-overview), [Site Recovery overview](https://learn.microsoft.com/en-us/azure/site-recovery/site-recovery-overview).
 
-This module is written for platform,
-SRE, and infrastructure engineers who
-own the recovery surface but are not
-backup-vendor specialists. You will
-learn how the two Azure services fit
-together, where they stop, how vaults
-and policies shape recovery, how
-identity and network controls change
-restore operations, how cost grows,
-and how to test the design before the
-incident. The goal is not to memorize
-every portal blade. The goal is to
-build the operator mental model that
-makes the first decision during a bad
-day defensible.
+This module is written for platform, SRE, and infrastructure engineers who own the recovery surface but are not backup-vendor specialists. You will learn how the two Azure services fit together, where they stop, how vaults and policies shape recovery, how identity and network controls change restore operations, how cost grows, and how to test the design before the incident. The goal is not to memorize every portal blade. The goal is to build the operator mental model that makes the first decision during a bad day defensible.
 
 ## 1. Backup and Disaster Recovery Are Different Contracts
 
-Backup answers a narrow question: can
-I return a protected workload to a
-specific recovery point? The workload
-might be an Azure VM, an Azure file
-share, SQL Server inside an Azure VM,
-SAP HANA inside an Azure VM, a managed
-disk, a Blob storage account, or a
-PostgreSQL database that needs
-long-term retention. The RPO is
-bounded by how often usable recovery
-points are created, and the RTO is
-bounded by how long restore,
-validation, and cutover take. A daily
-VM backup can be excellent for
-accidental deletion, but it is not a
-promise that production will be online
-in a second region within minutes.
+Backup answers a narrow question: can I return a protected workload to a specific recovery point? The workload might be an Azure VM, an Azure file share, SQL Server inside an Azure VM, SAP HANA inside an Azure VM, a managed disk, a Blob storage account, or a PostgreSQL database that needs long-term retention. The RPO is bounded by how often usable recovery points are created, and the RTO is bounded by how long restore, validation, and cutover take. A daily VM backup can be excellent for accidental deletion, but it is not a promise that production will be online in a second region within minutes.
 
-Disaster recovery answers a broader
-question: can I operate a secondary
-environment when the primary
-environment is unavailable? For
-Azure-to-Azure VM recovery, Site
-Recovery continuously replicates VM
-disk writes through a cache path,
-builds recovery points in a target
-region, and creates VMs from those
-recovery points during failover
-[Azure-to-Azure
-architecture](https://learn.microsoft.com/en-us/azure/site-recovery/azure-to-azure-architecture).
-The RPO is the replication lag and the
-latest recoverable point, while the
-RTO is the orchestration time to start
-the failed-over workload and reconnect
-dependencies.
+Disaster recovery answers a broader question: can I operate a secondary environment when the primary environment is unavailable? For Azure-to-Azure VM recovery, Site Recovery continuously replicates VM disk writes through a cache path, builds recovery points in a target region, and creates VMs from those recovery points during failover [Azure-to-Azure architecture](https://learn.microsoft.com/en-us/azure/site-recovery/azure-to-azure-architecture). The RPO is the replication lag and the latest recoverable point, while the RTO is the orchestration time to start the failed-over workload and reconnect dependencies.
 
-The difference matters most when the
-failure is logical. A ransomware
-process that encrypts files, a bad
-migration that corrupts records, and a
-privileged operator who deletes a
-resource are not solved by replicating
-the corruption quickly to another
-region. DR gives you a second place to
-run. Backup gives you a previous point
-to inspect and restore. A mature
-production design usually needs both
-because logical loss and regional loss
-are different failure families.
+The difference matters most when the failure is logical. A ransomware process that encrypts files, a bad migration that corrupts records, and a privileged operator who deletes a resource are not solved by replicating the corruption quickly to another region. DR gives you a second place to run. Backup gives you a previous point to inspect and restore. A mature production design usually needs both because logical loss and regional loss are different failure families.
 
-The inverse mistake is also common. A
-team may say that immutable backups
-cover regional DR because the data is
-safe. That may be true for evidence,
-compliance, and rebuilds, but users
-are still offline until the
-application stack is recreated,
-networks are connected, DNS or traffic
-routing is switched, identities are
-validated, secrets are present, and
-downstream systems accept the restored
-service. A restore-only plan can be
-acceptable for a lower-priority
-workload, but it is not the same as a
-failover plan.
+The inverse mistake is also common. A team may say that immutable backups cover regional DR because the data is safe. That may be true for evidence, compliance, and rebuilds, but users are still offline until the application stack is recreated, networks are connected, DNS or traffic routing is switched, identities are validated, secrets are present, and downstream systems accept the restored service. A restore-only plan can be acceptable for a lower-priority workload, but it is not the same as a failover plan.
 
-The most dangerous misconception is
-"geo-redundant storage means I have a
-backup." Geo-redundant storage is a
-storage replication choice. It can
-protect against some storage-platform
-durability failures, and some Azure
-Backup vault modes use it to place
-backup data in a paired region, but it
-does not by itself define backup
-policy, retention, restore workflow,
-immutability, access control, or
-workload-consistent recovery.
-Microsoft separates storage
-redundancy, backup services, and Site
-Recovery for a reason; operators
-should keep those layers separate when
-they write recovery objectives.
+The most dangerous misconception is "geo-redundant storage means I have a backup." Geo-redundant storage is a storage replication choice. It can protect against some storage-platform durability failures, and some Azure Backup vault modes use it to place backup data in a paired region, but it does not by itself define backup policy, retention, restore workflow, immutability, access control, or workload-consistent recovery. Microsoft separates storage redundancy, backup services, and Site Recovery for a reason; operators should keep those layers separate when they write recovery objectives.
 
 ```text
 +------------------+-------------------------------+------------------------------+
@@ -183,115 +56,23 @@ they write recovery objectives.
 +------------------+-------------------------------+------------------------------+
 ```
 
-Worked example: a VM hosts a small
-order-processing worker. The VM has a
-daily backup at midnight with seven
-days of retention. At 15:00, an
-operator deletes a configuration
-directory and the service fails. The
-backup RPO is roughly the time between
-midnight and the delete, and the RTO
-includes restore, validation, and
-application repair. If the same VM is
-protected by Site Recovery with
-healthy replication, a regional outage
-might be handled by failover, but
-failover is not the clean fix for the
-deleted directory if the deletion has
-already replicated.
+Worked example: a VM hosts a small order-processing worker. The VM has a daily backup at midnight with seven days of retention. At 15:00, an operator deletes a configuration directory and the service fails. The backup RPO is roughly the time between midnight and the delete, and the RTO includes restore, validation, and application repair. If the same VM is protected by Site Recovery with healthy replication, a regional outage might be handled by failover, but failover is not the clean fix for the deleted directory if the deletion has already replicated.
 
 > **Pause and predict:** if a team protects every VM with Site Recovery but disables backup to save money, what happens when a corrupt application release runs successfully for an hour before anyone notices? Which recovery point family is missing?
 
-Now you solve it: a production VM uses
-GRS managed disks, but no Azure Backup
-policy and no Site Recovery
-replication. The application owner
-asks whether that satisfies "one
-off-region copy." Your answer should
-separate disk durability, backup
-retention, and failover readiness
-instead of treating them as one
-checkbox.
+Now you solve it: a production VM uses GRS managed disks, but no Azure Backup policy and no Site Recovery replication. The application owner asks whether that satisfies "one off-region copy." Your answer should separate disk durability, backup retention, and failover readiness instead of treating them as one checkbox.
 
-The operator language should be
-precise. Use "backup" when you mean
-recovery points, retention, restore,
-soft delete, immutability, and restore
-validation. Use "DR" when you mean
-secondary region, replicated state,
-failover runbook, re-protection,
-failback, and traffic switch. Use
-"availability zone" when you mean
-intra-region fault isolation. Use
-"active-active" when both regions are
-already serving traffic and conflict
-handling is part of the application
-design.
+The operator language should be precise. Use "backup" when you mean recovery points, retention, restore, soft delete, immutability, and restore validation. Use "DR" when you mean secondary region, replicated state, failover runbook, re-protection, failback, and traffic switch. Use "availability zone" when you mean intra-region fault isolation. Use "active-active" when both regions are already serving traffic and conflict handling is part of the application design.
 
-One simple rule helps during design
-reviews: a recovery objective is not
-real until the operator can name the
-service, the recovery point, the
-identity allowed to execute it, the
-network path used during restore, the
-cost owner, and the test evidence. If
-any one of those is missing, the plan
-is still an intention rather than an
-operational capability.
+One simple rule helps during design reviews: a recovery objective is not real until the operator can name the service, the recovery point, the identity allowed to execute it, the network path used during restore, the cost owner, and the test evidence. If any one of those is missing, the plan is still an intention rather than an operational capability.
 
 ## 2. Azure Backup Deep Dive
 
-Azure Backup is not one implementation
-behind one vault. The control plane is
-split between Recovery Services vaults
-and Backup vaults, and the right vault
-depends on the datasource. Recovery
-Services vaults are the long-standing
-vault type for Azure VM backup, SQL
-Server in Azure VM, SAP HANA in Azure
-VM, Azure Files, and on-premises
-backup agents. Backup vaults are the
-newer Azure Resource Manager model for
-newer datasources such as Azure Blob
-backup, Azure Disk backup, Azure
-Database for PostgreSQL long-term
-retention, and other data-protection
-workloads [Backup support
-matrix](https://learn.microsoft.com/en-us/azure/backup/backup-support-matrix),
-[Backup vault
-overview](https://learn.microsoft.com/en-us/azure/backup/backup-vault-overview).
+Azure Backup is not one implementation behind one vault. The control plane is split between Recovery Services vaults and Backup vaults, and the right vault depends on the datasource. Recovery Services vaults are the long-standing vault type for Azure VM backup, SQL Server in Azure VM, SAP HANA in Azure VM, Azure Files, and on-premises backup agents. Backup vaults are the newer Azure Resource Manager model for newer datasources such as Azure Blob backup, Azure Disk backup, Azure Database for PostgreSQL long-term retention, and other data-protection workloads [Backup support matrix](https://learn.microsoft.com/en-us/azure/backup/backup-support-matrix), [Backup vault overview](https://learn.microsoft.com/en-us/azure/backup/backup-vault-overview).
 
-This split is the first day-two
-operations trap. A Recovery Services
-vault and a Backup vault can sit in
-the same resource group, have similar
-names, and both appear in backup
-management views, but they do not
-protect the same workload families. If
-your ticket says "put the VM into the
-Backup vault," the ticket is probably
-using the generic noun rather than the
-Azure resource type. Azure VM backup
-still uses a Recovery Services vault,
-while Azure Disk backup uses a Backup
-vault. An operator should correct the
-language before building automation.
+This split is the first day-two operations trap. A Recovery Services vault and a Backup vault can sit in the same resource group, have similar names, and both appear in backup management views, but they do not protect the same workload families. If your ticket says "put the VM into the Backup vault," the ticket is probably using the generic noun rather than the Azure resource type. Azure VM backup still uses a Recovery Services vault, while Azure Disk backup uses a Backup vault. An operator should correct the language before building automation.
 
-Backup policy is the second trap. A
-policy is not only a schedule. It is
-the binding between backup frequency,
-retention duration, and recovery-point
-lifecycle. For a VM, a simple policy
-might take one daily recovery point
-and retain it for a week. A production
-policy often uses a GFS pattern: daily
-short-term points for operational
-mistakes, weekly points for recent
-rollback, monthly points for audit,
-and yearly points for long compliance
-windows. Those longer tiers are
-useful, but they are also where
-storage cost grows quietly.
+Backup policy is the second trap. A policy is not only a schedule. It is the binding between backup frequency, retention duration, and recovery-point lifecycle. For a VM, a simple policy might take one daily recovery point and retain it for a week. A production policy often uses a GFS pattern: daily short-term points for operational mistakes, weekly points for recent rollback, monthly points for audit, and yearly points for long compliance windows. Those longer tiers are useful, but they are also where storage cost grows quietly.
 
 ```text
 +-------------------------+----------------------------------------------+
@@ -306,274 +87,39 @@ storage cost grows quietly.
 +-------------------------+----------------------------------------------+
 ```
 
-Azure VM backup uses a VM backup
-extension or an agentless
-crash-consistent path depending on
-policy and workload choices. Windows
-VMs can coordinate with VSS for
-application-consistent snapshots,
-while Linux VMs can provide
-file-system consistency when the guest
-can quiesce appropriately. Microsoft
-documents that VM backup creates
-snapshots and transfers backup data to
-the vault, with consistency behavior
-depending on the policy and guest
-support [Azure VM backup
-overview](https://learn.microsoft.com/en-us/azure/backup/backup-azure-vms-introduction).
-The operator consequence is simple: a
-VM recovery point is only as useful as
-the consistency level and the
-application validation behind it.
+Azure VM backup uses a VM backup extension or an agentless crash-consistent path depending on policy and workload choices. Windows VMs can coordinate with VSS for application-consistent snapshots, while Linux VMs can provide file-system consistency when the guest can quiesce appropriately. Microsoft documents that VM backup creates snapshots and transfers backup data to the vault, with consistency behavior depending on the policy and guest support [Azure VM backup overview](https://learn.microsoft.com/en-us/azure/backup/backup-azure-vms-introduction). The operator consequence is simple: a VM recovery point is only as useful as the consistency level and the application validation behind it.
 
-Azure Files backup uses share
-snapshots and can protect file shares
-from accidental deletion and
-corruption. It is attractive because
-it is close to the storage service,
-but it has a different restore shape
-than a VM or database. Restoring a
-share, item, or prior snapshot may be
-enough for a file-service mistake,
-while an application using the share
-may still require coordinated downtime
-or application-level validation.
-Microsoft documents Azure Files backup
-as a managed protection path for Azure
-file shares [Azure Files backup
-overview](https://learn.microsoft.com/en-us/azure/backup/azure-file-share-backup-overview).
+Azure Files backup uses share snapshots and can protect file shares from accidental deletion and corruption. It is attractive because it is close to the storage service, but it has a different restore shape than a VM or database. Restoring a share, item, or prior snapshot may be enough for a file-service mistake, while an application using the share may still require coordinated downtime or application-level validation. Microsoft documents Azure Files backup as a managed protection path for Azure file shares [Azure Files backup overview](https://learn.microsoft.com/en-us/azure/backup/azure-file-share-backup-overview).
 
-SQL Server in Azure VM backup is not
-the same as backing up the VM disk.
-Azure Backup offers a stream-based
-workload-aware solution for SQL Server
-running in Azure VMs, with full,
-differential, and log backup support,
-database-level restore, and a much
-tighter RPO than a once-daily VM
-snapshot [SQL Server in Azure VM
-backup](https://learn.microsoft.com/en-us/azure/backup/backup-azure-sql-database).
-Operators should use the SQL workload
-backup when database point-in-time
-recovery matters and use VM backup for
-the OS and non-database disks. Doing
-only one of those may leave either the
-application state or the machine state
-under-protected.
+SQL Server in Azure VM backup is not the same as backing up the VM disk. Azure Backup offers a stream-based workload-aware solution for SQL Server running in Azure VMs, with full, differential, and log backup support, database-level restore, and a much tighter RPO than a once-daily VM snapshot [SQL Server in Azure VM backup](https://learn.microsoft.com/en-us/azure/backup/backup-azure-sql-database). Operators should use the SQL workload backup when database point-in-time recovery matters and use VM backup for the OS and non-database disks. Doing only one of those may leave either the application state or the machine state under-protected.
 
-SAP HANA in Azure VM has the same
-principle but a different engine
-contract. Azure Backup integrates with
-SAP HANA using a Backint-certified
-path and supports database-level
-backup and restore for HANA workloads
-[SAP HANA backup
-overview](https://learn.microsoft.com/en-us/azure/backup/sap-hana-database-about).
-The operator should not assume that a
-VM-level crash-consistent backup is a
-sufficient database recovery plan for
-an SAP HANA production system. The
-database service, application team,
-and platform team should agree on both
-database-level backup and VM-level
-recovery boundaries.
+SAP HANA in Azure VM has the same principle but a different engine contract. Azure Backup integrates with SAP HANA using a Backint-certified path and supports database-level backup and restore for HANA workloads [SAP HANA backup overview](https://learn.microsoft.com/en-us/azure/backup/sap-hana-database-about). The operator should not assume that a VM-level crash-consistent backup is a sufficient database recovery plan for an SAP HANA production system. The database service, application team, and platform team should agree on both database-level backup and VM-level recovery boundaries.
 
-Azure Disk backup is snapshot based
-and uses a Backup vault rather than a
-Recovery Services vault. It is useful
-when a managed disk needs frequent
-crash-consistent recovery points, when
-an agent is not acceptable, or when
-the cost of full VM backup is not
-justified for a disk-specific use
-case. Microsoft documents Azure Disk
-backup as an agentless incremental
-snapshot solution where snapshots
-remain in the tenant and do not incur
-a protected-instance fee for the
-Backup vault storage tier [Azure Disk
-backup
-overview](https://learn.microsoft.com/en-us/azure/backup/disk-backup-overview).
-That makes it operationally different
-from vaulted VM backup.
+Azure Disk backup is snapshot based and uses a Backup vault rather than a Recovery Services vault. It is useful when a managed disk needs frequent crash-consistent recovery points, when an agent is not acceptable, or when the cost of full VM backup is not justified for a disk-specific use case. Microsoft documents Azure Disk backup as an agentless incremental snapshot solution where snapshots remain in the tenant and do not incur a protected-instance fee for the Backup vault storage tier [Azure Disk backup overview](https://learn.microsoft.com/en-us/azure/backup/disk-backup-overview). That makes it operationally different from vaulted VM backup.
 
-Blob backup has two shapes:
-operational backup and vaulted backup.
-Operational backup is local to the
-storage account and uses Blob service
-capabilities such as point-in-time
-restore, versioning, change feed, and
-soft delete. Vaulted backup copies
-backup data into a Backup vault
-according to a policy and is the
-better fit when the source account or
-subscription compromise is part of the
-threat model [Blob backup
-overview](https://learn.microsoft.com/en-us/azure/backup/blob-backup-overview).
-Operators should ask whether the
-backup must survive loss or compromise
-of the source storage account.
+Blob backup has two shapes: operational backup and vaulted backup. Operational backup is local to the storage account and uses Blob service capabilities such as point-in-time restore, versioning, change feed, and soft delete. Vaulted backup copies backup data into a Backup vault according to a policy and is the better fit when the source account or subscription compromise is part of the threat model [Blob backup overview](https://learn.microsoft.com/en-us/azure/backup/blob-backup-overview). Operators should ask whether the backup must survive loss or compromise of the source storage account.
 
-Azure Database for PostgreSQL has
-native automated backups for
-operational PITR and an Azure Backup
-long-term retention option for
-compliance-oriented logical backups.
-Microsoft documents native retention
-up to thirty-five days and long-term
-retention through Azure Backup for up
-to ten years [PostgreSQL backup and
-restore](https://learn.microsoft.com/en-us/azure/postgresql/backup-restore/concepts-backup-restore).
-The platform choice is not "does
-PostgreSQL have backup?" It is whether
-the needed recovery is recent
-operational PITR, database-level
-logical restore, audit retention, or
-off-domain isolation.
+Azure Database for PostgreSQL has native automated backups for operational PITR and an Azure Backup long-term retention option for compliance-oriented logical backups. Microsoft documents native retention up to thirty-five days and long-term retention through Azure Backup for up to ten years [PostgreSQL backup and restore](https://learn.microsoft.com/en-us/azure/postgresql/backup-restore/concepts-backup-restore). The platform choice is not "does PostgreSQL have backup?" It is whether the needed recovery is recent operational PITR, database-level logical restore, audit retention, or off-domain isolation.
 
-Soft delete and immutability are the
-security boundary that many teams add
-too late. Soft delete keeps deleted
-backup items or recovery points
-recoverable during a configured
-retention window, with a default
-period of fourteen days and options to
-extend the window for stronger
-protection [Azure Backup soft
-delete](https://learn.microsoft.com/en-us/azure/backup/quick-backup-azure-enable-enhanced-soft-delete).
-Immutable vault settings can block
-destructive operations against
-protected backup data and can be
-locked for WORM behavior [Immutable
-vault
-concept](https://learn.microsoft.com/en-us/azure/backup/backup-azure-immutable-vault-concept).
-These controls do not make restore
-automatic, but they buy time when
-credentials are stolen or an operator
-makes a destructive mistake.
+Soft delete and immutability are the security boundary that many teams add too late. Soft delete keeps deleted backup items or recovery points recoverable during a configured retention window, with a default period of fourteen days and options to extend the window for stronger protection [Azure Backup soft delete](https://learn.microsoft.com/en-us/azure/backup/quick-backup-azure-enable-enhanced-soft-delete). Immutable vault settings can block destructive operations against protected backup data and can be locked for WORM behavior [Immutable vault concept](https://learn.microsoft.com/en-us/azure/backup/backup-azure-immutable-vault-concept). These controls do not make restore automatic, but they buy time when credentials are stolen or an operator makes a destructive mistake.
 
-Encryption is built into the backup
-platform, but the key-management
-choice still matters. Azure Backup
-encrypts backed-up data at rest and
-transfers backup data over HTTPS on
-the Azure backbone [Backup
-encryption](https://learn.microsoft.com/en-us/azure/backup/backup-encryption).
-Recovery Services vaults use
-platform-managed keys by default and
-can use customer-managed keys when
-configured before protection begins.
-Backup vaults also support
-Microsoft-managed and customer-managed
-key options, with the Backup
-Management Service app involved in Key
-Vault access for the Backup vault
-model [Backup vault
-overview](https://learn.microsoft.com/en-us/azure/backup/backup-vault-overview).
+Encryption is built into the backup platform, but the key-management choice still matters. Azure Backup encrypts backed-up data at rest and transfers backup data over HTTPS on the Azure backbone [Backup encryption](https://learn.microsoft.com/en-us/azure/backup/backup-encryption). Recovery Services vaults use platform-managed keys by default and can use customer-managed keys when configured before protection begins. Backup vaults also support Microsoft-managed and customer-managed key options, with the Backup Management Service app involved in Key Vault access for the Backup vault model [Backup vault overview](https://learn.microsoft.com/en-us/azure/backup/backup-vault-overview).
 
-The key rotation story is subtle.
-Rotating a key version is normal when
-the vault is configured for
-customer-managed keys and the Key
-Vault permissions remain correct.
-Disabling a key, purging a key, moving
-a Key Vault without updating
-dependencies, or removing the vault's
-access can turn a restore path into an
-incident. Operators should document
-key ownership and recovery procedures
-with the same seriousness as backup
-policy because a recovery point that
-cannot be decrypted is only a billing
-artifact.
+The key rotation story is subtle. Rotating a key version is normal when the vault is configured for customer-managed keys and the Key Vault permissions remain correct. Disabling a key, purging a key, moving a Key Vault without updating dependencies, or removing the vault's access can turn a restore path into an incident. Operators should document key ownership and recovery procedures with the same seriousness as backup policy because a recovery point that cannot be decrypted is only a billing artifact.
 
-Recovery time varies by workload type.
-File or disk restores can be fast when
-the target is small and the restore
-path stays in the same region. Full VM
-restore takes longer because disks and
-VM resources must be created,
-extensions must initialize, and the
-application must be checked. SQL and
-SAP HANA database restores depend on
-full, differential, and log chains as
-well as target server capacity.
-Cross-region restore adds regional
-placement and data path
-considerations. A serious RTO
-statement should be based on measured
-drills, not service names.
+Recovery time varies by workload type. File or disk restores can be fast when the target is small and the restore path stays in the same region. Full VM restore takes longer because disks and VM resources must be created, extensions must initialize, and the application must be checked. SQL and SAP HANA database restores depend on full, differential, and log chains as well as target server capacity. Cross-region restore adds regional placement and data path considerations. A serious RTO statement should be based on measured drills, not service names.
 
-Worked example: an internal Git
-service runs on an Azure VM with a
-separate data disk. The team wants
-quick rollback after package upgrades,
-daily operational recovery for
-accidental deletion, and a monthly
-restore point for audit. A good design
-might use VM backup in a Recovery
-Services vault for the full machine,
-keep daily points for two weeks,
-weekly points for two months, and
-monthly points for a year, then run a
-quarterly restore drill into an
-isolated subnet. If the repository
-data disk needs more frequent
-crash-consistent points before
-upgrades, Azure Disk backup can
-complement the VM backup, but it
-should not replace the full VM
-recovery plan.
+Worked example: an internal Git service runs on an Azure VM with a separate data disk. The team wants quick rollback after package upgrades, daily operational recovery for accidental deletion, and a monthly restore point for audit. A good design might use VM backup in a Recovery Services vault for the full machine, keep daily points for two weeks, weekly points for two months, and monthly points for a year, then run a quarterly restore drill into an isolated subnet. If the repository data disk needs more frequent crash-consistent points before upgrades, Azure Disk backup can complement the VM backup, but it should not replace the full VM recovery plan.
 
 > **Pause and predict:** if a VM has a daily VM backup and a SQL Server database inside the guest has a fifteen-minute log backup policy, which recovery path do you choose after one table is corrupted by a migration? What evidence would you collect before restoring?
 
-Now you solve it: a file-share
-workload has a one-day RPO requirement
-for accidental deletion, but the
-compliance team also asks for
-off-domain retention that survives
-storage-account compromise. Decide
-whether local share snapshots are
-enough, whether vaulted backup is
-required, and how soft delete plus
-immutability change the operational
-risk.
+Now you solve it: a file-share workload has a one-day RPO requirement for accidental deletion, but the compliance team also asks for off-domain retention that survives storage-account compromise. Decide whether local share snapshots are enough, whether vaulted backup is required, and how soft delete plus immutability change the operational risk.
 
 ## 3. Azure Site Recovery Deep Dive
 
-Azure Site Recovery is a replication
-and orchestration service for disaster
-recovery, not a general-purpose backup
-system. The common modern scenario is
-Azure-to-Azure replication, where VMs
-in one Azure region replicate to
-another region. Site Recovery also
-supports on-premises VMware, Hyper-V,
-physical servers, Azure Stack, and
-some site-to-site patterns, but the
-operator path for Azure platform
-engineers usually starts with Azure VM
-disaster recovery [Site Recovery
-overview](https://learn.microsoft.com/en-us/azure/site-recovery/site-recovery-overview).
+Azure Site Recovery is a replication and orchestration service for disaster recovery, not a general-purpose backup system. The common modern scenario is Azure-to-Azure replication, where VMs in one Azure region replicate to another region. Site Recovery also supports on-premises VMware, Hyper-V, physical servers, Azure Stack, and some site-to-site patterns, but the operator path for Azure platform engineers usually starts with Azure VM disaster recovery [Site Recovery overview](https://learn.microsoft.com/en-us/azure/site-recovery/site-recovery-overview).
 
-Azure-to-Azure replication has a
-concrete data path. The protected VM
-runs a Mobility Service extension.
-Disk writes are captured and sent
-through a cache storage account in the
-source region. Data is processed into
-replica managed disks and recovery
-points in the target region. During
-failover, Site Recovery uses a
-selected recovery point to create a VM
-in the target region. Microsoft
-documents this flow in the Azure VM
-disaster recovery tutorial and
-architecture pages [VM disaster
-recovery
-tutorial](https://learn.microsoft.com/en-us/azure/virtual-machines/windows/tutorial-disaster-recovery),
-[Azure-to-Azure
-architecture](https://learn.microsoft.com/en-us/azure/site-recovery/azure-to-azure-architecture).
+Azure-to-Azure replication has a concrete data path. The protected VM runs a Mobility Service extension. Disk writes are captured and sent through a cache storage account in the source region. Data is processed into replica managed disks and recovery points in the target region. During failover, Site Recovery uses a selected recovery point to create a VM in the target region. Microsoft documents this flow in the Azure VM disaster recovery tutorial and architecture pages [VM disaster recovery tutorial](https://learn.microsoft.com/en-us/azure/virtual-machines/windows/tutorial-disaster-recovery), [Azure-to-Azure architecture](https://learn.microsoft.com/en-us/azure/site-recovery/azure-to-azure-architecture).
 
 ```text
 +-------------------+        +---------------------+        +-------------------+
@@ -589,453 +135,61 @@ architecture](https://learn.microsoft.com/en-us/azure/site-recovery/azure-to-azu
                                                         +-------------------+
 ```
 
-The RPO signal for ASR is not the same
-as "last backup time." Replication is
-continuous, recovery points are
-created from replicated data, and the
-operator watches replication health,
-failover readiness, and lag. Site
-Recovery monitoring examples use
-fields such as `rpoInSeconds_d` in Log
-Analytics queries, and those values
-are the practical "are we within SLA
-right now?" signal for replicated
-items [Site Recovery
-monitoring](https://learn.microsoft.com/en-us/azure/site-recovery/monitor-log-analytics).
-If the lag is already outside the
-business RPO, a failover may still
-work, but it may not meet the promise.
+The RPO signal for ASR is not the same as "last backup time." Replication is continuous, recovery points are created from replicated data, and the operator watches replication health, failover readiness, and lag. Site Recovery monitoring examples use fields such as `rpoInSeconds_d` in Log Analytics queries, and those values are the practical "are we within SLA right now?" signal for replicated items [Site Recovery monitoring](https://learn.microsoft.com/en-us/azure/site-recovery/monitor-log-analytics). If the lag is already outside the business RPO, a failover may still work, but it may not meet the promise.
 
-Recovery plans are the orchestration
-layer above single-VM failover. A
-recovery plan groups machines, orders
-startup, and can include manual
-actions and automation runbooks.
-Microsoft documents recovery plans as
-a way to define systematic recovery
-for multi-tier applications, with
-groups, sequencing, scripts, and
-manual tasks [Recovery plan
-overview](https://learn.microsoft.com/en-us/azure/site-recovery/recovery-plan-overview).
-Operators should use recovery plans
-when a service is more than one VM
-because order matters: domain
-dependencies, database tiers, message
-brokers, app servers, and web tiers
-rarely recover safely in a random
-sequence.
+Recovery plans are the orchestration layer above single-VM failover. A recovery plan groups machines, orders startup, and can include manual actions and automation runbooks. Microsoft documents recovery plans as a way to define systematic recovery for multi-tier applications, with groups, sequencing, scripts, and manual tasks [Recovery plan overview](https://learn.microsoft.com/en-us/azure/site-recovery/recovery-plan-overview). Operators should use recovery plans when a service is more than one VM because order matters: domain dependencies, database tiers, message brokers, app servers, and web tiers rarely recover safely in a random sequence.
 
-Failover has three operator-visible
-modes. Test failover creates an
-isolated recovery drill without
-affecting production replication.
-Planned failover is used for a
-controlled event when the source is
-healthy enough to shut down gracefully
-and minimize data loss. Unplanned
-failover is the emergency path when
-the primary environment is already
-unavailable or unsafe. Microsoft
-documents failover behavior and the
-difference between test, planned, and
-unplanned operations in Site Recovery
-failover guidance [Site Recovery
-failover](https://learn.microsoft.com/en-us/azure/site-recovery/site-recovery-failover).
+Failover has three operator-visible modes. Test failover creates an isolated recovery drill without affecting production replication. Planned failover is used for a controlled event when the source is healthy enough to shut down gracefully and minimize data loss. Unplanned failover is the emergency path when the primary environment is already unavailable or unsafe. Microsoft documents failover behavior and the difference between test, planned, and unplanned operations in Site Recovery failover guidance [Site Recovery failover](https://learn.microsoft.com/en-us/azure/site-recovery/site-recovery-failover).
 
-Test failover is the mode that
-separates real DR from slideware. A
-test that only proves "the VM booted"
-is incomplete. A passing test should
-show that target networking works,
-security groups and routes are
-correct, DNS or traffic management can
-point to the secondary path,
-application dependencies connect,
-identity and secrets are usable,
-monitoring recognizes the new
-location, and the test resources are
-cleaned up. A quarterly test is a
-reasonable minimum for ordinary
-production workloads, while
-mission-critical systems often justify
-monthly testing.
+Test failover is the mode that separates real DR from slideware. A test that only proves "the VM booted" is incomplete. A passing test should show that target networking works, security groups and routes are correct, DNS or traffic management can point to the secondary path, application dependencies connect, identity and secrets are usable, monitoring recognizes the new location, and the test resources are cleaned up. A quarterly test is a reasonable minimum for ordinary production workloads, while mission-critical systems often justify monthly testing.
 
-Re-protection is the step many
-runbooks forget. After failover, the
-workload is running in the secondary
-region and is no longer protected in
-the original direction. Re-protection
-starts replication back toward the
-original primary or toward another
-target so that the new production
-location is protected. Microsoft
-documents the Azure-to-Azure
-re-protection flow after failover
-[Reprotect Azure
-VMs](https://learn.microsoft.com/en-us/azure/site-recovery/azure-to-azure-how-to-reprotect).
-Until that step completes, the team
-has restored service but may be
-exposed to another fault.
+Re-protection is the step many runbooks forget. After failover, the workload is running in the secondary region and is no longer protected in the original direction. Re-protection starts replication back toward the original primary or toward another target so that the new production location is protected. Microsoft documents the Azure-to-Azure re-protection flow after failover [Reprotect Azure VMs](https://learn.microsoft.com/en-us/azure/site-recovery/azure-to-azure-how-to-reprotect). Until that step completes, the team has restored service but may be exposed to another fault.
 
-Failback is not a magic undo button.
-After the primary region or original
-environment is healthy, the operator
-must decide whether to fail back,
-remain in the secondary region, or
-rebuild a new primary. Failback
-requires capacity, network readiness,
-data synchronization, application
-validation, and a business-approved
-cutover window. The most disciplined
-teams treat failback as a second
-planned migration rather than an
-automatic clean-up step.
+Failback is not a magic undo button. After the primary region or original environment is healthy, the operator must decide whether to fail back, remain in the secondary region, or rebuild a new primary. Failback requires capacity, network readiness, data synchronization, application validation, and a business-approved cutover window. The most disciplined teams treat failback as a second planned migration rather than an automatic clean-up step.
 
-ASR also has clear boundaries. It is
-not the right orchestrator for Azure
-SQL Database failover groups because
-Azure SQL has managed database-level
-HA and DR features that preserve
-database semantics and listener
-behavior. It is not the DR mechanism
-for App Service, where deployment
-slots, regional deployments, Front
-Door, and application-level
-architecture matter. It is not the
-recovery system for Azure Functions,
-where deployment automation, storage
-dependencies, slots, and regional
-patterns matter. ASR protects
-machines; PaaS services usually need
-service-native availability and
-recovery patterns.
+ASR also has clear boundaries. It is not the right orchestrator for Azure SQL Database failover groups because Azure SQL has managed database-level HA and DR features that preserve database semantics and listener behavior. It is not the DR mechanism for App Service, where deployment slots, regional deployments, Front Door, and application-level architecture matter. It is not the recovery system for Azure Functions, where deployment automation, storage dependencies, slots, and regional patterns matter. ASR protects machines; PaaS services usually need service-native availability and recovery patterns.
 
-That boundary does not make ASR less
-important. Many production estates
-still run stateful or packaged
-workloads on VMs because of vendor
-support, licensing, agents,
-appliances, migration timelines, or
-operating-system dependencies. For
-those VM-shaped workloads, ASR
-provides a managed replication and
-failover control plane that would
-otherwise require custom scripts,
-storage replication plumbing, target
-resource creation, and manual
-dependency tracking.
+That boundary does not make ASR less important. Many production estates still run stateful or packaged workloads on VMs because of vendor support, licensing, agents, appliances, migration timelines, or operating-system dependencies. For those VM-shaped workloads, ASR provides a managed replication and failover control plane that would otherwise require custom scripts, storage replication plumbing, target resource creation, and manual dependency tracking.
 
-Worked example: a three-tier internal
-application has a VM-based database
-appliance, two application VMs, and a
-web VM behind an internal load
-balancer. The recovery plan should
-start the database appliance first,
-pause for a health check, start the
-application VMs, run a script that
-validates service ports, then start
-the web tier and update the target
-load balancer backend. A test failover
-should use an isolated VNet so it
-cannot accidentally receive production
-traffic, but it still needs enough
-DNS, identity, and Key Vault
-connectivity to prove the service can
-run.
+Worked example: a three-tier internal application has a VM-based database appliance, two application VMs, and a web VM behind an internal load balancer. The recovery plan should start the database appliance first, pause for a health check, start the application VMs, run a script that validates service ports, then start the web tier and update the target load balancer backend. A test failover should use an isolated VNet so it cannot accidentally receive production traffic, but it still needs enough DNS, identity, and Key Vault connectivity to prove the service can run.
 
-Now you solve it: a team protects the
-four VMs above with ASR but has no
-recovery plan. During a test failover,
-all VMs boot, but the application
-fails because the web tier starts
-before the database appliance accepts
-connections. Decide what belongs in
-the recovery plan, what belongs in
-application health checks, and what
-should remain as a manual action for
-the incident commander.
+Now you solve it: a team protects the four VMs above with ASR but has no recovery plan. During a test failover, all VMs boot, but the application fails because the web tier starts before the database appliance accepts connections. Decide what belongs in the recovery plan, what belongs in application health checks, and what should remain as a manual action for the incident commander.
 
 ## 4. Identity, Networking, Security, and Compliance
 
-Recovery tooling is security tooling.
-The identities that can configure
-backup, delete recovery points,
-disable replication, trigger restore,
-run test failover, or execute
-unplanned failover can change the
-blast radius of both accidents and
-attacks. Azure provides built-in roles
-such as Backup Contributor, Backup
-Operator, and Site Recovery
-Contributor, and the built-in role
-documentation explains the permission
-boundaries for management and
-governance roles [Azure built-in
-roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/management-and-governance).
-The operator should assign the least
-role that lets a person perform the
-recovery task, not broad Contributor
-rights by habit.
+Recovery tooling is security tooling. The identities that can configure backup, delete recovery points, disable replication, trigger restore, run test failover, or execute unplanned failover can change the blast radius of both accidents and attacks. Azure provides built-in roles such as Backup Contributor, Backup Operator, and Site Recovery Contributor, and the built-in role documentation explains the permission boundaries for management and governance roles [Azure built-in roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/management-and-governance). The operator should assign the least role that lets a person perform the recovery task, not broad Contributor rights by habit.
 
-Backup roles are also operationally
-distinct. A person who can monitor
-jobs does not necessarily need
-permission to delete backup data. A
-person who can trigger an on-demand
-backup before a risky change may not
-need permission to change
-immutability. A person who can run a
-restore drill into a lab subscription
-may not need permission to restore
-over production. Azure Backup's RBAC
-guidance exists because recovery-point
-management is sensitive enough to
-deserve separate roles and approval
-paths [Backup
-RBAC](https://learn.microsoft.com/en-us/azure/backup/backup-rbac-rs-vault).
+Backup roles are also operationally distinct. A person who can monitor jobs does not necessarily need permission to delete backup data. A person who can trigger an on-demand backup before a risky change may not need permission to change immutability. A person who can run a restore drill into a lab subscription may not need permission to restore over production. Azure Backup's RBAC guidance exists because recovery-point management is sensitive enough to deserve separate roles and approval paths [Backup RBAC](https://learn.microsoft.com/en-us/azure/backup/backup-rbac-rs-vault).
 
-Managed identities appear in several
-places. Backup vaults use managed
-identity to access datasources such as
-disks or PostgreSQL resources and to
-receive workload-level permissions.
-Recovery Services vaults can use
-managed identity for private endpoint
-and customer-managed key patterns.
-Operators need to document which
-identity is used by which vault and
-which Key Vault or resource
-permissions it holds. Treat the
-identity as part of the recovery
-system, not as a portal implementation
-detail.
+Managed identities appear in several places. Backup vaults use managed identity to access datasources such as disks or PostgreSQL resources and to receive workload-level permissions. Recovery Services vaults can use managed identity for private endpoint and customer-managed key patterns. Operators need to document which identity is used by which vault and which Key Vault or resource permissions it holds. Treat the identity as part of the recovery system, not as a portal implementation detail.
 
-Private endpoints change backup and
-restore behavior. Azure Backup private
-endpoints are supported for Recovery
-Services vaults, but Microsoft calls
-out important constraints: create
-private endpoints before protecting
-items in the vault, keep managed
-identity enabled, configure DNS
-correctly, and remember that the
-private endpoint for Backup is not
-used for Site Recovery [Azure Backup
-private
-endpoints](https://learn.microsoft.com/en-us/azure/backup/private-endpoints).
-Network isolation is valuable, but a
-misconfigured private endpoint can
-make restore fail during the exact
-moment you need it.
+Private endpoints change backup and restore behavior. Azure Backup private endpoints are supported for Recovery Services vaults, but Microsoft calls out important constraints: create private endpoints before protecting items in the vault, keep managed identity enabled, configure DNS correctly, and remember that the private endpoint for Backup is not used for Site Recovery [Azure Backup private endpoints](https://learn.microsoft.com/en-us/azure/backup/private-endpoints). Network isolation is valuable, but a misconfigured private endpoint can make restore fail during the exact moment you need it.
 
-For ASR, network design is more than
-opening a portal blade. The target
-region needs VNets, subnets, NSGs,
-routes, load balancers, private DNS,
-identity endpoints, Key Vault access,
-monitoring egress, and application
-dependency paths. Replication itself
-has service dependencies, but failover
-success depends on the target runtime
-network. A DR drill should therefore
-validate routes and name resolution,
-not only replication health.
+For ASR, network design is more than opening a portal blade. The target region needs VNets, subnets, NSGs, routes, load balancers, private DNS, identity endpoints, Key Vault access, monitoring egress, and application dependency paths. Replication itself has service dependencies, but failover success depends on the target runtime network. A DR drill should therefore validate routes and name resolution, not only replication health.
 
-Customer-managed keys introduce a
-compliance and sovereignty control,
-but they also introduce an operational
-dependency. For Recovery Services
-vault CMK, Microsoft requires the key
-to be configured before protecting
-items, and once enabled it cannot
-simply be reversed for that vault
-[Recovery Services vault
-configuration](https://learn.microsoft.com/en-us/azure/backup/backup-create-recovery-services-vault).
-For Backup vaults, CMK is also a
-supported encryption option in the
-Backup vault model [Backup vault
-overview](https://learn.microsoft.com/en-us/azure/backup/backup-vault-overview).
-Key rotation should be tested with
-restore, because policy compliance is
-not enough if the recovery process
-cannot unwrap backup data.
+Customer-managed keys introduce a compliance and sovereignty control, but they also introduce an operational dependency. For Recovery Services vault CMK, Microsoft requires the key to be configured before protecting items, and once enabled it cannot simply be reversed for that vault [Recovery Services vault configuration](https://learn.microsoft.com/en-us/azure/backup/backup-create-recovery-services-vault). For Backup vaults, CMK is also a supported encryption option in the Backup vault model [Backup vault overview](https://learn.microsoft.com/en-us/azure/backup/backup-vault-overview). Key rotation should be tested with restore, because policy compliance is not enough if the recovery process cannot unwrap backup data.
 
-The IDE pattern is a useful review
-tool: Identity, Data, Encryption.
-Identity asks who can administer the
-vault, who can restore, and which
-managed identities can reach source
-resources or keys. Data asks where
-recovery points live, which redundancy
-mode is selected, whether cross-region
-restore is enabled, and whether source
-compromise can affect backup copies.
-Encryption asks which key protects the
-backup data, who can disable or purge
-that key, and how key rotation is
-validated. A vault design that passes
-IDE review is usually easier to defend
-in audit and incident response.
+The IDE pattern is a useful review tool: Identity, Data, Encryption. Identity asks who can administer the vault, who can restore, and which managed identities can reach source resources or keys. Data asks where recovery points live, which redundancy mode is selected, whether cross-region restore is enabled, and whether source compromise can affect backup copies. Encryption asks which key protects the backup data, who can disable or purge that key, and how key rotation is validated. A vault design that passes IDE review is usually easier to defend in audit and incident response.
 
-Immutability creates a real compliance
-tension. WORM retention and locked
-immutable vaults are designed to
-prevent deletion, including deletion
-by compromised or mistaken
-administrators. Privacy and records
-programs may also require deletion of
-personal data under lawful processes.
-Operators do not resolve that conflict
-by secretly disabling immutability.
-They resolve it by classifying data
-before policy assignment, choosing
-retention windows with legal approval,
-documenting exception workflows, and
-making sure application teams
-understand that immutable backup
-copies can outlive source deletion
-requests for a defined retention
-period.
+Immutability creates a real compliance tension. WORM retention and locked immutable vaults are designed to prevent deletion, including deletion by compromised or mistaken administrators. Privacy and records programs may also require deletion of personal data under lawful processes. Operators do not resolve that conflict by secretly disabling immutability. They resolve it by classifying data before policy assignment, choosing retention windows with legal approval, documenting exception workflows, and making sure application teams understand that immutable backup copies can outlive source deletion requests for a defined retention period.
 
-Audit is part of recoverability. Every
-restore, stop-protection action,
-replication-disable action, failover,
-test failover, role assignment, key
-permission change, and vault
-networking change should be visible in
-Azure Activity logs, diagnostic logs,
-or service job history. If the first
-question after an emergency restore is
-"who did this?", the audit path should
-already exist. Backup Center, Azure
-Monitor, Activity Log, and Log
-Analytics give the operator the
-evidence chain when diagnostic
-settings are enabled [Backup Center
-overview](https://learn.microsoft.com/en-us/azure/backup/backup-center-overview).
+Audit is part of recoverability. Every restore, stop-protection action, replication-disable action, failover, test failover, role assignment, key permission change, and vault networking change should be visible in Azure Activity logs, diagnostic logs, or service job history. If the first question after an emergency restore is "who did this?", the audit path should already exist. Backup Center, Azure Monitor, Activity Log, and Log Analytics give the operator the evidence chain when diagnostic settings are enabled [Backup Center overview](https://learn.microsoft.com/en-us/azure/backup/backup-center-overview).
 
-Worked example: a security team asks
-for customer-managed keys on all
-backup vaults, but the platform team
-already protected production VMs in
-Recovery Services vaults that use
-platform-managed keys. The correct
-response is not to promise an instant
-in-place switch. The operator should
-check which vaults support CMK for the
-workload, whether CMK must be
-configured before protection, what
-migration or reprotection path exists,
-which recovery points would remain
-under the old vault model, and what
-restore tests prove after the change.
+Worked example: a security team asks for customer-managed keys on all backup vaults, but the platform team already protected production VMs in Recovery Services vaults that use platform-managed keys. The correct response is not to promise an instant in-place switch. The operator should check which vaults support CMK for the workload, whether CMK must be configured before protection, what migration or reprotection path exists, which recovery points would remain under the old vault model, and what restore tests prove after the change.
 
-Now you solve it: a vault uses private
-endpoints and denies public access. A
-restore of SQL in Azure VM fails from
-a locked-down subnet during a drill.
-List the checks you run before
-changing the policy: private DNS
-records, managed identity state, Key
-Vault reachability, Azure Storage
-endpoints, Microsoft Entra ID access,
-and whether the workload type supports
-the blocked network path.
+Now you solve it: a vault uses private endpoints and denies public access. A restore of SQL in Azure VM fails from a locked-down subnet during a drill. List the checks you run before changing the policy: private DNS records, managed identity state, Key Vault reachability, Azure Storage endpoints, Microsoft Entra ID access, and whether the workload type supports the blocked network path.
 
 ## 5. Cost Lens for Backup and DR
 
-Recovery is an engineering control
-with a recurring bill. Azure Backup
-usually charges along two dimensions:
-protected-instance-month and backup
-storage GB-month. The
-protected-instance line depends on
-workload type and size, while storage
-depends on how much recovery-point
-data is retained and which redundancy
-option is selected. Microsoft Learn's
-Azure Backup pricing guidance points
-operators to workload size, churn,
-retention, instant restore snapshot
-duration, and storage redundancy as
-the major estimation variables [Azure
-Backup
-pricing](https://learn.microsoft.com/en-us/azure/backup/azure-backup-pricing).
+Recovery is an engineering control with a recurring bill. Azure Backup usually charges along two dimensions: protected-instance-month and backup storage GB-month. The protected-instance line depends on workload type and size, while storage depends on how much recovery-point data is retained and which redundancy option is selected. Microsoft Learn's Azure Backup pricing guidance points operators to workload size, churn, retention, instant restore snapshot duration, and storage redundancy as the major estimation variables [Azure Backup pricing](https://learn.microsoft.com/en-us/azure/backup/azure-backup-pricing).
 
-Site Recovery has a different shape.
-ASR charges per protected instance
-after the free initial period, and
-failover adds the cost of compute,
-disks, networking, and any supporting
-services in the target region.
-Microsoft documents Site Recovery
-charges for managed disks and the
-protected-instance license as a core
-charge [Site Recovery
-cost](https://learn.microsoft.com/en-us/azure/site-recovery/site-recovery-cost).
-The operator should expect ASR to be
-materially more expensive than simple
-backup for the same VM because it is
-buying a lower RPO, faster regional
-recovery, and orchestration.
+Site Recovery has a different shape. ASR charges per protected instance after the free initial period, and failover adds the cost of compute, disks, networking, and any supporting services in the target region. Microsoft documents Site Recovery charges for managed disks and the protected-instance license as a core charge [Site Recovery cost](https://learn.microsoft.com/en-us/azure/site-recovery/site-recovery-cost). The operator should expect ASR to be materially more expensive than simple backup for the same VM because it is buying a lower RPO, faster regional recovery, and orchestration.
 
-Pricing data changes by region,
-agreement, currency, and date, so
-production estimates should be pulled
-from the Azure pricing calculator,
-your enterprise price sheet, or the
-Azure Retail Prices API. Microsoft
-documents the Retail Prices API as a
-way to query prices by service,
-region, SKU, and meter [Azure Retail
-Prices
-API](https://learn.microsoft.com/en-us/rest/api/cost-management/retail-prices/azure-retail-prices).
-The numbers below are a worked example
-for East US public pricing at write
-time, not a contract. The method
-matters more than the exact cents.
+Pricing data changes by region, agreement, currency, and date, so production estimates should be pulled from the Azure pricing calculator, your enterprise price sheet, or the Azure Retail Prices API. Microsoft documents the Retail Prices API as a way to query prices by service, region, SKU, and meter [Azure Retail Prices API](https://learn.microsoft.com/en-us/rest/api/cost-management/retail-prices/azure-retail-prices). The numbers below are a worked example for East US public pricing at write time, not a contract. The method matters more than the exact cents.
 
-Worked example: assume fifty
-production VMs, each with 200 GiB of
-protected data, daily backup,
-thirty-day retention, three percent
-daily churn, and GRS backup storage.
-The simplified storage model is one
-initial 200 GiB recovery point plus
-twenty-nine daily deltas of 6 GiB, or
-374 GiB per VM. Across fifty VMs, that
-is 18,700 GiB of retained backup data.
-Using an Azure VM protected-instance
-meter of $10.00 per VM-month and a
-Standard GRS backup storage meter of
-$0.0448 per GiB-month, the backup
-estimate is $500.00 for protected
-instances plus $837.76 for storage, or
-$1,337.76 per month before restore
-traffic, transactions, discounts,
-taxes, and policy differences.
+Worked example: assume fifty production VMs, each with 200 GiB of protected data, daily backup, thirty-day retention, three percent daily churn, and GRS backup storage. The simplified storage model is one initial 200 GiB recovery point plus twenty-nine daily deltas of 6 GiB, or 374 GiB per VM. Across fifty VMs, that is 18,700 GiB of retained backup data. Using an Azure VM protected-instance meter of $10.00 per VM-month and a Standard GRS backup storage meter of $0.0448 per GiB-month, the backup estimate is $500.00 for protected instances plus $837.76 for storage, or $1,337.76 per month before restore traffic, transactions, discounts, taxes, and policy differences.
 
-Now add ASR for only the five
-mission-critical VMs. Using the
-Azure-to-Azure Site Recovery meter of
-$25.00 per protected instance-month,
-the ASR service line is $125.00 per
-month after the free initial period.
-If each VM has one 256 GiB Standard
-SSD E15 replica disk in the target
-region at $19.20 per disk-month,
-replica disk capacity adds $96.00 per
-month. A two-hour quarterly test
-failover using B1s Linux VMs at
-$0.0104 per VM-hour is roughly $0.11
-for compute in that drill window,
-although real mission-critical VM
-sizes would cost more. The
-steady-state ASR estimate for this
-simplified line is $221.00 per month
-before cache storage transactions,
-network, monitoring, target load
-balancers, and failover-time compute.
+Now add ASR for only the five mission-critical VMs. Using the Azure-to-Azure Site Recovery meter of $25.00 per protected instance-month, the ASR service line is $125.00 per month after the free initial period. If each VM has one 256 GiB Standard SSD E15 replica disk in the target region at $19.20 per disk-month, replica disk capacity adds $96.00 per month. A two-hour quarterly test failover using B1s Linux VMs at $0.0104 per VM-hour is roughly $0.11 for compute in that drill window, although real mission-critical VM sizes would cost more. The steady-state ASR estimate for this simplified line is $221.00 per month before cache storage transactions, network, monitoring, target load balancers, and failover-time compute.
 
 | Cost line | Assumption | Monthly estimate |
 |---|---|---:|
@@ -1047,166 +201,27 @@ balancers, and failover-time compute.
 | ASR drill compute | 5 B1s VMs x two hours | $0.11 |
 | ASR subtotal | Service plus simple replica storage | $221.11 |
 
-The example teaches three cost
-lessons. First, backup storage is
-dominated by retention and churn, not
-by the number of policies in the
-portal. Second, ASR is expensive
-enough that many teams protect only
-business-critical VM tiers rather than
-every VM. Third, the cheapest DR plan
-may be a service-native architecture
-that removes the need for VM-level
-replication entirely, but only when
-the application and data services
-actually support that model.
+The example teaches three cost lessons. First, backup storage is dominated by retention and churn, not by the number of policies in the portal. Second, ASR is expensive enough that many teams protect only business-critical VM tiers rather than every VM. Third, the cheapest DR plan may be a service-native architecture that removes the need for VM-level replication entirely, but only when the application and data services actually support that model.
 
-Cost spikes usually come from policy
-drift. A team adds yearly retention
-for audit and forgets that every
-retained delta has a storage cost. A
-vault uses GRS by default even for
-development workloads that could use
-LRS. ASR is enabled for every VM in a
-resource group, including stateless
-build workers and cache nodes that
-could be redeployed. Test failover
-resources are left running in the
-target region. Diagnostic logs are
-exported without retention rules. None
-of these mistakes looks dramatic on
-day one, but all of them show up in
-the monthly bill.
+Cost spikes usually come from policy drift. A team adds yearly retention for audit and forgets that every retained delta has a storage cost. A vault uses GRS by default even for development workloads that could use LRS. ASR is enabled for every VM in a resource group, including stateless build workers and cache nodes that could be redeployed. Test failover resources are left running in the target region. Diagnostic logs are exported without retention rules. None of these mistakes looks dramatic on day one, but all of them show up in the monthly bill.
 
-Cost reduction should not start by
-deleting recovery controls. Start by
-classifying workloads. Put stateless
-tiers behind rebuild automation and
-short backup retention. Give stateful
-VM workloads backup and maybe ASR if
-the business RTO requires it. Use SQL
-failover groups or managed database
-features where the PaaS service owns
-the failover semantics. Use LRS for
-non-production backups when off-region
-recovery is not required. Use GRS,
-cross-region restore, immutable
-vaults, and ASR only where the
-recovery objective justifies them.
+Cost reduction should not start by deleting recovery controls. Start by classifying workloads. Put stateless tiers behind rebuild automation and short backup retention. Give stateful VM workloads backup and maybe ASR if the business RTO requires it. Use SQL failover groups or managed database features where the PaaS service owns the failover semantics. Use LRS for non-production backups when off-region recovery is not required. Use GRS, cross-region restore, immutable vaults, and ASR only where the recovery objective justifies them.
 
-One cloud version of the three-two-one
-backup rule is useful: keep three
-copies, use two protection mechanisms
-or storage domains, and keep one copy
-off-region. Azure Backup with
-cross-region restore and immutable
-vault settings can satisfy the spirit
-for many VM workloads, but only when
-the backup is actually off-region and
-protected against deletion. A local
-snapshot, a GRS disk, and a mutable
-vault controlled by the same broad
-admin group do not provide the same
-risk reduction.
+One cloud version of the three-two-one backup rule is useful: keep three copies, use two protection mechanisms or storage domains, and keep one copy off-region. Azure Backup with cross-region restore and immutable vault settings can satisfy the spirit for many VM workloads, but only when the backup is actually off-region and protected against deletion. A local snapshot, a GRS disk, and a mutable vault controlled by the same broad admin group do not provide the same risk reduction.
 
 ## 6. Observability and Day-Two Operations
 
-A recovery platform without monitoring
-is a story, not a system. Operators
-need to know whether the last backup
-succeeded, whether recovery points are
-growing as expected, whether protected
-items are drifting out of policy,
-whether ASR replicated items are
-within RPO, whether a vault is
-accessible, and whether anyone changed
-recovery controls. Backup Center
-provides a unified management
-experience for backup and Site
-Recovery estates across vaults,
-subscriptions, regions, and supported
-workload types [Backup Center
-overview](https://learn.microsoft.com/en-us/azure/backup/backup-center-overview).
+A recovery platform without monitoring is a story, not a system. Operators need to know whether the last backup succeeded, whether recovery points are growing as expected, whether protected items are drifting out of policy, whether ASR replicated items are within RPO, whether a vault is accessible, and whether anyone changed recovery controls. Backup Center provides a unified management experience for backup and Site Recovery estates across vaults, subscriptions, regions, and supported workload types [Backup Center overview](https://learn.microsoft.com/en-us/azure/backup/backup-center-overview).
 
-Backup Center has evolved toward Azure
-Business Continuity Center, but the
-operator pattern remains the same: use
-an estate view rather than clicking
-through each vault during an incident.
-The source of truth should let you
-answer "which production workloads are
-unprotected?", "which backup jobs
-failed last night?", "which restores
-happened recently?", "which vaults
-have soft-deleted items?", and "which
-replicated items are unhealthy?" If
-those queries require tribal memory,
-the platform is not ready.
+Backup Center has evolved toward Azure Business Continuity Center, but the operator pattern remains the same: use an estate view rather than clicking through each vault during an incident. The source of truth should let you answer "which production workloads are unprotected?", "which backup jobs failed last night?", "which restores happened recently?", "which vaults have soft-deleted items?", and "which replicated items are unhealthy?" If those queries require tribal memory, the platform is not ready.
 
-Azure Monitor metrics for Recovery
-Services vaults and Backup vaults
-include health-event metrics such as
-`BackupHealthEvent` and
-`RestoreHealthEvent` [Recovery
-Services vault
-metrics](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-recoveryservices-vaults-metrics),
-[Backup vault
-metrics](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-dataprotection-backupvaults-metrics).
-Storage allocation and job history are
-often examined through Backup reports,
-Log Analytics tables, vault jobs, and
-cost data rather than one universal
-metric name. Operators should build
-dashboards around the signals they can
-alert on and the questions incident
-responders ask.
+Azure Monitor metrics for Recovery Services vaults and Backup vaults include health-event metrics such as `BackupHealthEvent` and `RestoreHealthEvent` [Recovery Services vault metrics](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-recoveryservices-vaults-metrics), [Backup vault metrics](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-dataprotection-backupvaults-metrics). Storage allocation and job history are often examined through Backup reports, Log Analytics tables, vault jobs, and cost data rather than one universal metric name. Operators should build dashboards around the signals they can alert on and the questions incident responders ask.
 
-For ASR, the key day-two signal is RPO
-and replication health. The Site
-Recovery monitoring guidance includes
-KQL examples that filter A2A
-replicated items and use
-`rpoInSeconds_d` to alert when one VM
-or a fleet exceeds an RPO threshold
-[Site Recovery
-monitoring](https://learn.microsoft.com/en-us/azure/site-recovery/monitor-log-analytics).
-That is the signal that tells you
-whether the secondary environment is
-currently close enough to the primary.
-A healthy-looking vault with stale
-recovery points is not healthy for DR.
+For ASR, the key day-two signal is RPO and replication health. The Site Recovery monitoring guidance includes KQL examples that filter A2A replicated items and use `rpoInSeconds_d` to alert when one VM or a fleet exceeds an RPO threshold [Site Recovery monitoring](https://learn.microsoft.com/en-us/azure/site-recovery/monitor-log-analytics). That is the signal that tells you whether the secondary environment is currently close enough to the primary. A healthy-looking vault with stale recovery points is not healthy for DR.
 
-Alert rules should be tied to operator
-action. Backup job failure should
-create a ticket or page when the
-workload is production and the next
-scheduled run would violate RPO. RPO
-breach should page the team that owns
-DR because the workload is no longer
-meeting its recovery promise. Vault
-inaccessibility should trigger a
-security and network investigation
-because restore may fail even if jobs
-were previously healthy. A restore
-event in production should notify the
-service owner and security team
-because it can indicate either an
-incident response action or
-unauthorized data access.
+Alert rules should be tied to operator action. Backup job failure should create a ticket or page when the workload is production and the next scheduled run would violate RPO. RPO breach should page the team that owns DR because the workload is no longer meeting its recovery promise. Vault inaccessibility should trigger a security and network investigation because restore may fail even if jobs were previously healthy. A restore event in production should notify the service owner and security team because it can indicate either an incident response action or unauthorized data access.
 
-Activity log queries answer the
-uncomfortable questions. Who disabled
-soft delete? Who changed a backup
-policy? Who triggered an unplanned
-restore last night? Who ran a test
-failover and left resources behind?
-Who changed role assignments on the
-vault? A recovery design should
-include diagnostic settings and
-retention for those events before the
-first audit request. Without that
-history, the team may restore service
-but still fail the incident review.
+Activity log queries answer the uncomfortable questions. Who disabled soft delete? Who changed a backup policy? Who triggered an unplanned restore last night? Who ran a test failover and left resources behind? Who changed role assignments on the vault? A recovery design should include diagnostic settings and retention for those events before the first audit request. Without that history, the team may restore service but still fail the incident review.
 
 ```kusto
 AzureActivity
@@ -1244,44 +259,13 @@ AzureDiagnostics
 | order by TimeGenerated desc
 ```
 
-Run test failover on a schedule.
-Quarterly is a reasonable floor for
-production VM workloads, and monthly
-is appropriate when the business RTO
-is measured in minutes or the
-dependency graph changes frequently. A
-passing test should prove boot,
-application health, target network,
-identity, secret access, monitoring,
-traffic switch procedure, and cleanup.
-A failed test is not wasted time. It
-is an incident discovered under
-controlled conditions.
+Run test failover on a schedule. Quarterly is a reasonable floor for production VM workloads, and monthly is appropriate when the business RTO is measured in minutes or the dependency graph changes frequently. A passing test should prove boot, application health, target network, identity, secret access, monitoring, traffic switch procedure, and cleanup. A failed test is not wasted time. It is an incident discovered under controlled conditions.
 
-Day-two operations should also include
-restore sampling. Pick a small set of
-workloads each month, restore them
-into isolated targets, and verify
-application-level data. Rotate through
-VM restore, file restore, database
-restore, cross-region restore, and ASR
-test failover. The test evidence
-should record the selected recovery
-point, elapsed restore time,
-validation steps, operator identity,
-blockers, cleanup status, and any cost
-anomalies. That evidence is what turns
-backup policy into trust.
+Day-two operations should also include restore sampling. Pick a small set of workloads each month, restore them into isolated targets, and verify application-level data. Rotate through VM restore, file restore, database restore, cross-region restore, and ASR test failover. The test evidence should record the selected recovery point, elapsed restore time, validation steps, operator identity, blockers, cleanup status, and any cost anomalies. That evidence is what turns backup policy into trust.
 
 ## Patterns & Anti-Patterns
 
-The patterns below are the practices
-that repeatedly survive real
-operations. They are not
-vendor-neutral abstractions; they are
-Azure-specific ways to keep the
-recovery surface understandable,
-testable, and affordable.
+The patterns below are the practices that repeatedly survive real operations. They are not vendor-neutral abstractions; they are Azure-specific ways to keep the recovery surface understandable, testable, and affordable.
 
 | Pattern | When to Use | Why It Works | Scaling Consideration |
 |---|---|---|---|
@@ -1292,10 +276,7 @@ testable, and affordable.
 | Test in isolated target networks | DR drills and restore validation | Production traffic and test recovery cannot collide | Maintain DNS and identity dependencies for the isolated network |
 | Put cost ownership on policies | Backup and DR estates with many teams | Retention and ASR scope become financial decisions | Tag vaults, protected items, and recovery tiers consistently |
 
-Anti-patterns are usually
-understandable shortcuts. They become
-dangerous when the shortcut is not
-named and reviewed.
+Anti-patterns are usually understandable shortcuts. They become dangerous when the shortcut is not named and reviewed.
 
 | Anti-pattern | What Goes Wrong | Better Alternative |
 |---|---|---|
@@ -1309,23 +290,7 @@ named and reviewed.
 
 ## Decision Framework
 
-Start with the failure you are
-designing for, not the service name.
-If the expected incident is accidental
-deletion, bad migration, corruption,
-or ransomware discovered after the
-fact, begin with Azure Backup and
-immutability. If the expected incident
-is primary-region loss and the
-workload is VM-shaped, evaluate Site
-Recovery. If the workload is a managed
-PaaS service with its own replication
-and failover feature, use the
-service-native design before reaching
-for ASR. If the risk is only a zone
-failure inside one region, a
-zone-redundant SKU may meet the
-objective without cross-region DR.
+Start with the failure you are designing for, not the service name. If the expected incident is accidental deletion, bad migration, corruption, or ransomware discovered after the fact, begin with Azure Backup and immutability. If the expected incident is primary-region loss and the workload is VM-shaped, evaluate Site Recovery. If the workload is a managed PaaS service with its own replication and failover feature, use the service-native design before reaching for ASR. If the risk is only a zone failure inside one region, a zone-redundant SKU may meet the objective without cross-region DR.
 
 ```mermaid
 flowchart TD
@@ -1355,76 +320,15 @@ flowchart TD
 | Survive source compromise | Immutable vaulted backup | Runtime must also continue elsewhere | Local snapshots only |
 | Active-active global app | Service-native multi-region design | Conflict handling or data consistency is weak | ASR as a substitute for application architecture |
 
-When Azure Backup is enough, the
-workload can tolerate data loss equal
-to the backup frequency and downtime
-measured in restore hours. This is
-common for development systems,
-internal tools, stateless workers with
-small state, and production workloads
-whose business owner accepts a rebuild
-window. The key is explicit
-acceptance. "We can restore in hours"
-is a valid requirement when the
-business says so and drills prove it.
+When Azure Backup is enough, the workload can tolerate data loss equal to the backup frequency and downtime measured in restore hours. This is common for development systems, internal tools, stateless workers with small state, and production workloads whose business owner accepts a rebuild window. The key is explicit acceptance. "We can restore in hours" is a valid requirement when the business says so and drills prove it.
 
-When ASR is required, the workload
-needs a secondary runtime with RPO
-measured in seconds or minutes and RTO
-measured in minutes. This does not
-mean every VM needs ASR. It means the
-specific VM tier is hard to rebuild,
-stateful enough to need replication,
-and important enough to justify the
-service line plus target-region
-storage and drill costs. ASR should be
-tied to a recovery plan and test
-schedule, not just enabled because the
-portal offered it.
+When ASR is required, the workload needs a secondary runtime with RPO measured in seconds or minutes and RTO measured in minutes. This does not mean every VM needs ASR. It means the specific VM tier is hard to rebuild, stateful enough to need replication, and important enough to justify the service line plus target-region storage and drill costs. ASR should be tied to a recovery plan and test schedule, not just enabled because the portal offered it.
 
-When zone-redundant SKUs replace ASR,
-the failure target is a zone inside
-the same Azure region and the service
-supports zone resilience.
-Zone-redundant App Gateway,
-zone-redundant managed disks where
-available, zone-redundant storage, and
-zone-aware compute placement can
-remove the need for cross-region
-failover for a zonal fault. They do
-not solve total regional loss, and
-they do not protect against logical
-corruption.
+When zone-redundant SKUs replace ASR, the failure target is a zone inside the same Azure region and the service supports zone resilience. Zone-redundant App Gateway, zone-redundant managed disks where available, zone-redundant storage, and zone-aware compute placement can remove the need for cross-region failover for a zonal fault. They do not solve total regional loss, and they do not protect against logical corruption.
 
-When Azure SQL Database failover
-groups beat both, the database is a
-managed Azure SQL Database or Managed
-Instance workload that should use
-database-native replication,
-listeners, and failover policy. ASR is
-for machines, not for Azure SQL
-Database. Backup remains relevant for
-PITR and long-term retention, but the
-regional availability mechanism
-belongs to Azure SQL. This module
-references that decision only at a
-high level because the Azure SQL
-operator path is covered in module
-3.16.
+When Azure SQL Database failover groups beat both, the database is a managed Azure SQL Database or Managed Instance workload that should use database-native replication, listeners, and failover policy. ASR is for machines, not for Azure SQL Database. Backup remains relevant for PITR and long-term retention, but the regional availability mechanism belongs to Azure SQL. This module references that decision only at a high level because the Azure SQL operator path is covered in module 3.16.
 
-When active-active replaces ASR, the
-application is already built to run in
-more than one region at the same time.
-Cosmos DB multi-region writes, Front
-Door, Traffic Manager, stateless
-services deployed through CI/CD, and
-application-level conflict handling
-can make VM failover unnecessary. This
-is usually better for user-facing
-global systems, but it is also harder
-to design because the application must
-own consistency, routing, deployment,
-and data semantics.
+When active-active replaces ASR, the application is already built to run in more than one region at the same time. Cosmos DB multi-region writes, Front Door, Traffic Manager, stateless services deployed through CI/CD, and application-level conflict handling can make VM failover unnecessary. This is usually better for user-facing global systems, but it is also harder to design because the application must own consistency, routing, deployment, and data semantics.
 
 ## Did You Know?
 
@@ -1449,135 +353,51 @@ and data semantics.
 
 <details><summary>Your team has Azure Backup on a VM with daily recovery points and ASR replication to a paired region. A bad deployment corrupts files, and the issue is detected after replication is healthy. What is the safest recovery direction?</summary>
 
-Start with backup, not ASR. ASR has
-likely replicated the corrupted state
-to the secondary region, so failover
-may only move the bad state. Identify
-the last clean recovery point, restore
-into an isolated target, validate the
-application, and then decide whether
-to repair production or cut over to
-the restored copy.
+Start with backup, not ASR. ASR has likely replicated the corrupted state to the secondary region, so failover may only move the bad state. Identify the last clean recovery point, restore into an isolated target, validate the application, and then decide whether to repair production or cut over to the restored copy.
 
 </details>
 
 <details><summary>A regional outage affects the primary region for a VM-based payment worker. The VM has immutable backups with GRS storage but no ASR. What should the incident commander expect?</summary>
 
-The backup data may be safe, but the
-team does not have an orchestrated
-secondary runtime. Recovery will look
-like a rebuild or restore into another
-region, including networking,
-identity, secrets, monitoring, and
-traffic routing. That can be
-acceptable only if the agreed RTO is
-measured in hours rather than minutes.
+The backup data may be safe, but the team does not have an orchestrated secondary runtime. Recovery will look like a rebuild or restore into another region, including networking, identity, secrets, monitoring, and traffic routing. That can be acceptable only if the agreed RTO is measured in hours rather than minutes.
 
 </details>
 
 <details><summary>A security review finds that Backup Operators can delete recovery points and change policy on a critical vault. What design issue is this?</summary>
 
-This is a separation-of-duties
-problem. Recovery controls are
-powerful enough to be part of the
-security boundary. The team should
-review built-in roles, restrict
-destructive operations, use approval
-for sensitive changes, enable soft
-delete and immutability, and ensure
-audit logs capture role and vault
-changes.
+This is a separation-of-duties problem. Recovery controls are powerful enough to be part of the security boundary. The team should review built-in roles, restrict destructive operations, use approval for sensitive changes, enable soft delete and immutability, and ensure audit logs capture role and vault changes.
 
 </details>
 
 <details><summary>A test failover boots the recovered VM, but the application cannot read secrets from Key Vault. The source VM worked before the drill. Where do you investigate first?</summary>
 
-Investigate target-region identity and
-network dependencies, not the VM boot
-path. Check managed identity
-permissions, Key Vault firewall or
-private endpoint rules, DNS
-resolution, route tables, and whether
-the test network is intentionally
-isolated from shared services. A VM
-that boots without secrets is not a
-passing DR test.
+Investigate target-region identity and network dependencies, not the VM boot path. Check managed identity permissions, Key Vault firewall or private endpoint rules, DNS resolution, route tables, and whether the test network is intentionally isolated from shared services. A VM that boots without secrets is not a passing DR test.
 
 </details>
 
 <details><summary>A product owner asks to lower cost by switching all backup vaults from GRS to LRS. Which question determines whether this is acceptable?</summary>
 
-Ask whether off-region restore is part
-of the recovery objective for each
-workload tier. LRS may be reasonable
-for development or rebuildable
-workloads, but it weakens protection
-against regional storage loss and may
-remove cross-region restore options.
-The decision should be made per
-workload classification, not as a
-subscription-wide savings toggle.
+Ask whether off-region restore is part of the recovery objective for each workload tier. LRS may be reasonable for development or rebuildable workloads, but it weakens protection against regional storage loss and may remove cross-region restore options. The decision should be made per workload classification, not as a subscription-wide savings toggle.
 
 </details>
 
 <details><summary>An Azure SQL Database workload has a regional RTO requirement. A teammate proposes ASR because every other critical workload uses it. How do you respond?</summary>
 
-Use the service-native Azure SQL DR
-feature first, such as failover
-groups, because Azure SQL Database is
-not a VM that ASR should orchestrate.
-ASR protects machines and disks, while
-Azure SQL failover mechanisms preserve
-database-specific replication and
-listener behavior. Backup still
-matters for PITR and long-term
-retention, but it is not the regional
-failover tool.
+Use the service-native Azure SQL DR feature first, such as failover groups, because Azure SQL Database is not a VM that ASR should orchestrate. ASR protects machines and disks, while Azure SQL failover mechanisms preserve database-specific replication and listener behavior. Backup still matters for PITR and long-term retention, but it is not the regional failover tool.
 
 </details>
 
 <details><summary>A quarterly restore test succeeds, but nobody records the recovery point, operator, elapsed time, or validation result. Did the test pass operationally?</summary>
 
-Not fully. The workload may have
-restored, but the platform lacks
-evidence for audit, trend analysis,
-and incident readiness. A passing
-recovery test should include the
-selected recovery point, elapsed
-restore time, validation checks,
-cleanup status, operator identity,
-blockers, and any follow-up work.
+Not fully. The workload may have restored, but the platform lacks evidence for audit, trend analysis, and incident readiness. A passing recovery test should include the selected recovery point, elapsed restore time, validation checks, cleanup status, operator identity, blockers, and any follow-up work.
 
 </details>
 
 ## Hands-On Exercise
 
-Exercise scenario: you will create a
-small Azure VM, protect it with Azure
-Backup in a Recovery Services vault,
-create a Backup vault to see the newer
-vault model, enable Azure-to-Azure
-Site Recovery for the same VM, run an
-isolated test failover, and clean up
-in the order that production operators
-need to understand. Use a
-non-production subscription and a
-region pair where your subscription
-has quota. The exact portal screens
-change over time, so the success
-criteria matter more than memorizing
-blade names.
+Exercise scenario: you will create a small Azure VM, protect it with Azure Backup in a Recovery Services vault, create a Backup vault to see the newer vault model, enable Azure-to-Azure Site Recovery for the same VM, run an isolated test failover, and clean up in the order that production operators need to understand. Use a non-production subscription and a region pair where your subscription has quota. The exact portal screens change over time, so the success criteria matter more than memorizing blade names.
 
-Before you start, install the Azure
-CLI on your workstation, sign in, and
-select the right subscription. The ASR
-portion is easiest through the Azure
-portal because it creates and
-validates several target resources.
-The CLI snippets below create the base
-resources and provide cleanup checks;
-use portal steps for backup policy and
-ASR enablement where noted.
+Before you start, install the Azure CLI on your workstation, sign in, and select the right subscription. The ASR portion is easiest through the Azure portal because it creates and validates several target resources. The CLI snippets below create the base resources and provide cleanup checks; use portal steps for backup policy and ASR enablement where noted.
 
 ```bash
 az login
@@ -1586,16 +406,7 @@ az account show --query "{name:name, id:id, tenant:tenantId}" -o table
 
 ### Step 1: Create the resource group and both vault types
 
-Create one lab resource group in the
-primary region. Create a Recovery
-Services vault for VM backup and Site
-Recovery. Create a Backup vault as the
-contrast point for newer backup
-workloads such as disks, blobs, and
-PostgreSQL long-term retention. If the
-`dataprotection` extension is missing,
-install it before creating the Backup
-vault.
+Create one lab resource group in the primary region. Create a Recovery Services vault for VM backup and Site Recovery. Create a Backup vault as the contrast point for newer backup workloads such as disks, blobs, and PostgreSQL long-term retention. If the `dataprotection` extension is missing, install it before creating the Backup vault.
 
 ```bash
 RG="rg-bcdr-operator-lab"
@@ -1630,30 +441,13 @@ az dataprotection backup-vault create \
 
 <details><summary>Solution notes for Step 1</summary>
 
-If the Backup vault command fails,
-check that the `dataprotection` CLI
-extension installed successfully and
-that the provider is registered. If
-the Recovery Services vault command
-succeeds but Backup vault creation
-fails, do not switch the VM backup to
-the Backup vault. That failure
-demonstrates the distinction between
-the two vault models rather than a
-reason to blur them.
+If the Backup vault command fails, check that the `dataprotection` CLI extension installed successfully and that the provider is registered. If the Recovery Services vault command succeeds but Backup vault creation fails, do not switch the VM backup to the Backup vault. That failure demonstrates the distinction between the two vault models rather than a reason to blur them.
 
 </details>
 
 ### Step 2: Create a small test VM
 
-Create a small Ubuntu VM in the
-primary region. Keep it inexpensive,
-but use a supported image and a public
-IP only if your lab policy allows it.
-In stricter environments, place the VM
-on a private subnet and connect
-through a bastion or existing jump
-path.
+Create a small Ubuntu VM in the primary region. Keep it inexpensive, but use a supported image and a public IP only if your lab policy allows it. In stricter environments, place the VM on a private subnet and connect through a bastion or existing jump path.
 
 ```bash
 VM="vm-bcdr-operator"
@@ -1677,29 +471,13 @@ az vm create \
 
 <details><summary>Solution notes for Step 2</summary>
 
-If your subscription lacks quota for
-`Standard_B1s`, choose the smallest
-allowed general-purpose size in your
-region. If policy blocks public IPs,
-create the VM in an approved VNet and
-use your normal private access path.
-The DR lesson does not depend on
-inbound internet access.
+If your subscription lacks quota for `Standard_B1s`, choose the smallest allowed general-purpose size in your region. If policy blocks public IPs, create the VM in an approved VNet and use your normal private access path. The DR lesson does not depend on inbound internet access.
 
 </details>
 
 ### Step 3: Enable Azure Backup with a daily policy and trigger a backup
 
-In the Azure portal, open the Recovery
-Services vault, choose Backup, select
-Azure VM as the datasource, and create
-a daily policy with seven-day
-retention for this lab VM. Enable
-backup for `vm-bcdr-operator`, then
-trigger an on-demand backup. Use the
-Backup jobs view to watch the job and
-the Backup items view to confirm a
-recovery point appears.
+In the Azure portal, open the Recovery Services vault, choose Backup, select Azure VM as the datasource, and create a daily policy with seven-day retention for this lab VM. Enable backup for `vm-bcdr-operator`, then trigger an on-demand backup. Use the Backup jobs view to watch the job and the Backup items view to confirm a recovery point appears.
 
 ```bash
 az backup item list \
@@ -1724,35 +502,13 @@ az backup job list \
 
 <details><summary>Solution notes for Step 3</summary>
 
-The first VM backup can take longer
-than later incremental backups because
-Azure must create the initial
-protected state. If no item appears,
-confirm that you selected the Recovery
-Services vault rather than the Backup
-vault. If the job fails, inspect the
-job details before retrying; backup
-job failure is exactly the kind of
-day-two signal this module expects
-operators to monitor.
+The first VM backup can take longer than later incremental backups because Azure must create the initial protected state. If no item appears, confirm that you selected the Recovery Services vault rather than the Backup vault. If the job fails, inspect the job details before retrying; backup job failure is exactly the kind of day-two signal this module expects operators to monitor.
 
 </details>
 
 ### Step 4: Enable Azure-to-Azure Site Recovery
 
-In the Azure portal, open the VM,
-select Disaster recovery, and choose
-the secondary region. Use the Recovery
-Services vault from Step 1. Let the
-wizard create target resources for the
-lab, or select explicit target
-resource groups, network, and cache
-storage if your subscription policy
-requires it. Start replication and
-wait for initial replication to
-complete; a small B1s VM commonly
-completes in a short lab window, but
-production disks can take much longer.
+In the Azure portal, open the VM, select Disaster recovery, and choose the secondary region. Use the Recovery Services vault from Step 1. Let the wizard create target resources for the lab, or select explicit target resource groups, network, and cache storage if your subscription policy requires it. Start replication and wait for initial replication to complete; a small B1s VM commonly completes in a short lab window, but production disks can take much longer.
 
 ```bash
 az backup vault show \
@@ -1777,34 +533,13 @@ az vm show \
 
 <details><summary>Solution notes for Step 4</summary>
 
-If replication does not start, inspect
-permissions, target quota, policy
-assignments, and unsupported VM
-features. If the VM has data disks,
-verify that all intended disks are
-included. If your network team
-requires pre-created target VNets, do
-that before enabling replication
-rather than accepting a wizard-created
-network that cannot pass a real test.
+If replication does not start, inspect permissions, target quota, policy assignments, and unsupported VM features. If the VM has data disks, verify that all intended disks are included. If your network team requires pre-created target VNets, do that before enabling replication rather than accepting a wizard-created network that cannot pass a real test.
 
 </details>
 
 ### Step 5: Run a test failover and clean it up
 
-From the Recovery Services vault or
-the replicated item, choose Test
-Failover. Select a recent recovery
-point and an isolated target network.
-Do not use the production target
-network for a casual drill unless the
-recovery plan explicitly says so.
-After the test VM boots, verify that
-the VM exists in the secondary region,
-check boot diagnostics or SSH if
-allowed, then complete test failover
-cleanup from the Site Recovery
-workflow.
+From the Recovery Services vault or the replicated item, choose Test Failover. Select a recent recovery point and an isolated target network. Do not use the production target network for a casual drill unless the recovery plan explicitly says so. After the test VM boots, verify that the VM exists in the secondary region, check boot diagnostics or SSH if allowed, then complete test failover cleanup from the Site Recovery workflow.
 
 ```bash
 az vm list \
@@ -1822,36 +557,13 @@ az vm list \
 
 <details><summary>Solution notes for Step 5</summary>
 
-If the test VM boots but the
-application is not healthy, treat that
-as a valuable failure. Check DNS,
-routes, NSGs, identity, Key Vault,
-package repositories, and any
-dependency that exists only in the
-primary region. If cleanup is still
-running, wait for the Site Recovery
-job to finish before deleting
-resources manually; manual deletion
-can leave replication metadata in an
-awkward state.
+If the test VM boots but the application is not healthy, treat that as a valuable failure. Check DNS, routes, NSGs, identity, Key Vault, package repositories, and any dependency that exists only in the primary region. If cleanup is still running, wait for the Site Recovery job to finish before deleting resources manually; manual deletion can leave replication metadata in an awkward state.
 
 </details>
 
 ### Step 6: Disable replication, stop backup, and delete safely
 
-Cleanup order matters. First, disable
-Site Recovery replication for the VM
-so the Recovery Services vault no
-longer has replicated items. Then stop
-backup for the VM and choose whether
-to retain or delete backup data. For a
-disposable lab, delete backup data,
-but notice the soft-delete behavior:
-recovery points or vaults may remain
-in a soft-deleted state until the
-retention window expires. Finally,
-delete the VM resources and the vaults
-when Azure allows it.
+Cleanup order matters. First, disable Site Recovery replication for the VM so the Recovery Services vault no longer has replicated items. Then stop backup for the VM and choose whether to retain or delete backup data. For a disposable lab, delete backup data, but notice the soft-delete behavior: recovery points or vaults may remain in a soft-deleted state until the retention window expires. Finally, delete the VM resources and the vaults when Azure allows it.
 
 ```bash
 az backup item list \
@@ -1877,19 +589,7 @@ az group delete \
 
 <details><summary>Solution notes for Step 6</summary>
 
-Recovery Services vault deletion fails
-while protected backup items,
-soft-deleted items, registered
-containers, or replicated Site
-Recovery items remain. That is
-intentional. In production, this
-behavior prevents a fast destructive
-cleanup from removing recoverability
-without evidence. For lab work, it
-means you may need to wait for
-soft-delete windows or follow the
-documented permanent-delete procedure
-if your policy permits it.
+Recovery Services vault deletion fails while protected backup items, soft-deleted items, registered containers, or replicated Site Recovery items remain. That is intentional. In production, this behavior prevents a fast destructive cleanup from removing recoverability without evidence. For lab work, it means you may need to wait for soft-delete windows or follow the documented permanent-delete procedure if your policy permits it.
 
 </details>
 
@@ -1928,10 +628,4 @@ if your policy permits it.
 
 ## Next Module
 
-Return to the [Azure Essentials
-index](../) until the next ordered
-module is assigned; the next
-operator-path topic should continue
-from business-continuity foundations
-into production integration,
-migration, or data movement.
+You have completed Azure Essentials. Continue to the [AKS Deep Dive](../../aks-deep-dive/) to run production Kubernetes on the Azure primitives you now understand.

--- a/src/content/docs/cloud/eks-deep-dive/module-5.1-eks-architecture.md
+++ b/src/content/docs/cloud/eks-deep-dive/module-5.1-eks-architecture.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 ## What You'll Be Able to Do
 
-This module is rated **[MEDIUM]** complexity with roughly **2.5 hours** of reading and lab time. You should be comfortable with [AWS Essentials](../../aws-essentials/) networking and IAM basics plus general [Cloud Architecture Patterns](../../architecture-patterns/) before diving into EKS control-plane design. After completing the module, you will be able to:
+This module is rated **[MEDIUM]** complexity with roughly **2.5 hours** of reading and lab time. You should be comfortable with [AWS Essentials](../../aws-essentials/) networking and IAM basics before diving into EKS control-plane design. [Cloud Architecture Patterns](../../architecture-patterns/) is a recommended companion, not required first. After completing the module, you will be able to:
 
 - **Configure EKS clusters with private API endpoints, managed node groups, and Fargate profiles for production workloads**
 - **Design EKS control plane connectivity (public, private, dual-stack) based on security and availability requirements**

--- a/src/content/docs/cloud/gke-deep-dive/module-6.1-gke-architecture.md
+++ b/src/content/docs/cloud/gke-deep-dive/module-6.1-gke-architecture.md
@@ -4,7 +4,7 @@ slug: cloud/gke-deep-dive/module-6.1-gke-architecture
 sidebar:
   order: 2
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2h | **Prerequisites**: GCP Essentials, Cloud Architecture Patterns — expect to run real `gcloud` commands against a billing-enabled project and delete clusters when finished.
+**Complexity**: [MEDIUM] | **Time to Complete**: 2h | **Prerequisites**: GCP Essentials — expect to run real `gcloud` commands against a billing-enabled project and delete clusters when finished. [Cloud Architecture Patterns](../../architecture-patterns/) is a recommended companion, not required first.
 
 ## What You'll Be Able to Do
 


### PR DESCRIPTION
Fixes the cloud-track route/navigation coherence defects from the s191 GLM cross-module coherence audit. Closes #2184, #2185, #2186.

## What & why

### #2184 (class A) — entry modules contradicted their own fixed indexes
The #2155 fix (Architecture Patterns downgraded to "recommended companion, not required first") landed only in the three deep-dive **indexes**. The entry modules still hard-required it, recreating the cycle. Reworded to match the indexes:
- `eks-deep-dive/module-5.1`, `gke-deep-dive/module-6.1`, `aks-deep-dive/module-7.1` — Architecture Patterns is now "a recommended companion, not required first."
- Blast-radius verified: 5.2–5.5 / 6.2–6.5 / 7.2–7.5 prereq on "Module X.1", not on Architecture Patterns — no residual offenders.

### #2186 (class A) — Architecture Patterns index reversed the hub route
- "What's Next" repointed **forward** to [Advanced Operations](../advanced-operations/) (it was sending learners *backward* into the provider deep dives, which the hub gates as a prerequisite).
- Prerequisites block reconciled with `cloud/index.md:78` — now names "at least one provider path first (Essentials → EKS/GKE/AKS)."
- **Review-fix (orchestrator):** the intro line ("Before diving into EKS/GKE/AKS you need to understand…") was self-contradictory with the new prereq/What's-Next; reworded so intro + prereq + What's-Next all agree with the hub (deep dives first, arch-patterns generalizes).

### #2185 (class M) — broken Azure/AKS navigation
- Azure `3.15` Next → `3.16` (was wrongly → **AWS**); `3.16` → `3.17`; `3.17` (terminal Azure Essentials) → **AKS Deep Dive** (hub route); `3.14` gains a real link → `3.15`.
- AKS `7.4` false "final module" claim removed; Next → `7.5` (Fleet Manager exists).
- `3.15/3.16/3.17` hard-wrapped narrow-column prose reflowed (mid-sentence line-joins only).
- AWS `1.3` sibling link `./module-1.4-s3/` → `../module-1.4-s3/`.

## Verification
- **Reflow is content-safe:** words retained 100.0% / 99.9% / 99.9% (3.15/3.16/3.17); code-fence / table-row / heading counts **identical** main↔branch (no table flattened, no code fence joined).
- `npm run build` — **0 errors**, 2169 pages.
- All 8 new nav link targets verified to resolve as files.
- Cross-family review: cursor/composer-2.5 author → opus (orchestrator inline) reviewer, per `docs/review-protocol.md`. Adversarial pass caught + fixed the intro contradiction.

## Deferred
#2187 (class M mechanical normalization: sidebar collisions, missing headers, complexity-marker format drift, stray frontmatter) is **not** in this PR — it belongs to the coordinated repo-wide mechanical pass (canonical marker format is locked repo-wide; half-converting cloud markers here = churn). Left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)