### PR TITLE
docs(cloud): fix stale hub module counts + broken What's-Next/Next-Module nav (#2156 #2157)

### DIFF
--- a/src/content/docs/cloud/architecture-patterns/module-4.4-vpc-topologies.md
+++ b/src/content/docs/cloud/architecture-patterns/module-4.4-vpc-topologies.md
@@ -483,7 +483,7 @@ k logs -n kube-system -l k8s-app=aws-node --tail=100
 
 ## Next Module
 
-*Next module coming soon.*
+Continue to [Advanced Operations](../../advanced-operations/) to scale these architectural decisions beyond a single cluster — multi-account strategies, transit-hub networking, cross-cluster service discovery, and disaster recovery at enterprise scale.
 
 ## Sources
 

--- a/src/content/docs/cloud/aws-essentials/index.md
+++ b/src/content/docs/cloud/aws-essentials/index.md
@@ -39,4 +39,4 @@ Not everything goes into Kubernetes. This track covers the core AWS services eve
 
 ## What's Next
 
-After AWS Essentials, continue to [Cloud Deep Dive: AWS EKS Mastery](../) for production Kubernetes on AWS.
+After AWS Essentials, continue to [AWS EKS Deep Dive](../eks-deep-dive/) for production Kubernetes on AWS.

--- a/src/content/docs/cloud/aws-essentials/module-1.13-data-ingestion.md
+++ b/src/content/docs/cloud/aws-essentials/module-1.13-data-ingestion.md
@@ -2218,7 +2218,4 @@ aws s3api delete-bucket --bucket "$BUCKET_NAME" --region "$AWS_REGION"
 
 ## Next Module
 
-Continue to
-[Cloud Deep Dive: AWS EKS Mastery](../) to
-apply AWS platform foundations to production
-Kubernetes on AWS.
+Continue to [AWS EKS Deep Dive](../eks-deep-dive/) to apply AWS platform foundations to production Kubernetes on AWS.

--- a/src/content/docs/cloud/index.md
+++ b/src/content/docs/cloud/index.md
@@ -15,13 +15,13 @@ Kubernetes doesn't exist in a vacuum. It runs on AWS, GCP, or Azure — and you 
 Rosetta Stone (cross-provider concepts)
         │
         ├─── AWS ──────────────────────────┐
-        │    Essentials (12) → EKS (5)     │
+        │    Essentials (13) → EKS (5)     │
         │                                  │
         ├─── Google Cloud ─────────────────┤
         │    Essentials (12) → GKE (5)     │
         │                                  │
         └─── Azure ────────────────────────┤
-             Essentials (12) → AKS (4)     │
+             Essentials (17) → AKS (5)     │
                                            │
                     ┌──────────────────────-┘
                     ▼
@@ -29,7 +29,7 @@ Rosetta Stone (cross-provider concepts)
         ├── Architecture Patterns (4)
         ├── Advanced Operations (10)
         ├── Managed Services (10)
-        └── Enterprise & Hybrid (10)
+        └── Enterprise & Hybrid (11)
 ```
 
 **Pick one provider deeply first** — you do not need all three. Learn the essentials for the cloud you actually use, then go deep on its managed Kubernetes offering before you spend time comparing clouds.
@@ -86,11 +86,11 @@ Equivalent depth means this:
 
 ## Sections
 
-### AWS (17 modules)
+### AWS (18 modules)
 
 | Section | Modules | Description |
 |---------|---------|-------------|
-| [AWS Essentials](aws-essentials/) | 12 | IAM, VPC, EC2, S3, Route53, ECR, ECS, Lambda, Secrets, CloudWatch, CI/CD, CloudFormation |
+| [AWS Essentials](aws-essentials/) | 13 | IAM, VPC, EC2, S3, Route53, ECR, ECS, Lambda, Secrets, CloudWatch, CI/CD, CloudFormation |
 | [EKS Deep Dive](eks-deep-dive/) | 5 | EKS architecture, networking, identity, autoscaling, production |
 
 ### Google Cloud (17 modules)
@@ -100,14 +100,14 @@ Equivalent depth means this:
 | [GCP Essentials](gcp-essentials/) | 12 | IAM, VPC, Compute, Cloud Storage, DNS, Artifact Registry, Cloud Run, Functions, Secret Manager, Monitoring, Cloud Build, Deployment Manager |
 | [GKE Deep Dive](gke-deep-dive/) | 5 | GKE architecture, networking, Workload Identity, Autopilot, Fleet |
 
-### Azure (16 modules)
+### Azure (22 modules)
 
 | Section | Modules | Description |
 |---------|---------|-------------|
-| [Azure Essentials](azure-essentials/) | 12 | Entra ID, VNet, VMs, Blob Storage, Azure DNS, ACR, ACI, Functions, Key Vault, Monitor, DevOps, Bicep |
-| [AKS Deep Dive](aks-deep-dive/) | 4 | AKS architecture, networking, identity, production |
+| [Azure Essentials](azure-essentials/) | 17 | Entra ID, VNet, VMs, Blob Storage, Azure DNS, ACR, ACI, Functions, Key Vault, Monitor, DevOps, Bicep |
+| [AKS Deep Dive](aks-deep-dive/) | 5 | AKS architecture, networking, identity, production |
 
-### Architecture & Enterprise (34 modules)
+### Architecture & Enterprise (36 modules)
 
 | Section | Modules | Description |
 |---------|---------|-------------|
@@ -115,9 +115,9 @@ Equivalent depth means this:
 | [Architecture Patterns](architecture-patterns/) | 4 | Managed vs self-managed, multi-cluster, cloud IAM, VPC topologies |
 | [Advanced Operations](advanced-operations/) | 10 | Multi-account, transit hubs, cross-cluster networking, DR, active-active |
 | [Managed Services](managed-services/) | 10 | Databases, caching, messaging, ML services, analytics |
-| [Enterprise & Hybrid](enterprise-hybrid/) | 10 | Landing zones, hybrid connectivity, compliance, migration, fleet management |
+| [Enterprise & Hybrid](enterprise-hybrid/) | 11 | Landing zones, hybrid connectivity, compliance, migration, fleet management |
 
-**84 modules total.** Not everything goes into Kubernetes — the essentials tracks cover standalone containers, serverless, and when K8s is overkill.
+**93 teachable units total** (92 modules + Hyperscaler Rosetta Stone). Not everything goes into Kubernetes — the essentials tracks cover standalone containers, serverless, and when K8s is overkill.
 
 ---
 


### PR DESCRIPTION
Cloud-track mechanical coherence fixes from the s191 GLM coherence audit. Closes #2156, closes #2157 (defects 1 & 2; defect 3 = marker-format normalization is out of scope, tracked with the repo-wide pass on #2151/#2141/#2146).

## #2156 — stale module counts in the cloud hub (`cloud/index.md`)
Every count reference (ASCII learning-path diagram, section headers, subsection tables, grand total) recomputed from the verified file tree and made mutually consistent:
- AWS Essentials 12→**13**, Azure Essentials 12→**17**, AKS 4→**5**, Enterprise & Hybrid 10→**11**.
- Section subtotals: AWS **18**, Azure **22**, Architecture & Enterprise **36** (Google 17 was already correct).
- Grand total "84 modules" → **93 teachable units** (92 `module-*.md` + the standalone Rosetta Stone).

## #2157 — broken navigation links
- **Defect 1:** AWS Essentials "What's Next" `[…AWS EKS Mastery](../)` (resolved to the track root) → `[AWS EKS Deep Dive](../eks-deep-dive/)`, fixed in both `aws-essentials/index.md` and `module-1.13-data-ingestion.md`.
- **Defect 2:** dead `*Next module coming soon.*` at the end of Architecture Patterns (`module-4.4`) → forward pointer to **Advanced Operations**, consistent with the arch-patterns index route just corrected in #2186.

## Verification
- Marker formats untouched (`git diff` shows only count lines + 3 nav links — the 3b normalization stays out).
- `npm run build` — **0 errors, 2169 pages** (local worktree build).
- Cross-family: cursor/composer-2.5 author → opus (orchestrator inline) reviewer; counts re-verified against disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Learner check

> The visible symptom is usually application pain, but the root cause is often VPC topology.

(Verbatim from the touched module `architecture-patterns/module-4.4-vpc-topologies.md`; the fix only re-pointed its dead Next-Module stub, leaving the teaching intact.)
