### PR TITLE
docs(linux,on-premises): fix cross-ref link identity + stale on-prem hub counts (#2154 #2168)

### DIFF
--- a/src/content/docs/linux/operations/module-8.4-scheduling-backups.md
+++ b/src/content/docs/linux/operations/module-8.4-scheduling-backups.md
@@ -19,7 +19,7 @@ lab:
 Before starting this module, make sure you are comfortable reading service state, interpreting basic filesystem layout, and thinking about Unix permissions. The examples use ordinary Linux paths and commands, but the operational judgment depends on knowing which user owns a job, which mount contains the data, and which service manager starts the work.
 - **Required**: [Module 1.2: Processes & systemd](/linux/foundations/system-essentials/module-1.2-processes-systemd/) for understanding services and unit files
 - **Required**: [Module 8.1: Storage Management](../module-8.1-storage-management/) for filesystem and mount point knowledge
-- **Helpful**: [Module 2.1: Users & Groups](../module-8.3-package-user-management/) for understanding file ownership and permissions
+- **Helpful**: [Module 8.3: Package & User Management](../module-8.3-package-user-management/) for understanding file ownership and permissions
 
 ## Learning Outcomes
 

--- a/src/content/docs/linux/operations/shell-scripting/module-7.4-devops-automation.md
+++ b/src/content/docs/linux/operations/shell-scripting/module-7.4-devops-automation.md
@@ -36,7 +36,7 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-The *Infrastructure as Code* module’s Knight Capital 2012 <!-- incident-xref: knight-capital-2012 --> reference is the canonical example that motivates this module: partial automation without strong state checks can make manual procedures slower, riskier, and much more expensive than intended.
+The [Infrastructure as Code](/prerequisites/modern-devops/module-1.1-infrastructure-as-code/) module’s Knight Capital 2012 <!-- incident-xref: knight-capital-2012 --> reference is the canonical example that motivates this module: partial automation without strong state checks can make manual procedures slower, riskier, and much more expensive than intended.
 
 The important lesson is not that shell scripts magically prevent incidents. A bad script can repeat a mistake faster than a person can type it, and a script without state checks can create a clean-looking audit trail while the platform is already broken. The lesson is that well-designed automation turns an operational procedure into something reviewable, repeatable, and testable. If the Knight deployment had required every server to report the expected version before trading traffic resumed, the missing machine would have been detected before the financial blast radius expanded.
 
@@ -809,7 +809,7 @@ One useful rule of thumb is to keep the first implementation close to the operat
 
 - The Bourne shell appeared in Version 7 Unix in 1979, and many of its error-handling defaults still influence modern Bash scripts used in CI/CD systems.
 - Kubernetes JSONPath support lets `kubectl` extract nested object fields without external tools, but `jq` remains stronger for filtering, restructuring, and calculating reports from full JSON documents.
-- The *Infrastructure as Code* module’s Knight Capital 2012 reference is where this class of blast-radius risk is taught with production stakes. <!-- incident-xref: knight-capital-2012 -->
+- The [Infrastructure as Code](/prerequisites/modern-devops/module-1.1-infrastructure-as-code/) module’s Knight Capital 2012 reference is where this class of blast-radius risk is taught with production stakes. <!-- incident-xref: knight-capital-2012 -->
 - The DORA research program has repeatedly linked elite software delivery performance with automation practices such as reliable deployments, fast recovery, and repeatable change validation.
 
 ## Common Mistakes

--- a/src/content/docs/on-premises/index.md
+++ b/src/content/docs/on-premises/index.md
@@ -20,7 +20,7 @@ Bare Metal Provisioning (4 modules)
         │
         ├── Networking (6 modules)
         ├── Storage (5 modules)
-        └── Multi-Cluster & Platform (5 modules)
+        └── Multi-Cluster & Platform (11 modules)
                 │
                 ▼
         Security & Compliance (8 modules)
@@ -43,13 +43,13 @@ Bare Metal Provisioning (4 modules)
 | [Bare Metal Provisioning](provisioning/) | 4 | PXE, MAAS, Talos, Sidero/Metal3 |
 | [Networking](networking/) | 6 | Spine-leaf, BGP, MetalLB, DNS/certs, cross-cluster, service mesh |
 | [Storage](storage/) | 5 | Ceph/Rook, local storage, object storage (MinIO), database operators |
-| [Multi-Cluster & Platform](multi-cluster/) | 5 | vSphere/OpenStack, vCluster/Kamaji, Cluster API, fleet management, active-active |
+| [Multi-Cluster & Platform](multi-cluster/) | 11 | vSphere/OpenStack, vCluster/Kamaji, Cluster API, fleet management, active-active |
 | [Security & Compliance](security/) | 8 | Air-gapped, HSM/TPM, AD/LDAP, SPIFFE, Vault, policy-as-code, zero-trust |
 | [Day-2 Operations](operations/) | 9 | Upgrades, firmware, observability, capacity, self-hosted CI/CD & registry, serverless |
 | [Resilience & Migration](resilience/) | 3 | Multi-site DR, hybrid connectivity, cloud repatriation |
 | [AI/ML Infrastructure](ai-ml-infrastructure/) | 6 | GPU nodes, private training, LLM serving, MLOps, AIOps, HPC storage |
 
-**51 modules total** (30 existing + 21 new from [#197](https://github.com/kube-dojo/kube-dojo.github.io/issues/197)). From "should we go on-prem?" to "how do we train LLMs on our own GPUs."
+**57 modules total** (expanded via [#197](https://github.com/kube-dojo/kube-dojo.github.io/issues/197)). From "should we go on-prem?" to "how do we train LLMs on our own GPUs."
 
 ---
 


### PR DESCRIPTION
Mechanical cross-reference + count fixes from the s191 GLM coherence audit. Closes #2154, closes #2168.

## #2154 — Linux operations cross-reference defects
- **Defect 1:** `operations/module-8.4-scheduling-backups.md` link text said "Module 2.1: Users & Groups" but the href points to Module 8.3 → text corrected to `[Module 8.3: Package & User Management]` (matches the href's real target).
- **Defect 2:** `operations/shell-scripting/module-7.4-devops-automation.md` named "the Infrastructure as Code module" with no link → linked to `/prerequisites/modern-devops/module-1.1-infrastructure-as-code/` at both occurrences.

## #2168 — stale module counts in the on-premises hub (`on-premises/index.md`)
- Multi-Cluster & Platform 5→**11** (ASCII tree + summary table), verified `find on-premises/multi-cluster -name 'module-*.md'` = 11.
- Grand total 51→**57** (the stale "30 existing + 21 new" arithmetic dropped since 30+21≠57). The other 8 subsections already summed to 46 → 57 total ✓.

## Verification
- Marker formats untouched (out of scope for 3b normalization).
- `npm run build` — **0 errors, 2169 pages** (local worktree build).
- Cross-family: cursor/composer-2.5 author → opus (orchestrator inline) reviewer; on-prem counts re-verified against disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Learner check

> The lesson is that well-designed automation turns an operational procedure into something reviewable, repeatable, and testable.

(Verbatim from the touched module `linux/operations/shell-scripting/module-7.4-devops-automation.md`; the fix only linked its Infrastructure-as-Code reference, leaving the teaching intact.)
