### PR TITLE
docs(k8s,prereq): remove dead LFCS three-pass link + fix philosophy prereq citation numbering (#2162 #2147)

### DIFF
--- a/src/content/docs/k8s/lfcs/index.md
+++ b/src/content/docs/k8s/lfcs/index.md
@@ -173,7 +173,7 @@ Just like CKA/CKAD, you get a terminal and must complete tasks. No multiple choi
 
 ### Time Management
 - **2 hours** for all tasks
-- Use the [Three-Pass Strategy](../../prerequisites/philosophy-design/):
+- Use the Three-Pass Strategy:
   - **Pass 1**: Quick wins — file creation, user management, basic commands
   - **Pass 2**: Medium tasks — filesystem, systemd, networking config
   - **Pass 3**: Complex tasks — LVM, NFS, firewall rules

--- a/src/content/docs/prerequisites/philosophy-design/module-1.3-what-we-dont-cover.md
+++ b/src/content/docs/prerequisites/philosophy-design/module-1.3-what-we-dont-cover.md
@@ -9,7 +9,7 @@ revision_pending: false
 >
 > **Time to Complete**: 35-45 minutes
 >
-> **Prerequisites**: Module 1, Module 2
+> **Prerequisites**: Module 1.1, Module 1.2
 
 ---
 

--- a/src/content/docs/prerequisites/philosophy-design/module-1.4-dead-ends.md
+++ b/src/content/docs/prerequisites/philosophy-design/module-1.4-dead-ends.md
@@ -10,7 +10,7 @@ sidebar:
 >
 > **Time to Complete**: 25-30 minutes.
 >
-> **Prerequisites**: Module 1, Module 2, Module 3.
+> **Prerequisites**: Module 1.1, Module 1.2, Module 1.3.
 
 ---
 


### PR DESCRIPTION
Mechanical coherence fixes from the s191 GLM coherence audit. Closes #2162, closes #2147.

## #2162 — LFCS "Three-Pass Strategy" dead/redundant link
`k8s/lfcs/index.md` linked "Three-Pass Strategy" to `prerequisites/philosophy-design/`, which contains **zero** three-pass content (verified), while the Pass 1/2/3 bullets are already inlined immediately below. Removed the dead link wrapper (`[Three-Pass Strategy](../../prerequisites/philosophy-design/)` → `Three-Pass Strategy`), keeping the inlined bullets.

## #2147 — philosophy-design prerequisite citations use wrong numbering
The section numbers modules 1.1–1.4 but two modules cited predecessors as "Module 1, Module 2, ..." (mismatching the section scheme every other subsection uses):
- `module-1.3-what-we-dont-cover.md`: `Module 1, Module 2` → `Module 1.1, Module 1.2`
- `module-1.4-dead-ends.md`: `Module 1, Module 2, Module 3` → `Module 1.1, Module 1.2, Module 1.3`

## Verification
- Marker formats untouched; 3 surgical line edits only.
- `npm run build` — **0 errors, 2169 pages** (local worktree build).
- Cross-family: cursor/composer-2.5 author → opus (orchestrator inline) reviewer; both premises ground-checked (grep confirmed philosophy-design has no three-pass content; citation scheme confirmed against sibling subsections).

## Learner check

> Docker Swarm, Apache Mesos, early Cloud Foundry, Chef, Puppet, Ansible, and Docker Compose each solved real problems for real teams.

(Verbatim from the touched module `prerequisites/philosophy-design/module-1.4-dead-ends.md`; the fix only corrected its prerequisite citation numbering, leaving the teaching intact.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)