### PR TITLE
docs(ai-ml): normalize phase self-labels + fix stale prereq refs to the hub contract (#2167 #2193 #2194)

### DIFF
--- a/src/content/docs/ai-ml-engineering/advanced-genai/index.md
+++ b/src/content/docs/ai-ml-engineering/advanced-genai/index.md
@@ -5,7 +5,7 @@ sidebar:
   label: "Advanced GenAI & Safety"
 ---
 
-> **AI/ML Engineering Track** | Phase 7
+> **AI/ML Engineering Track** | Phase 8
 
 **Best for:** learners who want deeper adaptation, evaluation, alignment, and local fine-tuning workflows after they already understand the basics.
 

--- a/src/content/docs/ai-ml-engineering/ai-infrastructure/module-1.1-cloud-ai-services.md
+++ b/src/content/docs/ai-ml-engineering/ai-infrastructure/module-1.1-cloud-ai-services.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 > **AI/ML Engineering Track** | Complexity: `[MEDIUM]` | Time: 5-6 hours
-**Prerequisites**: Phase 10 complete (DevOps & MLOps)
+**Prerequisites**: Phase 5 complete (MLOps & LLMOps)
 
 ## Learning Outcomes
 

--- a/src/content/docs/ai-ml-engineering/deep-learning/index.md
+++ b/src/content/docs/ai-ml-engineering/deep-learning/index.md
@@ -7,7 +7,7 @@ sidebar:
   label: "Deep Learning Foundations"
 ---
 
-> **AI/ML Engineering Track** | Phase 9 · 27 modules · ~70–110 hours
+> **AI/ML Engineering Track** | Phase 10 · 27 modules · ~70–110 hours
 
 ## Overview
 

--- a/src/content/docs/ai-ml-engineering/deep-learning/module-1.1-numpy-pandas-data-tooling.md
+++ b/src/content/docs/ai-ml-engineering/deep-learning/module-1.1-numpy-pandas-data-tooling.md
@@ -33,7 +33,7 @@ By the end of this module, you will:
 
 ## Introduction: The Scientific Python Ecosystem
 
-You've spent earlier modules building AI applications using APIs, frameworks, and high-level tools. Now we're going deeper. **Phase 6** is about understanding how neural networks actually work—not just using them, but building them from scratch.
+You've spent earlier modules building AI applications using APIs, frameworks, and high-level tools. Now we're going deeper. **Phase 10** is about understanding how neural networks actually work—not just using them, but building them from scratch.
 
 But before we can build neural networks, we need the right tools. Imagine trying to build a house with your bare hands versus having power tools. NumPy, pandas, and matplotlib are your power tools for machine learning.
 

--- a/src/content/docs/ai-ml-engineering/deep-learning/module-1.10-modern-transformers-rope-and-attention.md
+++ b/src/content/docs/ai-ml-engineering/deep-learning/module-1.10-modern-transformers-rope-and-attention.md
@@ -838,7 +838,7 @@ Success criteria:
 
 ## Next Module
 
-Continue to [Module 1.6: Memory Bandwidth Math](../ai-infrastructure/module-1.6-memory-bandwidth-math/) to complete the bandwidth budget for these architecture decisions before tuning production inference engines.
+Continue to [Machine Learning](../machine-learning/) to apply these foundations to tabular ML — the sklearn API, regression, trees, and evaluation.
 
 ## Sources
 

--- a/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.1-langchain-fundamentals.md
+++ b/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.1-langchain-fundamentals.md
@@ -9,7 +9,7 @@ sidebar:
 > **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 5-6 hours
 
 **Reading Time**: 6-7 hours  
-**Prerequisites**: Module 14, Python fundamentals, basic HTTP/API concepts, and beginner familiarity with LLM prompts.
+**Prerequisites**: Phase 3 complete (Vector Search & RAG), Python fundamentals, basic HTTP/API concepts, and beginner familiarity with LLM prompts.
 
 > **Go deeper:** For prompt interfaces, retrieval boundaries, and harness guardrails underlying LangChain pipelines, see [Prompt Fundamentals](/ai/ai-engineering-foundations/module-1.1-prompt-fundamentals/), [Retrieval, Tools, and Memory Boundaries](/ai/ai-engineering-foundations/module-2.3-retrieval-tools-and-memory-boundaries/), and [Guardrails, Gates, and Agent-Legible Apps](/ai/ai-engineering-foundations/module-3.2-guardrails-gates-and-agent-legible-apps/).
 

--- a/src/content/docs/ai-ml-engineering/history/index.md
+++ b/src/content/docs/ai-ml-engineering/history/index.md
@@ -5,7 +5,7 @@ sidebar:
   label: "Appendix A: History of AI/ML"
 ---
 
-> **AI/ML Engineering Track** | Phase 11
+> **AI/ML Engineering Track** | Appendix
 
 ## Modules
 

--- a/src/content/docs/ai-ml-engineering/machine-learning/index.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/index.md
@@ -7,7 +7,7 @@ sidebar:
   label: "Machine Learning"
 ---
 
-> **AI/ML Engineering Track**
+> **AI/ML Engineering Track** | Phase 11
 
 ## Overview
 

--- a/src/content/docs/ai-ml-engineering/mlops/module-1.1-ml-devops-foundations.md
+++ b/src/content/docs/ai-ml-engineering/mlops/module-1.1-ml-devops-foundations.md
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 > **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 5-6 Hours  
-> **Prerequisites**: Phase 9 complete
+> **Prerequisites**: Phase 4 complete (Frameworks & Agents)
 
 ## Learning Outcomes
 

--- a/src/content/docs/ai-ml-engineering/multimodal-ai/index.md
+++ b/src/content/docs/ai-ml-engineering/multimodal-ai/index.md
@@ -5,7 +5,7 @@ sidebar:
   label: "Multimodal AI"
 ---
 
-> **AI/ML Engineering Track** | Phase 8
+> **AI/ML Engineering Track** | Phase 9
 
 ## Modules
 

--- a/src/content/docs/ai-ml-engineering/multimodal-ai/module-1.1-voice-audio-ai.md
+++ b/src/content/docs/ai-ml-engineering/multimodal-ai/module-1.1-voice-audio-ai.md
@@ -8,7 +8,7 @@ sidebar:
 
 **Complexity**: Intermediate to Advanced  
 **Reading Time**: 7-8 hours
-**Prerequisites**: Phase 4 complete, basic Python, HTTP APIs, container images, and Kubernetes v1.35+ deployment knowledge.
+**Prerequisites**: Phase 8 complete, basic Python, HTTP APIs, container images, and Kubernetes v1.35+ deployment knowledge.
 
 ## Learning Outcomes
 

--- a/src/content/docs/ai-ml-engineering/reinforcement-learning/index.md
+++ b/src/content/docs/ai-ml-engineering/reinforcement-learning/index.md
@@ -7,7 +7,7 @@ sidebar:
   label: "Reinforcement Learning"
 ---
 
-> **AI/ML Engineering Track**
+> **AI/ML Engineering Track** | Phase 12
 
 ## Overview
 


### PR DESCRIPTION
Fixes a systemic renumbering defect surfaced by the GLM ai-ml-engineering coherence audit: the hub phase table was renumbered but per-phase index/module self-labels and some prereq refs weren't updated ("fix landed in one place, not the others"). Everything normalized to the hub contract (`ai-ml-engineering/index.md:78-90`). Closes #2167, closes #2193.

## #2167 — phase self-labels (each `> **AI/ML Engineering Track** | Phase N`)
- advanced-genai `Phase 7`→**8**, multimodal-ai `Phase 8`→**9**, deep-learning `Phase 9`→**10**
- history `Phase 11`→**Appendix** (it collided with Machine Learning = Phase 11)
- machine-learning **+Phase 11**, reinforcement-learning **+Phase 12** (both had omitted it)
- deep-learning `module-1.1` prose `**Phase 6**`→**10** (left `module-1.1.7`'s gradient-descent "Phase 1/2" alone — different meaning)

## #2193 — stale/dangling prereq refs (all cited later or nonexistent phases)
- ai-infrastructure 1.1 `Phase 10 complete (DevOps & MLOps)`→**`Phase 5 complete (MLOps & LLMOps)`**
- mlops 1.1 `Phase 9 complete`→**`Phase 4 complete (Frameworks & Agents)`**
- frameworks 1.1 `Module 14`→**`Phase 3 complete (Vector Search & RAG)`**
- multimodal 1.1 `Phase 4 complete`→**`Phase 8 complete`**

## #2194 (confirmed part) — deep-learning 1.10 backward Next-link
`Next Module` linked backward to ai-infrastructure (Phase 6); repointed **forward to Machine Learning (Phase 11)**.

## Ground-check notes (orchestrator)
- The hub table is internally consistent 0–12 → it's the source of truth; every "should be X" matches it (verified against each self-label, not assumed).
- **Rejected as a false positive:** GLM's "#2194 synthesis 3.1 GPU-scheduling dead link" — the target file exists, its `slug:` matches, and `../../platform/` is the established convention (4× used); the link resolves. **Left untouched.**
- Out of scope (separate passes): #2195 marker-format drift → infra #2151; #2196 K8s-in-early-phase content scope (genai 1.5) → content decision.

## Verification
- `npm run build` — **0 errors, 2169 pages** (local worktree build).
- Cross-family: cursor/composer-2.5 author → opus (orchestrator inline) reviewer.

## Learner check

> This module builds that discipline from first principles. You will start with the failure modes, then add version control for the right artifacts, then use tests to catch ML-specific defects, then place local safeguards before Git history, and finally run finite validation work on Kubernetes with the workload primitive that matches the job.

(Verbatim from the touched module `ai-ml-engineering/mlops/module-1.1-ml-devops-foundations.md`; the fix only corrected its prereq phase reference, leaving the teaching intact.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)