### PR TITLE
docs(ai-ml): fix route-coherence Next links + add missing header banners (#2194 #2196 #2195)

### DIFF
--- a/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.10-next-gen-agentic-frameworks.md
+++ b/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.10-next-gen-agentic-frameworks.md
@@ -640,7 +640,7 @@ Cap the Security Analyst's reply budget — in AutoGen this is `max_consecutive_
 
 Now that you understand how to orchestrate multiple agents, manage persistent state, and prevent catastrophic context exhaustion, it is time to deploy these complex systems into production environments. Operating agents locally is one thing; running them at scale is another. In the next module, we will explore the cloud infrastructure required to host multi-agent systems, dealing with asynchronous task queues, system observability, and managing the financial costs of autonomous API usage.
 
-**Continue to:** [AI Infrastructure](/ai-ml-engineering/ai-infrastructure/) — Explore the inference stacks, observability, and cost controls required to run complex agent systems in production.
+**Continue to:** [MLOps & LLMOps](/ai-ml-engineering/mlops/) — Operationalize your agents: CI/CD for ML, experiment tracking, deployment, and monitoring before you scale the inference stack.
 
 ## Sources
 

--- a/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.3-langgraph-for-agents.md
+++ b/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.3-langgraph-for-agents.md
@@ -1362,4 +1362,4 @@ print("Final State:", output)
 
 ## Next Module
 
-[Module 1.5 - Building AI Agents](./module-1.5-building-ai-agents/) - Move from framework components to full agent architectures, orchestration patterns, and production-ready design tradeoffs that combine prompts, tools, memory, routing, and runtime safeguards.
+[Module 1.4 - LlamaIndex](./module-1.4-llamaindex/) - Add a purpose-built data framework for RAG and knowledge-intensive agents: ingestion, indexing, and query engines on top of the LangChain/LangGraph foundations you just built.

--- a/src/content/docs/ai-ml-engineering/generative-ai/module-1.5-vector-space-visualization.md
+++ b/src/content/docs/ai-ml-engineering/generative-ai/module-1.5-vector-space-visualization.md
@@ -5,6 +5,10 @@ sidebar:
   order: 306
 ---
 
+> **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 5-6 hours
+>
+> **Prerequisites**: Embeddings and semantic search fundamentals (module 1.4), Python with NumPy/scikit-learn, basic linear algebra, and familiarity with vector similarity metrics.
+
 ## Learning Outcomes
 
 By the end of this intensive module, you will be capable of the following advanced engineering tasks:

--- a/src/content/docs/ai-ml-engineering/generative-ai/module-1.6-reasoning-models.md
+++ b/src/content/docs/ai-ml-engineering/generative-ai/module-1.6-reasoning-models.md
@@ -5,6 +5,10 @@ sidebar:
   order: 307
 ---
 
+> **AI/ML Engineering Track** | Complexity: `[ADVANCED]` | Time: 4-5 hours
+>
+> **Prerequisites**: Prior generative AI modules on model APIs and prompting, production LLM integration experience, and comfort reading token-usage and latency metrics.
+
 ## Learning Outcomes
 
 By the end of this module, you will be able to:

--- a/src/content/docs/ai-ml-engineering/prerequisites/module-1.2-home-ai-workstation-fundamentals.md
+++ b/src/content/docs/ai-ml-engineering/prerequisites/module-1.2-home-ai-workstation-fundamentals.md
@@ -611,7 +611,6 @@ Write one final paragraph using this format: "For the next stage, I will choose 
 
 - [Reproducible Python, CUDA, and ROCm Environments](./module-1.3-reproducible-python-cuda-rocm-environments/)
 - [Notebooks, Scripts, and Project Layouts](./module-1.4-notebooks-scripts-project-layouts/)
-- [Local Models for AI Coding](../ai-native-development/module-1.2-local-models-for-ai-coding/)
 
 ## Sources
 

--- a/src/content/docs/ai-ml-engineering/prerequisites/module-1.4-notebooks-scripts-project-layouts.md
+++ b/src/content/docs/ai-ml-engineering/prerequisites/module-1.4-notebooks-scripts-project-layouts.md
@@ -1050,9 +1050,11 @@ After completing the exercise, compare your result with the worked example in th
 
 ## Next Module
 
+- [AI-Native Development](../ai-native-development/) — the next phase in the default route: bring local models and AI-assisted coding into your daily workflow.
+
+Optional later-phase deep-dives (after you complete Phases 1–4):
 - [Home-Scale RAG Systems](../vector-rag/module-1.6-home-scale-rag-systems/)
 - [Notebooks to Production for ML/LLMs](../mlops/module-1.11-notebooks-to-production-for-ml-llms/)
-- [Experiment Tracking](../mlops/module-1.6-experiment-tracking/)
 
 ## Sources
 

--- a/src/content/docs/ai-ml-engineering/vector-rag/module-1.2-building-rag-systems.md
+++ b/src/content/docs/ai-ml-engineering/vector-rag/module-1.2-building-rag-systems.md
@@ -5,6 +5,10 @@ sidebar:
   order: 403
 ---
 
+> **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 5-6 hours
+>
+> **Prerequisites**: Vector databases and embeddings (module 1.1), Python, LLM API usage, and basic document chunking concepts.
+
 ## Learning Outcomes
 
 When you finish this module, you will be able to design, implement, evaluate, and debug complete Retrieval-Augmented Generation pipelines rather than treating retrieval as a black-box library call. The learning outcomes below map directly to the hands-on lab and knowledge check at the end of the module. Each outcome corresponds to a phase of the ingest→retrieve→generate loop you will assemble in code, instrument in metrics, and defend in production reviews.

--- a/src/content/docs/ai-ml-engineering/vector-rag/module-1.3-advanced-rag-patterns.md
+++ b/src/content/docs/ai-ml-engineering/vector-rag/module-1.3-advanced-rag-patterns.md
@@ -5,6 +5,10 @@ sidebar:
   order: 404
 ---
 
+> **AI/ML Engineering Track** | Complexity: `[ADVANCED]` | Time: 4-5 hours
+>
+> **Prerequisites**: A working RAG pipeline from module 1.2, embeddings and hybrid retrieval basics, Python, and familiarity with BM25 and cross-encoder reranking concepts.
+
 ## Learning Outcomes
 
 By the end of this module, you will be able to:

--- a/src/content/docs/ai-ml-engineering/vector-rag/module-1.4-rag-evaluation-optimization.md
+++ b/src/content/docs/ai-ml-engineering/vector-rag/module-1.4-rag-evaluation-optimization.md
@@ -5,6 +5,10 @@ sidebar:
   order: 405
 ---
 
+> **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 4-5 hours
+>
+> **Prerequisites**: RAG architecture from modules 1.2–1.3, Python, labeled evaluation datasets, and basic information-retrieval metrics (recall, precision, ranking).
+
 ## What You'll Be Able to Do
 
 By the end of this module, you will be able to evaluate and improve Retrieval-Augmented Generation systems with the same discipline you would apply to search, reliability, and production software changes. These outcomes focus on measurement, diagnosis, and controlled iteration rather than on adding more retrieval patterns by instinct.

--- a/src/content/docs/ai-ml-engineering/vector-rag/module-1.5-long-context-prompt-caching.md
+++ b/src/content/docs/ai-ml-engineering/vector-rag/module-1.5-long-context-prompt-caching.md
@@ -5,6 +5,10 @@ sidebar:
   order: 406
 ---
 
+> **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 3-4 hours
+>
+> **Prerequisites**: RAG fundamentals (modules 1.2+), LLM API integration, prompt-structure discipline, and basic cost/latency observability for inference workloads.
+
 ## Learning Outcomes
 
 By the end of this module, you will be able to:


### PR DESCRIPTION
## What

Mechanical route-coherence + missing-header pass on the **ai-ml-engineering** track (s193 continuation of the GLM coherence workstream). 10 files, no teaching prose/code altered.

### Navigation / route fixes (respect the hub Default Route: Prerequisites → AI-Native Development → Generative AI → Vector Search & RAG → Frameworks & Agents → MLOps & LLMOps → AI Infrastructure → Synthesis Apps)
- `frameworks-agents/module-1.10` Continue-to → **MLOps & LLMOps** (was AI Infrastructure — skipped Phase 5 entirely). **#2194 part 1**
- `frameworks-agents/module-1.3` Next → **1.4 LlamaIndex** (was skipping to 1.5, orphaning 1.4). **#2194 part 2**
- `prerequisites/module-1.4` (Phase-0 terminus) Next → **AI-Native Development** primary; later-phase RAG/MLOps links demoted to explicit optional. **#2196 part 1**
- `prerequisites/module-1.2` Next → dropped the mid-Phase-0 jump to Phase 1; keeps in-phase 1.3/1.4. **#2196 part 1**

### Missing Complexity/Time/Prerequisites banners added (canonical tiers only)
- `generative-ai/1.5`, `generative-ai/1.6`, `vector-rag/1.2`, `vector-rag/1.3`, `vector-rag/1.4`, `vector-rag/1.5` — each gained a banner matching the modal sibling format, using `[COMPLEX]`/`[ADVANCED]` (no bare "Intermediate"). **#2195 part 1**

## Resolution status
- **#2194** — fully resolved (part 1+2 here; part 3 GPU-scheduling "dead link" was a false positive rejected in s192 on file+slug+convention; part 4 DL 1.10 already fixed). → Closes.
- **#2196** — part 1 (Phase-0 nav) done here; **part 2** (genai 1.5 K8s-v1.35 overreach, a class-B audience decision) tracked separately. → stays open.
- **#2195** — part 1 (6 headers) done here; **part 2** (track-wide complexity-marker canonicalization, ~450 files) is the infra-lane marker-normalization task. → stays open.

## Verification
- Build green: 2169 pages, 0 errors.
- Cross-family review: cursor (Kimi) author → **codex (OpenAI) R1: APPROVE**, zero findings; every nav target independently verified to resolve on disk, route order confirmed, no teaching content altered.

Closes #2194

🤖 Generated with [Claude Code](https://claude.com/claude-code)