### PR TITLE
fix(dispatch): capture opencode run via --format json for clean agentic output (#2171)

### DIFF
--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -517,6 +517,65 @@ def _opencode_binary() -> str:
     )
 
 
+def _parse_opencode_json_events(stdout: str) -> str:
+    """Extract the final assistant message from opencode ``--format json`` NDJSON.
+
+  Empirical schema (opencode run --format json, one JSON object per line):
+
+  - ``step_start``: agent turn begins; ``part.messageID`` identifies the turn.
+  - ``tool_use``: tool invocation; ignore for response capture.
+  - ``text``: assistant output chunk; final text is in ``part.text``.
+  - ``step_finish``: turn ends; ``part.reason`` is ``stop`` (final reply) or
+    ``tool-calls`` (intermediate turn).
+
+  Concatenate all ``text`` chunks for the message whose ``step_finish`` has
+  ``reason=stop``. Fall back to the last message that emitted text.
+  """
+    texts_by_message: dict[str, list[str]] = {}
+    message_order: list[str] = []
+    final_message_id: str | None = None
+
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+
+        event_type = event.get("type")
+        part = event.get("part")
+        if not isinstance(part, dict):
+            part = {}
+
+        if event_type == "text":
+            text = part.get("text")
+            if not isinstance(text, str) or not text:
+                continue
+            message_id = part.get("messageID")
+            if not isinstance(message_id, str):
+                message_id = ""
+            if message_id not in texts_by_message:
+                message_order.append(message_id)
+            texts_by_message.setdefault(message_id, []).append(text)
+        elif event_type == "step_finish" and part.get("reason") == "stop":
+            message_id = part.get("messageID")
+            if isinstance(message_id, str):
+                final_message_id = message_id
+
+    if final_message_id and final_message_id in texts_by_message:
+        return "".join(texts_by_message[final_message_id]).strip()
+
+    for message_id in reversed(message_order):
+        chunks = texts_by_message.get(message_id)
+        if chunks:
+            return "".join(chunks).strip()
+    return ""
+
+
 def _hermes_binary() -> str:
     """Resolve the hermes CLI path with an env override for local installs."""
     return (
@@ -571,7 +630,16 @@ def _hermes_cli_model(model: str) -> str:
 def _router_command(agent: str, model: str, prompt: str) -> list[str]:
     """Build the subprocess command for direct router CLIs."""
     if agent == "opencode":
-        return [_opencode_binary(), "run", "-m", model, "-"]
+        # ``--format json`` emits NDJSON events instead of ANSI TUI output.
+        # Reasoning effort can be overridden via opencode's ``--variant`` flag
+        # (e.g. high, max, minimal); plumb with dispatch_smart ``--variant``
+        # or ``KUBEDOJO_OPENCODE_VARIANT`` when we need per-task effort control.
+        cmd = [_opencode_binary(), "run", "--format", "json"]
+        variant = os.environ.get("KUBEDOJO_OPENCODE_VARIANT", "").strip()
+        if variant:
+            cmd.extend(["--variant", variant])
+        cmd.extend(["-m", model, "-"])
+        return cmd
     if agent == "cursor":
         return [
             _cursor_binary(),
@@ -602,6 +670,16 @@ def _router_command(agent: str, model: str, prompt: str) -> list[str]:
     raise ValueError(f"unsupported direct router agent: {agent}")
 
 
+def _router_subprocess_env(agent: str) -> dict[str, str]:
+    """Return env overrides for direct router CLIs."""
+    env = os.environ.copy()
+    if agent == "opencode":
+        # Prevent git tool calls from paging or blocking on credentials.
+        env.setdefault("GIT_PAGER", "cat")
+        env.setdefault("GIT_TERMINAL_PROMPT", "0")
+    return env
+
+
 def _run_router_agent(
     *,
     agent: str,
@@ -620,6 +698,7 @@ def _run_router_agent(
             cmd,
             input=stdin_payload,
             cwd=cwd,
+            env=_router_subprocess_env(agent),
             text=True,
             capture_output=True,
             check=False,
@@ -632,8 +711,12 @@ def _run_router_agent(
     except OSError as exc:
         return False, "", f"{type(exc).__name__}: {exc}"
 
-    response = proc.stdout or ""
+    raw_stdout = proc.stdout or ""
     stderr = proc.stderr or ""
+    if agent == "opencode":
+        response = _parse_opencode_json_events(raw_stdout)
+    else:
+        response = raw_stdout.strip()
     ok = proc.returncode == 0 and bool(response.strip())
     if not ok and not stderr.strip():
         stderr = f"{agent} exited {proc.returncode} with no stdout"

--- a/tests/test_dispatch_smart.py
+++ b/tests/test_dispatch_smart.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -73,6 +74,84 @@ def test_hermes_router_argv_handles_flag_like_prompt() -> None:
     argv = _router_command("hermes", "qwen-3.6-flash", "--provider")
     assert "--oneshot=--provider" in argv
     assert "-z" not in argv
+
+
+def test_opencode_router_argv_uses_json_format() -> None:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    from dispatch_smart import _router_command
+
+    cmd = _router_command("opencode", "zai-coding-plan/glm-5.2", "hello")
+    assert cmd[1:4] == ["run", "--format", "json"]
+    assert cmd[-3:] == ["-m", "zai-coding-plan/glm-5.2", "-"]
+
+
+def test_parse_opencode_json_events_extracts_final_assistant_text() -> None:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    from dispatch_smart import _parse_opencode_json_events
+
+    ndjson = "\n".join(
+        [
+            json.dumps(
+                {
+                    "type": "step_start",
+                    "part": {"messageID": "msg_tool", "type": "step-start"},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "tool_use",
+                    "part": {"messageID": "msg_tool", "type": "tool", "tool": "bash"},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "step_finish",
+                    "part": {
+                        "messageID": "msg_tool",
+                        "reason": "tool-calls",
+                        "type": "step-finish",
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "step_start",
+                    "part": {"messageID": "msg_final", "type": "step-start"},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "text",
+                    "part": {
+                        "messageID": "msg_final",
+                        "type": "text",
+                        "text": "VERDICT: ",
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "text",
+                    "part": {
+                        "messageID": "msg_final",
+                        "type": "text",
+                        "text": "APPROVE",
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "step_finish",
+                    "part": {
+                        "messageID": "msg_final",
+                        "reason": "stop",
+                        "type": "step-finish",
+                    },
+                }
+            ),
+        ]
+    )
+    assert _parse_opencode_json_events(ndjson) == "VERDICT: APPROVE"
 
 
 def test_codex_draft_default_is_gpt_5_5() -> None:


### PR DESCRIPTION
## What
Clean, **pure-infra** re-cut of #2188 — hardens OpenCode headless capture in `scripts/dispatch_smart.py`. Switches `opencode run` to `--format json`, parses the JSON events for the final assistant message, and sets a non-paging git env. Fixes GLM-via-OpenCode reviews returning ANSI/TUI-polluted, truncated output (the s191 bug).

## Why this supersedes #2188
#2188's branch sat on top of an already-merged linux content commit, so it carried 7 stray `src/content/docs/linux/**` files (a no-op dup). This branch is a clean cherry-pick of the fix commit only — the diff is exactly two files:
- `scripts/dispatch_smart.py` (+87/-2 — the `--format json` capture + NDJSON parser + non-paging env)
- `tests/test_dispatch_smart.py` (+79 — asserts the `["run","--format","json"]` prefix + exercises the parser)

No curriculum content touched.

## Verification
- `pytest tests/test_dispatch_smart.py` → **11 passed**; `ruff` clean.
- The identical infra change already carried a cross-family **APPROVE** review under #2188 (opencode `--format json` capture path verified against `_parse_opencode_json_events`).

## Lane
⚠ **INFRA-LANE** — touches `scripts/dispatch_smart.py`. Needs infra-orchestrator gate before merge.

## Follow-up (post-merge)
Depth re-test: `dispatch_smart review --agent opencode --model zai-coding-plan/glm-5.2` on a small diff → confirm a clean, complete verdict. If GLM-via-OpenCode reaches UI-depth, it graduates into the automated headless-audit lane. Local-only (China-hosted → never CI).

Refs #2171. Supersedes #2188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)