### PR TITLE
docs(platform): fix 18 dead/stale Next links + IPv6-tail nav + framing/prereq (#2199 #2201 #2202)

### DIFF
--- a/src/content/docs/platform/disciplines/data-ai/data-engineering/module-1.2-kafka.md
+++ b/src/content/docs/platform/disciplines/data-ai/data-engineering/module-1.2-kafka.md
@@ -7,6 +7,16 @@ revision_pending: false
 ---
 > **Discipline Module** | Complexity: `[COMPLEX]` | Time: 3.5 hours
 
+## Prerequisites
+
+Before starting this module:
+- **Required**: [Module 1.1 — Stateful Workloads & Storage](../module-1.1-stateful-workloads/) — StatefulSets, PVCs, and operator patterns for stateful systems
+- **Required**: Kubernetes Storage fundamentals — PersistentVolumes, PersistentVolumeClaims, StorageClasses
+- **Required**: Kubernetes Jobs and CronJobs
+- **Recommended**: Familiarity with event-driven architecture, replication, partitioning, and basic streaming concepts
+
+---
+
 ## What You'll Be Able to Do
 
 After completing this module, you will be able to:

--- a/src/content/docs/platform/disciplines/data-ai/data-engineering/module-1.6-lakehouse.md
+++ b/src/content/docs/platform/disciplines/data-ai/data-engineering/module-1.6-lakehouse.md
@@ -1392,7 +1392,7 @@ This is the promise of the lakehouse: warehouse-grade reliability, lake-scale ec
 
 ## Next Module
 
-[Module 1.7 — Data Orchestration with Apache Airflow on Kubernetes](../module-1.7-airflow/) — Learn to build, schedule, and monitor complex data pipelines that span your lakehouse components
+[Module 1.7 — Event Streaming Fundamentals](../module-1.7-event-streaming-fundamentals/) — Learn the streaming mental model—logs, partitions, ordering, backpressure, and replay—that underpins lakehouse ingestion pipelines
 
 ---
 

--- a/src/content/docs/platform/disciplines/data-ai/data-engineering/module-1.7-event-streaming-fundamentals.md
+++ b/src/content/docs/platform/disciplines/data-ai/data-engineering/module-1.7-event-streaming-fundamentals.md
@@ -1025,4 +1025,4 @@ Your record should include the decision and the risk that would make you revisit
 
 ## Next Module
 
-Continue to [Module 1.2: Apache Kafka on Kubernetes (Strimzi)](../module-1.2-kafka/) to deploy and operate Kafka after you understand the streaming mental model.
+Continue to [Module 1.8: CloudEvents and Event-Driven Architecture](../module-1.8-cloudevents-event-driven-arch/) to design event contracts and Kubernetes delivery paths on top of the streaming mental model.

--- a/src/content/docs/platform/disciplines/data-ai/data-engineering/module-1.8-cloudevents-event-driven-arch.md
+++ b/src/content/docs/platform/disciplines/data-ai/data-engineering/module-1.8-cloudevents-event-driven-arch.md
@@ -1138,4 +1138,4 @@ Build a small CloudEvents path for `order-placed` events in a Kubernetes 1.35+ c
 
 ## Next Module
 
-You've completed the Data Engineering track. Continue to the [MLOps discipline](../../mlops/) — [Module 5.1 — MLOps Fundamentals](../../mlops/module-5.1-mlops-fundamentals/) builds on these event-driven foundations when ML pipelines need to react to data-arrival events and emit prediction-emitted CloudEvents downstream. If you want to revisit stateful stream processing with the contracts from this module, return to [Module 1.3 — Stream Processing with Flink](../module-1.3-flink/).
+Continue to [Module 1.9 — NATS JetStream on Kubernetes](../module-1.9-nats-jetstream/) to run production NATS JetStream with streams, consumers, security, and observability. After finishing the Data Engineering sub-track, continue to the [MLOps discipline](../../mlops/) — [Module 5.1 — MLOps Fundamentals](../../mlops/module-5.1-mlops-fundamentals/) builds on these event-driven foundations when ML pipelines need to react to data-arrival events and emit prediction-emitted CloudEvents downstream.

--- a/src/content/docs/platform/disciplines/data-ai/mlops/module-5.6-ml-pipelines.md
+++ b/src/content/docs/platform/disciplines/data-ai/mlops/module-5.6-ml-pipelines.md
@@ -1471,7 +1471,7 @@ You have completed this exercise when you can verify every item in the checklist
 - [ ] You can describe why model promotion should compare against a production baseline.
 - [ ] You can explain what evidence an incident responder needs from a model registry.
 ## Next Module
-The MLOps discipline sequence is complete. Next, move from discipline theory into implementation choices with the [ML Platforms Toolkit](/platform/toolkits/data-ai-platforms/ml-platforms/).
+Continue to [Module 5.7: Data Versioning with DVC](../module-5.7-dvc-data-versioning/) to version datasets and tie data changes to pipeline reproducibility.
 
 ## Sources
 - [kubeflow-pipelines.readthedocs.io: dsl.html](https://kubeflow-pipelines.readthedocs.io/en/latest/source/dsl.html) — The KFP DSL reference directly documents `kfp.dsl.component` as the decorator for Python-function-based components.

--- a/src/content/docs/platform/disciplines/data-ai/mlops/module-5.7-dvc-data-versioning.md
+++ b/src/content/docs/platform/disciplines/data-ai/mlops/module-5.7-dvc-data-versioning.md
@@ -1053,7 +1053,7 @@ DVC can record the validation artifact and decide what must rerun. Meanwhile, gr
 
 ## Next Module
 
-*Next module coming soon.*
+Continue to [Module 5.8: Great Expectations Data Quality](../module-5.8-great-expectations-data-quality/) to define data-quality contracts and gate pipeline stages on validation results.
 ## Sources
 
 - [DVC command reference: `init`](https://dvc.org/doc/command-reference/init) - Official behavior for initializing a DVC project and creating `.dvc/` configuration and cache structure.

--- a/src/content/docs/platform/disciplines/reliability-security/chaos-engineering/module-1.1-chaos-principles.md
+++ b/src/content/docs/platform/disciplines/reliability-security/chaos-engineering/module-1.1-chaos-principles.md
@@ -11,7 +11,7 @@ revision_pending: false
 
 Before starting this module:
 - **Required**: [Kubernetes Basics](/prerequisites/kubernetes-basics/) — Core cluster concepts and workloads
-- **Required**: [Release Engineering](/platform/disciplines/core-platform/sre/) — Understanding deployment pipelines and rollbacks
+- **Required**: [Release Engineering](/platform/disciplines/delivery-automation/release-engineering/) — Understanding deployment pipelines and rollbacks
 - **Recommended**: Experience operating at least one production system
 - **Recommended**: Familiarity with monitoring concepts (Prometheus, Grafana)
 

--- a/src/content/docs/platform/disciplines/reliability-security/chaos-engineering/module-1.5-automating-chaos.md
+++ b/src/content/docs/platform/disciplines/reliability-security/chaos-engineering/module-1.5-automating-chaos.md
@@ -1332,7 +1332,7 @@ Key takeaways:
 
 ## Next Module
 
-Return to the [Chaos Engineering README]() to review the complete discipline, explore further reading, and find links to related platform engineering tracks.
+Return to the [Chaos Engineering README](../) to review the complete discipline, explore further reading, and find links to related platform engineering tracks.
 
 ## Sources
 

--- a/src/content/docs/platform/foundations/advanced-networking/index.md
+++ b/src/content/docs/platform/foundations/advanced-networking/index.md
@@ -32,4 +32,4 @@ Kubernetes networking gets you pod-to-pod communication. But production traffic 
 
 - Basic DNS and HTTP knowledge
 - Kubernetes Ingress/Services (from CKA or Fundamentals)
-- Linux networking basics (from Linux Deep Dive)
+- Linux networking basics (from [Linux Networking](/linux/foundations/networking/))

--- a/src/content/docs/platform/foundations/advanced-networking/module-1.7-ipv6-fundamentals.md
+++ b/src/content/docs/platform/foundations/advanced-networking/module-1.7-ipv6-fundamentals.md
@@ -787,7 +787,7 @@ sudo bpftrace -e 'tracepoint:ipv6:ipv6_deliver { @[comm] = count(); } interval:s
 
 ## Next Module
 
-The canonical follow-on is the planned [Dual-stack K8s Setup module in issue #1523](https://github.com/kube-dojo/kube-dojo.github.io/issues/1523), which will layer Kubernetes-specific Services, Pod CIDRs, and cluster rollout mechanics on top of these foundations. Until that lands, use the upstream [Kubernetes dual-stack networking overview](https://kubernetes.io/docs/concepts/services-networking/dual-stack/) as a reference, not as this module’s main teaching path.
+Continue to [Module 1.8: Dual-Stack Kubernetes Setup & Operations](../module-1.8-dual-stack-k8s/) to configure dual-stack Services, Pod CIDRs, and cluster rollout mechanics on top of these IPv6 foundations.
 
 ## Sources
 

--- a/src/content/docs/platform/foundations/advanced-networking/module-1.8-dual-stack-k8s.md
+++ b/src/content/docs/platform/foundations/advanced-networking/module-1.8-dual-stack-k8s.md
@@ -858,4 +858,4 @@ kind delete cluster --name dualstack-dojo
 
 ## Next Module
 
-Use the upstream [Kubernetes dual-stack validation task](https://kubernetes.io/docs/tasks/network/validate-dual-stack/) as the operational follow-on while the later IPv6-only Kubernetes migration module is planned.
+Continue to [Module 1.9: IPv6-Only Kubernetes & Brownfield Migration](../module-1.9-ipv6-only-k8s/) to plan NAT64/DNS64, IPv6-only CNI, and brownfield migration paths.

--- a/src/content/docs/platform/foundations/advanced-networking/module-1.9-ipv6-only-k8s.md
+++ b/src/content/docs/platform/foundations/advanced-networking/module-1.9-ipv6-only-k8s.md
@@ -845,4 +845,4 @@ The `127.0.0.1` address is an IPv4 loopback literal. In an IPv6-only Pod's netwo
 
 ## Next Module
 
-Use the upstream [Kubernetes validate dual-stack task](https://kubernetes.io/docs/tasks/network/validate-dual-stack/) as a hands-on operational check until the Advanced Networking capstone module is available. For advanced routing topics, see [Module 1.4: BGP & Core Routing](module-1.4-bgp-routing/).
+You have completed the Advanced Networking track. Return to the [Advanced Networking overview](../) to review the full module sequence, or explore [Platform Engineering](/platform/) for persona-based next steps.

--- a/src/content/docs/platform/foundations/systems-thinking/module-1.1-what-is-systems-thinking.md
+++ b/src/content/docs/platform/foundations/systems-thinking/module-1.1-what-is-systems-thinking.md
@@ -5,7 +5,7 @@ sidebar:
   order: 2
 revision_pending: false
 ---
-> **Complexity**: `[MEDIUM]` | **Time**: 50-65 minutes | **Prerequisites**: None (entry point to Platform track)
+> **Complexity**: `[MEDIUM]` | **Time**: 50-65 minutes | **Prerequisites**: None (a natural starting point for the Platform foundations)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/platform/toolkits/data-ai-platforms/cloud-native-databases/module-15.4-vitess.md
+++ b/src/content/docs/platform/toolkits/data-ai-platforms/cloud-native-databases/module-15.4-vitess.md
@@ -1000,6 +1000,8 @@ kubectl delete secret commerce-schema
 
 ## Next Module
 
+Continue to [Module 15.5: etcd-operator](../module-15.5-etcd-operator/) — the final module in this toolkit — to manage etcd clusters that back Kubernetes and other distributed control planes.
+
 - **Related**: [Module 15.3: PlanetScale](../module-15.3-serverless-databases/) — Managed Vitess experience
 - **Related**: [Distributed Systems Foundation](/platform/foundations/distributed-systems/) — Sharding theory and CAP theorem foundations
 - **Related**: [Observability Toolkit](/platform/toolkits/observability-intelligence/observability/) — Monitoring Vitess clusters with Prometheus and Grafana

--- a/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.10-bentoml.md
+++ b/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.10-bentoml.md
@@ -1498,4 +1498,4 @@ The exact batch metric may differ in your BentoML version, so the first success 
 
 ## Next Module
 
-Next: bare-metal MLOps recipe (Module 9.11)
+Next: [Module 9.11 — Bare-Metal MLOps](../module-9.11-bare-metal-mlops/): Building a Production ML Platform Without Managed Cloud

--- a/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.3-feature-stores.md
+++ b/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.3-feature-stores.md
@@ -659,4 +659,4 @@ Add an on-demand feature view that computes `purchase_velocity` as `total_purcha
 
 ## Next Module
 
-Continue to [Module 9.4: Model Serving](/platform/toolkits/data-ai-platforms/ml-platforms/module-9.4-model-serving/) to learn how trained models are deployed behind production endpoints and how feature stores connect to the serving layer.
+Continue to [Module 9.4: vLLM](/platform/toolkits/data-ai-platforms/ml-platforms/module-9.4-vllm/) to learn high-throughput LLM serving and how feature stores connect to the inference layer.

--- a/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.9-seldon-core.md
+++ b/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.9-seldon-core.md
@@ -1678,7 +1678,7 @@ experiment.mlops.seldon.io/iris-final-ab True
 
 ## Next Module
 
-Next: Module 9.10 — BentoML: Unified Model Packaging and Deployment
+Next: [Module 9.10 — BentoML](../module-9.10-bentoml/): Python-First Model Packaging and Serving
 
 ## Sources
 

--- a/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.13-advanced-watches-yaml.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.13-advanced-watches-yaml.md
@@ -844,4 +844,4 @@ The `ignored-app` CR should have no status conditions because the operator never
 
 ## Next Module
 
-[Module 7.14: Ansible Operator with AWX/AAP](../module-7.14-awx-aap-operator-integration/)
+[Module 7.14: AWX, Tower, and Event-Driven Ansible (EDA) Integration](../module-7.14-awx-tower-eda/)

--- a/src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/module-14.6-managed-kubernetes.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/module-14.6-managed-kubernetes.md
@@ -1592,7 +1592,7 @@ If you cannot write those sentences clearly, your decision record still needs wo
 
 ## Next Module
 
-Next Toolkit: [CI/CD Pipelines Toolkit](/platform/toolkits/cicd-delivery/ci-cd-pipelines/)
+Next up: [Module 14.7: RKE2](../module-14.7-rke2/) — enterprise-hardened Kubernetes with CIS profiles and embedded container runtime.
 
 ## Sources
 

--- a/src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/module-14.7-rke2.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/module-14.7-rke2.md
@@ -680,4 +680,4 @@ sudo systemctl start rke2-server
 
 ## Next Module
 
-Next up: [Module 14.6: Managed Kubernetes](/platform/toolkits/infrastructure-networking/k8s-distributions/module-14.6-managed-kubernetes/) — exploring the architectural trade-offs of surrendering control plane management to AWS EKS, Google GKE, and Azure AKS.
+Next up: [Module 14.8: Edge Kubernetes Distros Landscape](../module-14.8-edge-distros-landscape/) — compare k3s, MicroK8s, K3OS, and other edge-focused distributions.

--- a/src/content/docs/platform/toolkits/infrastructure-networking/networking/module-5.4-metallb.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/networking/module-5.4-metallb.md
@@ -965,7 +965,7 @@ kind delete cluster --name metallb-lab
 
 ## Next Module
 
-*Next module coming soon.*
+Continue to [Module 5.5: Flannel](../module-5.5-flannel/) to learn overlay networking with VXLAN and host-gw backends from the ground up.
 
 ## Sources
 

--- a/src/content/docs/platform/toolkits/infrastructure-networking/networking/module-5.6-calico.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/networking/module-5.6-calico.md
@@ -1868,7 +1868,7 @@ rm -f calico-kind-config.yaml
 
 ## Next Module
 
-Continue to [Module 5.1: Cilium](../module-5.1-cilium/) if you have not already, or return to the [Networking Toolkit README]() to explore other networking modules.
+Continue to [Module 5.1: Cilium](../module-5.1-cilium/) if you have not already, or return to the [Networking Toolkit README](../) to explore other networking modules.
 
 ---
 

--- a/src/content/docs/platform/toolkits/infrastructure-networking/platforms/module-3.4-kubebuilder.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/platforms/module-3.4-kubebuilder.md
@@ -911,4 +911,4 @@ Add a `serviceType` field to the WebApp spec with an enum that allows `ClusterIP
 
 ## Next Module
 
-Continue to the next module in the Platforms Toolkit to expand your platform engineering skills.
+Continue to [Module 3.5: Cluster API (CAPI)](../module-3.5-cluster-api/) to learn declarative Kubernetes cluster lifecycle management across infrastructure providers.

--- a/src/content/docs/platform/toolkits/infrastructure-networking/platforms/module-3.5-cluster-api.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/platforms/module-3.5-cluster-api.md
@@ -609,7 +609,7 @@ The team should standardize and version the machine image contract before scalin
 
 Write a one-page recommendation for how your organization should adopt CAPI beyond the lab. Include the intended management-cluster ownership model, provider choice, base-image strategy, GitOps review process, deletion guardrails, backup plan, MachineHealthCheck stance, and the boundary between Terraform foundations and CAPI cluster lifecycle. Your recommendation should be specific enough that another platform engineer could challenge the trade-offs, not just agree with general statements.
 
-**Next Module**: [Module 7.1: Backstage](../module-7.1-backstage/) - Build an Internal Developer Portal to give developers self-service access to platform capabilities.
+**Next Module**: [Module 3.6: vCluster](../module-3.6-vcluster/) — run virtual Kubernetes clusters inside a host cluster for multi-tenancy and self-service isolation.
 
 ## Sources
 

--- a/src/content/docs/platform/toolkits/infrastructure-networking/storage/module-16.3-longhorn.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/storage/module-16.3-longhorn.md
@@ -955,7 +955,7 @@ rm -f kind-longhorn-config.yaml longhorn-test-pvc.yaml
 
 ## Next Module
 
-*Next module coming soon.*
+You have completed the Storage toolkit. Return to the [Storage toolkit overview](../) to review the module sequence or explore other infrastructure toolkits.
 
 ## Sources
 


### PR DESCRIPTION
## What
Mechanical navigation + framing pass across the **platform** track (GLM Platform re-audit, s193). 25 files, no teaching prose/code altered beyond the specified lines.

- **#2199** — 18 dead/stale/backward Next links repaired: 3 dead targets re-pointed to the real successor (data-eng 1.6→1.7-event-streaming, ml-platforms 9.3→9.4-vllm, iac 7.13→7.14-awx-tower-eda), 2 empty `()` targets filled, 1 mislabeled xref URL fixed, "coming soon"/"complete" stubs replaced with real forward links, backward/skip/no-link Next pointers corrected.
- **#2201** — advanced-networking IPv6 tail (1.7/1.8/1.9): Next links now point to the already-published successor modules instead of GitHub issues / external docs; "planned" framing removed; 1.9 gets a real terminal handoff.
- **#2202** — systems-thinking 1.1 "entry point to Platform track" softened to "a natural starting point" (Platform is role-shaped, no single entry point); data-engineering 1.2 (Kafka) gained a `## Prerequisites` section (K8s Storage/Jobs per the section index).
- **#2166 part 2** — dead "Linux Deep Dive" cross-ref → `/linux/foundations/networking/`.

## Verification
- Build green: 2169 pages, 0 errors.
- Cross-family review: cursor (Kimi) author → **agy (Gemini 3.1 Pro) R1: APPROVE**, zero findings; prove-the-negative validated every re-pointed target resolves, Kafka prereqs + framing ground-checked.

Closes #2199
Closes #2201
Closes #2202
Refs #2166

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Learner check
> A queue usually treats a message as a work item that disappears after successful processing.
