### PR TITLE
docs(on-premises): fix broken Next links + entry-gate/terminal framing + time-drift (#2203 #2204 #2205)

### DIFF
--- a/src/content/docs/on-premises/ai-ml-infrastructure/index.md
+++ b/src/content/docs/on-premises/ai-ml-infrastructure/index.md
@@ -14,12 +14,12 @@ Running AI and ML workloads on bare metal is a different sport from running them
 
 | Module | Focus | Time |
 |--------|-------|------|
-| [GPU Nodes & Accelerated Computing](module-9.1-gpu-nodes-accelerated/) | NVIDIA GPU Operator, MIG, time slicing, DCGM monitoring, AMD ROCm, Intel Gaudi | 60 min |
-| [Private AI Training Infrastructure](module-9.2-private-ai-training/) | Distributed training, NCCL over InfiniBand/RoCE, Volcano/Kueue, fault-tolerant jobs | 75 min |
-| [Private LLM Serving](module-9.3-private-llm-serving/) | vLLM, TGI, Ollama at scale, quantization, KServe, continuous batching | 75 min |
-| [Private MLOps Platform](module-9.4-private-mlops-platform/) | Kubeflow, MLflow, Feast, model registry, experiment tracking on bare metal | 60 min |
-| [Private AIOps](module-9.5-private-aiops/) | Anomaly detection, predictive scaling, AI-augmented incident response with guardrails | 60 min |
-| [High-Performance Storage for AI](module-9.6-high-performance-storage-ai/) | NFS-over-RDMA, Lustre/BeeGFS/WekaFS, avoiding GPU idle from storage bottlenecks | 60 min |
+| [GPU Nodes & Accelerated Computing](module-9.1-gpu-nodes-accelerated/) | NVIDIA GPU Operator, MIG, time slicing, DCGM monitoring, AMD ROCm, Intel Gaudi | 75-95 min |
+| [Private AI Training Infrastructure](module-9.2-private-ai-training/) | Distributed training, NCCL over InfiniBand/RoCE, Volcano/Kueue, fault-tolerant jobs | 120-150 min |
+| [Private LLM Serving](module-9.3-private-llm-serving/) | vLLM, TGI, Ollama at scale, quantization, KServe, continuous batching | 90-120 min |
+| [Private MLOps Platform](module-9.4-private-mlops-platform/) | Kubeflow, MLflow, Feast, model registry, experiment tracking on bare metal | 3-4 hours |
+| [Private AIOps](module-9.5-private-aiops/) | Anomaly detection, predictive scaling, AI-augmented incident response with guardrails | 90-120 min |
+| [High-Performance Storage for AI](module-9.6-high-performance-storage-ai/) | NFS-over-RDMA, Lustre/BeeGFS/WekaFS, avoiding GPU idle from storage bottlenecks | 90-120 min |
 
 ---
 

--- a/src/content/docs/on-premises/ai-ml-infrastructure/module-9.5-private-aiops.md
+++ b/src/content/docs/on-premises/ai-ml-infrastructure/module-9.5-private-aiops.md
@@ -1144,4 +1144,4 @@ Answer these questions before considering the design production-ready, because a
 
 ## Next Module
 
-Ready to take your bare-metal clusters to the next level; in the next module, [Module 9.6: Edge Inference and Hardware Acceleration](/on-premises/ai-ml-infrastructure/module-9.6-edge-inference), you will explore how to configure SR-IOV, MIG, and optimized scheduling to get reliable inference performance from local hardware.
+Ready to take your bare-metal clusters to the next level; in the next module, [Module 9.6: High-Performance Storage for AI](/on-premises/ai-ml-infrastructure/module-9.6-high-performance-storage-ai/), you will architect parallel file systems, distributed caches, and tiering strategies to prevent GPU starvation on bare-metal Kubernetes.

--- a/src/content/docs/on-premises/ai-ml-infrastructure/module-9.6-high-performance-storage-ai.md
+++ b/src/content/docs/on-premises/ai-ml-infrastructure/module-9.6-high-performance-storage-ai.md
@@ -568,4 +568,4 @@ If a pod fails to mount the PVC, ensure the `csi-nodeplugin-fluid` DaemonSet is 
 
 ## Next Module
 
-Ready to move from storage architectures to advanced scheduling? Continue with [GPU Scheduling](/platform/toolkits/data-ai-platforms/ml-platforms/module-9.7-gpu-scheduling/), where you will coordinate placement, queueing, and accelerator-aware scheduling patterns for large AI workloads.
+This is the final module of the On-Premises track — you've gone from planning and bare-metal provisioning through networking, storage, multi-cluster, security, day-2 operations, resilience, and AI/ML infrastructure on bare metal. To go deeper on accelerator-aware placement and queueing, see [GPU Scheduling](/platform/toolkits/data-ai-platforms/ml-platforms/module-9.7-gpu-scheduling/) in the Platform Engineering track.

--- a/src/content/docs/on-premises/multi-cluster/module-5.10-edge-fleet-patterns.md
+++ b/src/content/docs/on-premises/multi-cluster/module-5.10-edge-fleet-patterns.md
@@ -743,7 +743,7 @@ Final exercise success criteria:
 
 ## Next Module
 
-Continue to [Module 5.5: Active-Active Multi-Site](../module-5.5-active-active-multi-site/) to connect fleet rollout safety with global load balancing, data replication, and cross-site failure recovery.
+Continue to [Module 5.11: Disconnected & Air-gapped K8s Ops](../module-5.11-disconnected-airgapped-k8s-ops/) to operate multi-cluster fleets without continuous upstream connectivity.
 
 ---
 

--- a/src/content/docs/on-premises/multi-cluster/module-5.3-cluster-api-bare-metal.md
+++ b/src/content/docs/on-premises/multi-cluster/module-5.3-cluster-api-bare-metal.md
@@ -607,7 +607,7 @@ Both stacks share the same `Metal3Cluster` API VIP (`10.10.50.100:6443`); bootst
 
 ## Next Module
 
-Continue to [Module 6.1: Physical Security & Air-Gapped Environments](../../security/module-6.1-air-gapped/) to harden on-premises Kubernetes boundaries after your bare-metal fleet provisions declaratively.
+Continue to [Module 5.4: Fleet Management](../module-5.4-fleet-management/) to manage multi-cluster rollouts, GitOps bundles, and selective sync across bare-metal estates.
 
 ## Learner Check
 

--- a/src/content/docs/on-premises/multi-cluster/module-5.6-gardener.md
+++ b/src/content/docs/on-premises/multi-cluster/module-5.6-gardener.md
@@ -1472,7 +1472,7 @@ Garden, Seed, Shoot, extension, status, and reconciliation remain the same conce
 
 ## Next Module
 
-Next: Karmada/Liqo + kube-vip for multi-cluster on-prem federation, where you will compare cluster lifecycle management with workload placement and cross-cluster service continuity.
+Next: [Module 5.7: On-Premises Multi-Cluster Kubernetes Synthesis](../module-5.7-multi-cluster-on-prem/) — Karmada/Liqo + kube-vip for multi-cluster on-prem federation, where you will compare cluster lifecycle management with workload placement and cross-cluster service continuity.
 
 ---
 

--- a/src/content/docs/on-premises/multi-cluster/module-5.9-vmware-tanzu.md
+++ b/src/content/docs/on-premises/multi-cluster/module-5.9-vmware-tanzu.md
@@ -756,7 +756,7 @@ kind delete cluster --name capi-mgmt
 
 ## Next Module
 
-End of Section 5 — Multi-Cluster & On-Prem. Continue to [Platform Engineering](../../platform/) to explore the next layer of the cloud-native stack.
+Continue to [Module 5.10: Edge Fleet Patterns](../module-5.10-edge-fleet-patterns/) to model retail and edge store fleets with selective GitOps rollouts and constrained-network overrides.
 
 ## Learner Check
 

--- a/src/content/docs/on-premises/networking/module-3.2-bgp-routing.md
+++ b/src/content/docs/on-premises/networking/module-3.2-bgp-routing.md
@@ -452,7 +452,7 @@ kubectl -n lab run verifier --rm -i --restart=Never --image=curlimages/curl:8.7.
 
 ## Next Module
 
-*Next module coming soon.*
+Continue to [Module 3.3: Load Balancing Without Cloud](../module-3.3-load-balancing/) to design bare-metal ingress and service load balancing without cloud-managed L4/L7 primitives.
 
 ## Sources
 

--- a/src/content/docs/on-premises/networking/module-3.4-dns-certs.md
+++ b/src/content/docs/on-premises/networking/module-3.4-dns-certs.md
@@ -611,7 +611,7 @@ kind delete cluster --name dns-certs-lab
 
 ## Next Module
 
-Continue to [Module 4.1: Storage Architecture Decisions](/on-premises/storage/module-4.1-storage-architecture/) to design persistent storage for stateful workloads now that names and certificates resolve reliably inside your estate.
+Continue to [Module 3.5: Cross-Cluster Networking](../module-3.5-cross-cluster-networking/) to design east-west routing, MCS service discovery, and encrypted tunnels across bare-metal clusters.
 
 ## Learner Check
 

--- a/src/content/docs/on-premises/networking/module-3.6-service-mesh-bare-metal.md
+++ b/src/content/docs/on-premises/networking/module-3.6-service-mesh-bare-metal.md
@@ -678,7 +678,7 @@ Before closing the module, confirm you can explain—in your own words—how tra
 
 ## Next Module
 
-Return to the [Networking track overview](../) to review the full bare-metal networking sequence from datacenter design through cross-cluster connectivity and mesh operations.
+Next, continue to [Module 6.1: Physical Security & Air-Gapped Environments](../security/module-6.1-air-gapped/) to begin the Security & Compliance section — the networking, storage, and multi-cluster branches all converge here. (To review this branch first, see the [Networking track overview](../).)
 
 ---
 

--- a/src/content/docs/on-premises/operations/index.md
+++ b/src/content/docs/on-premises/operations/index.md
@@ -15,9 +15,9 @@ These modules cover the operational practices that keep on-premises clusters hea
 | [Module 7.1: Kubernetes Upgrades on Bare Metal](module-7.1-upgrades/) | kubeadm upgrade path, drain strategies, rollback, version skew | 60 min |
 | [Module 7.2: Hardware Lifecycle & Firmware](module-7.2-hardware-lifecycle/) | BIOS/firmware updates, disk replacement, SMART monitoring, Redfish API | 60 min |
 | [Module 7.3: Node Failure & Auto-Remediation](module-7.3-node-remediation/) | Machine Health Checks, node problem detector, automated reboot/reprovision | 60 min |
-| [Module 7.4: Observability Without Cloud Services](module-7.4-observability/) | Self-hosted Prometheus + Thanos, Grafana, Loki, IPMI exporter | 60 min |
+| [Module 7.4: Observability Without Cloud Services](module-7.4-observability/) | Self-hosted Prometheus + Thanos, Grafana, Loki, IPMI exporter | 90 min |
 | [Module 7.5: Capacity Expansion & Hardware Refresh](module-7.5-capacity-expansion/) | Adding racks, mixed CPU generations, topology spread, refresh cycles | 60 min |
 | [Self-Hosted CI/CD](module-7.6-self-hosted-cicd/) | Building robust pipeline infrastructure, runners, and GitOps on bare metal | 60 min |
 | [Self-Hosted Container Registry](module-7.7-self-hosted-registry/) | Deploying Harbor or similar registries, replication, caching, and vulnerability scanning | 60 min |
-| [Observability at Scale](module-7.8-observability-at-scale/) | Long-term metric retention, high availability logging, and distributed tracing architectures | 60 min |
+| [Observability at Scale](module-7.8-observability-at-scale/) | Long-term metric retention, high availability logging, and distributed tracing architectures | 90-120 min |
 | [Serverless on Bare Metal](module-7.9-serverless-bare-metal/) | Implementing Knative, OpenFaaS, and event-driven architectures without cloud primitives | 60 min |

--- a/src/content/docs/on-premises/operations/module-7.5-capacity-expansion.md
+++ b/src/content/docs/on-premises/operations/module-7.5-capacity-expansion.md
@@ -1076,7 +1076,7 @@ Why is it dangerous to treat all CPU cores as identical when combining servers f
 
 ## Next Module
 
-This concludes the Day-2 Operations section. Return to the [Operations index](/on-premises/operations/) to review all modules, or continue to the next section in the on-premises track.
+Continue to [Self-Hosted CI/CD](../module-7.6-self-hosted-cicd/) to build pipeline infrastructure, runners, and GitOps workflows on bare-metal Kubernetes.
 
 ## Sources
 

--- a/src/content/docs/on-premises/operations/module-7.8-observability-at-scale.md
+++ b/src/content/docs/on-premises/operations/module-7.8-observability-at-scale.md
@@ -530,7 +530,7 @@ k delete namespace observability
 
 ## Next Module
 
-*Next module coming soon.*
+Continue to [Serverless on Bare Metal](../module-7.9-serverless-bare-metal/) to design Knative, KEDA, and event-driven scale-to-zero workloads on bare-metal Kubernetes.
 
 ## Further Reading
 

--- a/src/content/docs/on-premises/operations/module-7.9-serverless-bare-metal.md
+++ b/src/content/docs/on-premises/operations/module-7.9-serverless-bare-metal.md
@@ -598,9 +598,7 @@ kubectl get pods
 
 ## Next Module
 
-Ready to secure the serverless platform you built? The next module covers advanced traffic management, zero-trust networking between functions, and mutual TLS with service meshes so that scale-to-zero endpoints do not become unauthenticated lateral movement paths inside your bare-metal fabric.
-
-[Continue with Zero-Trust Architecture ->](/on-premises/security/module-6.8-zero-trust-architecture/)
+This concludes the Day-2 Operations section. Continue to [Module 8.1: Multi-Site & Disaster Recovery](/on-premises/resilience/module-8.1-multi-site-dr/) to design multi-site failover, backup, and recovery patterns for bare-metal estates.
 
 ## Sources
 

--- a/src/content/docs/on-premises/planning/module-1.1-case-for-on-prem.md
+++ b/src/content/docs/on-premises/planning/module-1.1-case-for-on-prem.md
@@ -8,7 +8,7 @@ sidebar:
 
 > **Complexity**: `[MEDIUM]` | Time: 90 minutes
 >
-> **Prerequisites**: [Cloud Native 101](/prerequisites/cloud-native-101/), [Kubernetes Basics](/prerequisites/kubernetes-basics/)
+> **Prerequisites**: [CKA](/k8s/cka/) (cluster architecture, kubeadm) — required. You should already be comfortable with core Kubernetes troubleshooting, Linux networking/storage/security, and day-2 operational thinking. Foundational refreshers: [Cloud Native 101](/prerequisites/cloud-native-101/), [Kubernetes Basics](/prerequisites/kubernetes-basics/).
 
 ---
 

--- a/src/content/docs/on-premises/resilience/index.md
+++ b/src/content/docs/on-premises/resilience/index.md
@@ -16,4 +16,4 @@ Whether you are designing active-active multi-site failover, establishing hybrid
 |--------|-------------|------|
 | [Module 8.1: Multi-Site & Disaster Recovery](module-8.1-multi-site-dr/) | Active-active vs active-passive, stretched clusters, Velero backups, etcd snapshots, DNS failover | 60 min |
 | [Module 8.2: Hybrid Cloud Connectivity](module-8.2-hybrid-connectivity/) | VPN tunnels, direct interconnects, Submariner, cross-environment service mesh, unified policy | 60 min |
-| [Module 8.3: Cloud Repatriation & Migration](module-8.3-cloud-repatriation/) | Moving workloads from cloud to on-prem, service translation, storage migration, phased cutover | 60 min |
+| [Module 8.3: Cloud Repatriation & Migration](module-8.3-cloud-repatriation/) | Moving workloads from cloud to on-prem, service translation, storage migration, phased cutover | 90 min |

--- a/src/content/docs/on-premises/resilience/module-8.3-cloud-repatriation.md
+++ b/src/content/docs/on-premises/resilience/module-8.3-cloud-repatriation.md
@@ -662,9 +662,9 @@ kind delete cluster --name onprem-sim
 
 ## Next Module
 
-This formally concludes the final, culminating module in the comprehensive Resilience & Migration section. Your extensive technical journey—from establishing core fault tolerance patterns to architecting massive, multi-petabyte full cloud exits—is fundamentally complete. 
+This formally concludes the final module in the Resilience & Migration section. Your journey—from establishing core fault tolerance patterns to architecting multi-petabyte cloud exits—is complete.
 
-Return directly to the [Resilience & Migration overview](/on-premises/resilience/) to review the full section architecture, or continue your deep technical dive by stepping forward into the extraordinarily complex routing challenges presented in the upcoming bare-metal networking track.
+Return to the [Resilience & Migration overview](/on-premises/resilience/) to review the full section architecture, or continue to [AI/ML Infrastructure](/on-premises/ai-ml-infrastructure/) — the track's final section covering GPU scheduling, private MLOps, and high-performance storage for AI on bare metal.
 
 ## Sources
 

--- a/src/content/docs/on-premises/security/module-6.4-compliance.md
+++ b/src/content/docs/on-premises/security/module-6.4-compliance.md
@@ -943,4 +943,4 @@ For RBAC, expect create and delete events for `test-binding` at `RequestResponse
 
 ## Next Module
 
-Continue to [Module 7.1: Cluster Upgrades & Lifecycle](/on-premises/operations/module-7.1-upgrades/) to learn how to manage Kubernetes version upgrades, OS patching, and firmware updates in on-premises environments without violating the change-management controls you have just built.
+Continue to [Module 7.1: Kubernetes Upgrades on Bare Metal](/on-premises/operations/module-7.1-upgrades/) to learn how to manage Kubernetes version upgrades, OS patching, and firmware updates in on-premises environments without violating the change-management controls you have just built.

--- a/src/content/docs/on-premises/storage/module-4.3-local-storage.md
+++ b/src/content/docs/on-premises/storage/module-4.3-local-storage.md
@@ -942,7 +942,7 @@ kind delete cluster
 
 ## Next Module
 
-Continue to [Module 5.1: Private Cloud Platforms](../../multi-cluster/module-5.1-private-cloud/) to learn how VMware vSphere, OpenStack, and Harvester provide infrastructure abstraction layers for on-premises Kubernetes, including how those platforms handle storage, networking, and scheduling above the bare-metal layer you have been working at in this part of the curriculum.
+Continue to [Object Storage on Bare Metal](../module-4.4-object-storage-bare-metal/) to deploy and scale S3-compatible object storage on bare-metal Kubernetes using distributed MinIO, erasure coding, and DirectPV.
 
 ## Sources
 

--- a/src/content/docs/on-premises/storage/module-4.5-database-operators.md
+++ b/src/content/docs/on-premises/storage/module-4.5-database-operators.md
@@ -608,7 +608,7 @@ kubectl get pods -l cnpg.io/cluster=dojo-db -L cnpg.io/instanceRole -w
 
 ## Next Module
 
-Next, continue with [Storage Observability and Capacity Forecasting](module-4.6-storage-observability-capacity-forecasting/) to connect database operator health with the storage metrics and forecasts that keep on-premises stateful platforms reliable.
+Next, continue with [Module 6.1: Physical Security & Air-Gapped Environments](/on-premises/security/module-6.1-air-gapped/) to harden on-premises Kubernetes boundaries after your stateful storage platform is in place.
 
 ## Sources
 


### PR DESCRIPTION
## What
On-premises route-coherence + framing + time-reconciliation pass (GLM on-prem re-audit, s193). 20 files, no teaching prose altered beyond the specified lines.

- **#2203** — 13 broken Next links repaired: dead `9.6-edge-inference`→`9.6-high-performance-storage-ai`; phantom storage 4.6→Security 6.1; "coming soon" stubs (3.2/5.6/7.8)→real successors; false terminators (7.5/5.9) removed; backward/skip links (7.9→resilience 8.1, 5.10→5.11, 3.4→3.5, 4.3→4.4, 5.3→5.4) re-pointed forward; 7.1 label mismatch fixed.
- **#2204** — planning 1.1 entry prereqs raised to cite **CKA as required** + advanced-ops readiness (gate not lowered); resilience 8.3 terminal re-pointed forward to **AI/ML Infrastructure** (was a phantom "networking track").
- **#2205** — operations/resilience/ai-ml-infrastructure index time columns reconciled to module headers.
- **+2 route fixes surfaced by the cross-family reviewer** (same class, folded in): networking terminal 3.6 now converges to Security 6.1 (matching storage 4.5 & multi-cluster 5.11); AI/ML terminal 9.6 now **concludes the track** with the Platform GPU-Scheduling link demoted to an optional "go deeper" pointer.

## Verification
- Build green: 2169 pages, 0 errors.
- Cross-family review: cursor (Kimi) author → **codex (OpenAI) R1** — all 18 originally-touched files verified (targets resolve incl. `/k8s/cka/`, no stubs, time_mismatches=0, #2204 correct). codex flagged 2 additional out-of-diff route violations and **suggested the exact fixes**, which were implemented verbatim (3.6→Security 6.1; 9.6 conclude-track).

Closes #2203
Closes #2204
Closes #2205

## Learner check
> In 2023, a mid-sized European bank ran three hundred forty microservices on AWS EKS across three regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)