### PR TITLE
docs(on-premises): fix planning 1.4 Next link orphaning module 1.5

### DIFF
--- a/src/content/docs/on-premises/planning/module-1.4-tco-budget.md
+++ b/src/content/docs/on-premises/planning/module-1.4-tco-budget.md
@@ -560,7 +560,7 @@ The on-prem versus cloud question is rarely about hardware cost. Hardware accoun
 
 ## Next Module
 
-Continue to [Module 2.1: Datacenter Fundamentals](/on-premises/provisioning/module-2.1-datacenter-fundamentals/) to learn the physical infrastructure that supports your Kubernetes cluster.
+Continue to [Module 1.5: On-Prem FinOps & Chargeback](../module-1.5-onprem-finops-chargeback/) to turn the multi-year TCO model you just built into ongoing resource tracking, internal billing, and chargeback rates.
 
 ## Sources
 


### PR DESCRIPTION
## What
`on-premises/planning/module-1.4-tco-budget.md:563` Next link jumped to Module 2.1 (provisioning), **skipping Module 1.5** (On-Prem FinOps & Chargeback) — orphaning it (nothing pointed to 1.5 as Next; both 1.4 and 1.5 pointed to 2.1). Re-pointed 1.4 → 1.5; 1.5's existing exit to 2.1 is correct and unchanged.

## How it was found
Surfaced during the GLM opencode-vs-hermes depth A/B test on the planning section — planning's intra-section chain was never covered by the #2203 on-prem audit. 1.5 is logically downstream of 1.4 (it back-references "the five-year TCO from Module 1.4").

## Verification
- Build green.
- Cross-family review: **two independent agents (opencode-GLM + hermes-GLM, both glm-5.2) identified this exact defect and specified the identical fix** (repoint 1.4 → `../module-1.5-onprem-finops-chargeback/`). Both quotes ground-checked verbatim against disk.

## Learner check
> Your organisation is choosing between owning a datacenter and using colocation.
