### PR TITLE
docs(cloud): add missing headers + strip stray frontmatter + fix AKS 7.3 preamble + arch-patterns Complexity column (#2187)

### DIFF
--- a/src/content/docs/cloud/aks-deep-dive/module-7.3-aks-identity.md
+++ b/src/content/docs/cloud/aks-deep-dive/module-7.3-aks-identity.md
@@ -9,6 +9,7 @@ sidebar:
 ## What You'll Be Able to Do
 
 After completing this module, you will be able to:
+
 Treat this list as a verification checklist so you can confirm each competency end-to-end before adding additional workloads and team velocity-dependent pressure. Work through outcomes in order, validate each step with commands, and only then move to the next module.
 
 - **Configure AKS Workload Identity with Entra ID federated credentials for pod-level Azure resource access**

--- a/src/content/docs/cloud/architecture-patterns/index.md
+++ b/src/content/docs/cloud/architecture-patterns/index.md
@@ -12,12 +12,12 @@ This section covers the architectural decisions that apply across every cloud: m
 
 ## Modules
 
-| # | Module | Time | What You'll Learn |
-|---|--------|------|-------------------|
-| 1 | [Managed vs Self-Managed Kubernetes](module-4.1-managed-vs-selfmanaged/) | 2h | Trade-offs, decision frameworks, TCO analysis |
-| 2 | [Multi-Cluster and Multi-Region Architectures](module-4.2-multi-cluster/) | 3h | Topology patterns, failover, service mesh, federation |
-| 3 | [Cloud IAM Integration for Kubernetes](module-4.3-cloud-iam/) | 2.5h | Pod-level identity, OIDC federation, least privilege |
-| 4 | [Cloud-Native Networking and VPC Topologies](module-4.4-vpc-topologies/) | 3.5h | CIDR planning, CNI models, IP exhaustion, peering |
+| # | Module | Complexity | Time | What You'll Learn |
+|---|--------|------------|------|-------------------|
+| 1 | [Managed vs Self-Managed Kubernetes](module-4.1-managed-vs-selfmanaged/) | `[MEDIUM]` | 2h | Trade-offs, decision frameworks, TCO analysis |
+| 2 | [Multi-Cluster and Multi-Region Architectures](module-4.2-multi-cluster/) | `[COMPLEX]` | 3h | Topology patterns, failover, service mesh, federation |
+| 3 | [Cloud IAM Integration for Kubernetes](module-4.3-cloud-iam/) | `[MEDIUM]` | 2.5h | Pod-level identity, OIDC federation, least privilege |
+| 4 | [Cloud-Native Networking and VPC Topologies](module-4.4-vpc-topologies/) | `Advanced` | 3.5h | CIDR planning, CNI models, IP exhaustion, peering |
 
 **Total time**: ~11 hours
 

--- a/src/content/docs/cloud/azure-essentials/module-3.16-azure-sql.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.16-azure-sql.md
@@ -1,5 +1,4 @@
 ---
-citations_verified: true
 title: "Module 3.16: Azure SQL Database — Operator Path"
 slug: cloud/azure-essentials/module-3.16-azure-sql
 sidebar:

--- a/src/content/docs/cloud/azure-essentials/module-3.17-backup-site-recovery.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.17-backup-site-recovery.md
@@ -1,5 +1,4 @@
 ---
-citations_verified: true
 title: "Module 3.17: Azure Backup + Site Recovery — Operator Path"
 slug: cloud/azure-essentials/module-3.17-backup-site-recovery
 sidebar:

--- a/src/content/docs/cloud/eks-deep-dive/module-5.2-eks-networking.md
+++ b/src/content/docs/cloud/eks-deep-dive/module-5.2-eks-networking.md
@@ -4,6 +4,7 @@ slug: cloud/eks-deep-dive/module-5.2-eks-networking
 sidebar:
   order: 3
 ---
+**Complexity**: [COMPLEX] | **Time to Complete**: 3.5h | **Prerequisites**: Module 5.1 (EKS Architecture & Control Plane)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/enterprise-hybrid/module-10.4-hybrid.md
+++ b/src/content/docs/cloud/enterprise-hybrid/module-10.4-hybrid.md
@@ -4,6 +4,7 @@ slug: cloud/enterprise-hybrid/module-10.4-hybrid
 sidebar:
   order: 5
 ---
+**Complexity**: [COMPLEX] | **Time to Complete**: 3h | **Prerequisites**: Enterprise Landing Zones (Module 10.1), Kubernetes networking basics
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/enterprise-hybrid/module-10.5-fleet-management.md
+++ b/src/content/docs/cloud/enterprise-hybrid/module-10.5-fleet-management.md
@@ -4,6 +4,7 @@ slug: cloud/enterprise-hybrid/module-10.5-fleet-management
 sidebar:
   order: 6
 ---
+**Complexity**: [COMPLEX] | **Time to Complete**: 2.5h | **Prerequisites**: Hybrid Cloud Architecture (Module 10.4), GitOps Basics (ArgoCD/Flux)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/gcp-essentials/module-2.11-cloud-build.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.11-cloud-build.md
@@ -4,6 +4,7 @@ slug: cloud/gcp-essentials/module-2.11-cloud-build
 sidebar:
   order: 12
 ---
+**Complexity**: [COMPLEX] | **Time to Complete**: 2.5h | **Prerequisites**: Module 2.6 (Artifact Registry), Module 2.7 (Cloud Run)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/managed-services/module-9.9-api-gateways.md
+++ b/src/content/docs/cloud/managed-services/module-9.9-api-gateways.md
@@ -1,5 +1,4 @@
 ---
-revision_pending: false
 title: "Module 9.9: Cloud-Native API Gateways & WAF"
 slug: cloud/managed-services/module-9.9-api-gateways
 sidebar:


### PR DESCRIPTION
## What
Discrete mechanical defects from GLM's cloud re-audit (#2187). 9 files. (The marker-format normalization and sidebar-order parts of #2187 are handled separately by the infra marker-normalizer / config-order task.)

- **Missing headers** added to EKS 5.2, GCP 2.11, enterprise-hybrid 10.4 & 10.5 (matching sibling inline-pipe format, honest tier/time/prereqs).
- **Stray review frontmatter** removed: `citations_verified: true` (azure 3.16, 3.17), `revision_pending: false` (managed-services 9.9).
- **AKS 7.3** "What You'll Be Able to Do" preamble: guidance sentence given its own paragraph break (was jammed onto the outcomes line).
- **architecture-patterns/index.md** gained the Complexity column the other three A&E subsection indexes carry.

## Verification
- Build green: 2169 pages, 0 errors.
- Cross-family review: cursor (Kimi) author → orchestrator opus (Anthropic) inline R1 — header additions verified proper, frontmatter removals + preamble fix + column confirmed against disk.

Refs #2187 (discrete parts only — marker-format normalization + sidebar-order collision are handled by the infra normalizer/config-order task; #2187 stays open until those land)

## Learner check
> Verify that a pod in a different namespace or with a different service account cannot access the secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)