### PR TITLE
docs(linux): reconcile 1.1 difficulty + add 2.1 header + fix time-drift + container-primitives lab blocks (#2181)

### DIFF
--- a/src/content/docs/linux/foundations/container-primitives/index.md
+++ b/src/content/docs/linux/foundations/container-primitives/index.md
@@ -19,10 +19,10 @@ After this section, you'll understand that a "container" is just a process with:
 
 | # | Module | Description | Time |
 |---|--------|-------------|------|
-| 2.1 | [Module 2.1: Linux Namespaces](module-2.1-namespaces/) | PID, network, mount, UTS, user isolation | 30-35 min |
+| 2.1 | [Module 2.1: Linux Namespaces](module-2.1-namespaces/) | PID, network, mount, UTS, user isolation | 35-45 min |
 | 2.2 | [Module 2.2: Control Groups (cgroups)](module-2.2-cgroups/) | CPU/memory limits, v1 vs v2, systemd integration | 30-35 min |
-| 2.3 | [Module 2.3: Capabilities & Linux Security Modules](module-2.3-capabilities-lsms/) | CAP_*, AppArmor, SELinux, seccomp overview | 25-30 min |
-| 2.4 | [Module 2.4: Union Filesystems](module-2.4-union-filesystems/) | OverlayFS, layers, storage drivers | 25-30 min |
+| 2.3 | [Module 2.3: Capabilities & Linux Security Modules](module-2.3-capabilities-lsms/) | CAP_*, AppArmor, SELinux, seccomp overview | 35-45 min |
+| 2.4 | [Module 2.4: Union Filesystems](module-2.4-union-filesystems/) | OverlayFS, layers, storage drivers | 45-60 min |
 
 ## Why This Section Matters
 

--- a/src/content/docs/linux/foundations/container-primitives/module-2.1-namespaces.md
+++ b/src/content/docs/linux/foundations/container-primitives/module-2.1-namespaces.md
@@ -4,10 +4,16 @@ title: "Module 2.1: Linux Namespaces"
 slug: linux/foundations/container-primitives/module-2.1-namespaces
 sidebar:
   order: 2
+lab:
+  id: "linux-2.1-namespaces"
+  url: "https://killercoda.com/kubedojo/scenario/linux-2.1-namespaces"
+  duration: "35-45 min"
+  difficulty: "intermediate"
+  environment: "ubuntu"
 revision_pending: false
 ---
 
-This Linux Foundations module is a `[MEDIUM]` lesson designed for a 35-45 minute study session, with lab time focused on inspecting real namespace boundaries instead of memorizing container vocabulary.
+> **Linux Foundations** | Complexity: `[MEDIUM]` | Time: 35-45 min. This medium-depth lesson focuses on inspecting real namespace boundaries instead of memorizing container vocabulary.
 
 ## Prerequisites
 

--- a/src/content/docs/linux/foundations/container-primitives/module-2.2-cgroups.md
+++ b/src/content/docs/linux/foundations/container-primitives/module-2.2-cgroups.md
@@ -4,6 +4,12 @@ title: "Module 2.2: Control Groups (cgroups)"
 slug: linux/foundations/container-primitives/module-2.2-cgroups
 sidebar:
   order: 3
+lab:
+  id: "linux-2.2-cgroups"
+  url: "https://killercoda.com/kubedojo/scenario/linux-2.2-cgroups"
+  duration: "30-35 min"
+  difficulty: "intermediate"
+  environment: "ubuntu"
 ---
 
 > **Linux Foundations** | Complexity: `[MEDIUM]` | Time: 30-35 min. This medium-depth lesson assumes you can already read basic Linux commands and Kubernetes pod output, and it focuses on turning cgroup files into practical operational decisions.

--- a/src/content/docs/linux/foundations/container-primitives/module-2.3-capabilities-lsms.md
+++ b/src/content/docs/linux/foundations/container-primitives/module-2.3-capabilities-lsms.md
@@ -4,6 +4,12 @@ title: "Module 2.3: Capabilities & Linux Security Modules"
 slug: linux/foundations/container-primitives/module-2.3-capabilities-lsms
 sidebar:
   order: 4
+lab:
+  id: "linux-2.3-capabilities-lsms"
+  url: "https://killercoda.com/kubedojo/scenario/linux-2.3-capabilities-lsms"
+  duration: "35-45 min"
+  difficulty: "intermediate"
+  environment: "ubuntu"
 ---
 
 > **Linux Foundations** | Complexity: `[MEDIUM]` | Time: 35-45 min | Focus: least-privilege process control for container workloads on shared Linux kernels.

--- a/src/content/docs/linux/foundations/container-primitives/module-2.4-union-filesystems.md
+++ b/src/content/docs/linux/foundations/container-primitives/module-2.4-union-filesystems.md
@@ -4,6 +4,12 @@ title: "Module 2.4: Union Filesystems"
 slug: linux/foundations/container-primitives/module-2.4-union-filesystems
 sidebar:
   order: 5
+lab:
+  id: "linux-2.4-union-filesystems"
+  url: "https://killercoda.com/kubedojo/scenario/linux-2.4-union-filesystems"
+  duration: "45-60 min"
+  difficulty: "intermediate"
+  environment: "ubuntu"
 ---
 
 > **Linux Foundations** | Complexity: `[MEDIUM]` | Time: 45-60 min

--- a/src/content/docs/linux/foundations/everyday-use/index.md
+++ b/src/content/docs/linux/foundations/everyday-use/index.md
@@ -19,10 +19,10 @@ These 5 modules bridge the gap between "I can use a terminal" and "I understand 
 | 0.1 | [The CLI Power User (Search & Streams)](module-0.1-cli-power-user/) | 45 min | Wildcards, pipes, redirects, find, grep |
 | 0.2 | [Environment & Permissions (Who You Are & Where You Are)](module-0.2-environment-permissions/) | 45 min | $PATH, .bashrc, chmod, chown, sudo |
 | 0.3 | [Process & Resource Survival Guide](module-0.3-processes-resources/) | 40 min | ps, top, kill, background jobs, disk usage |
-| 0.4 | [Services & Logs Demystified](module-0.4-services-logs/) | 40 min | systemctl, journalctl, daemons |
+| 0.4 | [Services & Logs Demystified](module-0.4-services-logs/) | 45-50 min | systemctl, journalctl, daemons |
 | 0.5 | [Everyday Networking Tools](module-0.5-networking-tools/) | 45 min | ping, curl, ss, dig, traceroute |
 
-**Total time**: ~3.5 hours
+**Total time**: 3 hr 40-45 min
 
 ---
 

--- a/src/content/docs/linux/foundations/everyday-use/module-0.1-cli-power-user.md
+++ b/src/content/docs/linux/foundations/everyday-use/module-0.1-cli-power-user.md
@@ -7,7 +7,7 @@ sidebar:
 lab:
   id: "linux-0.1-cli-power-user"
   url: "https://killercoda.com/kubedojo/scenario/linux-0.1-cli-power-user"
-  duration: "30 min"
+  duration: "45 min"
   difficulty: "intermediate"
   environment: "ubuntu"
 ---

--- a/src/content/docs/linux/foundations/everyday-use/module-0.3-processes-resources.md
+++ b/src/content/docs/linux/foundations/everyday-use/module-0.3-processes-resources.md
@@ -7,7 +7,7 @@ sidebar:
 lab:
   id: "linux-0.3-processes-resources"
   url: "https://killercoda.com/kubedojo/scenario/linux-0.3-processes-resources"
-  duration: "35 min"
+  duration: "40 min"
   difficulty: "intermediate"
   environment: "ubuntu"
 ---

--- a/src/content/docs/linux/foundations/everyday-use/module-0.4-services-logs.md
+++ b/src/content/docs/linux/foundations/everyday-use/module-0.4-services-logs.md
@@ -7,7 +7,7 @@ sidebar:
 lab:
   id: "linux-0.4-services-logs"
   url: "https://killercoda.com/kubedojo/scenario/linux-0.4-services-logs"
-  duration: "30 min"
+  duration: "45-50 min"
   difficulty: "intermediate"
   environment: "ubuntu"
 ---

--- a/src/content/docs/linux/foundations/everyday-use/module-0.5-networking-tools.md
+++ b/src/content/docs/linux/foundations/everyday-use/module-0.5-networking-tools.md
@@ -7,7 +7,7 @@ sidebar:
 lab:
   id: "linux-0.5-networking-tools"
   url: "https://killercoda.com/kubedojo/scenario/linux-0.5-networking-tools"
-  duration: "35 min"
+  duration: "45 min"
   difficulty: "intermediate"
   environment: "ubuntu"
 ---

--- a/src/content/docs/linux/foundations/system-essentials/module-1.1-kernel-architecture.md
+++ b/src/content/docs/linux/foundations/system-essentials/module-1.1-kernel-architecture.md
@@ -9,7 +9,7 @@ lab:
   id: "linux-1.1-kernel-architecture"
   url: "https://killercoda.com/kubedojo/scenario/linux-1.1-kernel-architecture"
   duration: "35 min"
-  difficulty: "advanced"
+  difficulty: "intermediate"
   environment: "ubuntu"
 ---
 

--- a/src/content/docs/linux/index.md
+++ b/src/content/docs/linux/index.md
@@ -35,11 +35,11 @@ If your goal is:
 
 | # | Module | Time |
 |---|--------|------|
-| 0.1 | [The CLI Power User](/linux/foundations/everyday-use/module-0.1-cli-power-user/) | 30 min |
-| 0.2 | [Environment & Permissions](/linux/foundations/everyday-use/module-0.2-environment-permissions/) | 30 min |
-| 0.3 | [Process & Resource Survival Guide](/linux/foundations/everyday-use/module-0.3-processes-resources/) | 30 min |
-| 0.4 | [Services & Logs Demystified](/linux/foundations/everyday-use/module-0.4-services-logs/) | 30 min |
-| 0.5 | [Everyday Networking Tools](/linux/foundations/everyday-use/module-0.5-networking-tools/) | 30 min |
+| 0.1 | [The CLI Power User](/linux/foundations/everyday-use/module-0.1-cli-power-user/) | 45 min |
+| 0.2 | [Environment & Permissions](/linux/foundations/everyday-use/module-0.2-environment-permissions/) | 45 min |
+| 0.3 | [Process & Resource Survival Guide](/linux/foundations/everyday-use/module-0.3-processes-resources/) | 40 min |
+| 0.4 | [Services & Logs Demystified](/linux/foundations/everyday-use/module-0.4-services-logs/) | 45-50 min |
+| 0.5 | [Everyday Networking Tools](/linux/foundations/everyday-use/module-0.5-networking-tools/) | 45 min |
 
 ### [System Essentials](/linux/foundations/system-essentials/) — 4 modules
 *Kernel, processes, filesystem, permissions — the foundation of everything.*
@@ -56,10 +56,10 @@ If your goal is:
 
 | # | Module | Time |
 |---|--------|------|
-| 2.1 | [Linux Namespaces](/linux/foundations/container-primitives/module-2.1-namespaces/) | 30-35 min |
+| 2.1 | [Linux Namespaces](/linux/foundations/container-primitives/module-2.1-namespaces/) | 35-45 min |
 | 2.2 | [Control Groups (cgroups)](/linux/foundations/container-primitives/module-2.2-cgroups/) | 30-35 min |
-| 2.3 | [Capabilities & Linux Security Modules](/linux/foundations/container-primitives/module-2.3-capabilities-lsms/) | 25-30 min |
-| 2.4 | [Union Filesystems](/linux/foundations/container-primitives/module-2.4-union-filesystems/) | 25-30 min |
+| 2.3 | [Capabilities & Linux Security Modules](/linux/foundations/container-primitives/module-2.3-capabilities-lsms/) | 35-45 min |
+| 2.4 | [Union Filesystems](/linux/foundations/container-primitives/module-2.4-union-filesystems/) | 45-60 min |
 
 ### [Networking](/linux/foundations/networking/) — 4 modules
 *TCP/IP, DNS, network namespaces, iptables — the network stack that Kubernetes builds on.*
@@ -88,17 +88,17 @@ If your goal is:
 
 | # | Module | Time |
 |---|--------|------|
-| 8.1 | [Storage Management](/linux/operations/module-8.1-storage-management/) | 30-35 min |
-| 8.2 | [Network Administration](/linux/operations/module-8.2-network-administration/) | 30-35 min |
-| 8.3 | [Package & User Management](/linux/operations/module-8.3-package-user-management/) | 25-30 min |
-| 8.4 | [Scheduling & Backups](/linux/operations/module-8.4-scheduling-backups/) | 25-30 min |
+| 8.1 | [Storage Management](/linux/operations/module-8.1-storage-management/) | 35 min |
+| 8.2 | [Network Administration](/linux/operations/module-8.2-network-administration/) | 45-55 min |
+| 8.3 | [Package & User Management](/linux/operations/module-8.3-package-user-management/) | 40-50 min |
+| 8.4 | [Scheduling & Backups](/linux/operations/module-8.4-scheduling-backups/) | 45-55 min |
 
 #### [Performance](/linux/operations/performance/) — 4 modules
 
 | # | Module | Time |
 |---|--------|------|
 | 5.1 | [The USE Method](/linux/operations/performance/module-5.1-use-method/) | 25-30 min |
-| 5.2 | [CPU & Scheduling](/linux/operations/performance/module-5.2-cpu-scheduling/) | 30-35 min |
+| 5.2 | [CPU & Scheduling](/linux/operations/performance/module-5.2-cpu-scheduling/) | 40-55 min |
 | 5.3 | [Memory Management](/linux/operations/performance/module-5.3-memory-management/) | 30-35 min |
 | 5.4 | [I/O Performance](/linux/operations/performance/module-5.4-io-performance/) | 25-30 min |
 

--- a/src/content/docs/linux/operations/index.md
+++ b/src/content/docs/linux/operations/index.md
@@ -23,9 +23,9 @@ After [Security and Hardening](/linux/security/hardening/), follow the modules i
 
 ## Modules
 
-| Module | Description |
-|--------|-------------|
-| [Module 8.1: Storage Management](module-8.1-storage-management/) | Disk partitioning, filesystems, and LVM |
-| [Module 8.2: Network Administration](module-8.2-network-administration/) | Network configuration and management |
-| [Module 8.3: Package Management & User Administration](module-8.3-package-user-management/) | Package managers and user/group management |
-| [Module 8.4: Task Scheduling and Backup Strategies](module-8.4-scheduling-backups/) | Cron, systemd timers, and backup approaches |
+| Module | Description | Time |
+|--------|-------------|------|
+| [Module 8.1: Storage Management](module-8.1-storage-management/) | Disk partitioning, filesystems, and LVM | 35 min |
+| [Module 8.2: Network Administration](module-8.2-network-administration/) | Network configuration and management | 45-55 min |
+| [Module 8.3: Package Management & User Administration](module-8.3-package-user-management/) | Package managers and user/group management | 40-50 min |
+| [Module 8.4: Task Scheduling and Backup Strategies](module-8.4-scheduling-backups/) | Cron, systemd timers, and backup approaches | 45-55 min |

--- a/src/content/docs/linux/operations/module-8.2-network-administration.md
+++ b/src/content/docs/linux/operations/module-8.2-network-administration.md
@@ -7,7 +7,7 @@ sidebar:
 lab:
   id: linux-8.2-network-administration
   url: https://killercoda.com/kubedojo/scenario/linux-8.2-network-administration
-  duration: "35 min"
+  duration: "45-55 min"
   difficulty: intermediate
   environment: ubuntu
 ---

--- a/src/content/docs/linux/operations/module-8.3-package-user-management.md
+++ b/src/content/docs/linux/operations/module-8.3-package-user-management.md
@@ -7,7 +7,7 @@ sidebar:
 lab:
   id: linux-8.3-package-user-management
   url: https://killercoda.com/kubedojo/scenario/linux-8.3-package-user-management
-  duration: "30 min"
+  duration: "40-50 min"
   difficulty: intermediate
   environment: ubuntu
 ---

--- a/src/content/docs/linux/operations/module-8.4-scheduling-backups.md
+++ b/src/content/docs/linux/operations/module-8.4-scheduling-backups.md
@@ -7,7 +7,7 @@ sidebar:
 lab:
   id: linux-8.4-scheduling-backups
   url: https://killercoda.com/kubedojo/scenario/linux-8.4-scheduling-backups
-  duration: "30 min"
+  duration: "45-55 min"
   difficulty: intermediate
   environment: ubuntu
 ---

--- a/src/content/docs/linux/operations/performance/index.md
+++ b/src/content/docs/linux/operations/performance/index.md
@@ -14,7 +14,7 @@ Performance analysis is more than running `top`. This section teaches systematic
 | # | Module | Description | Time |
 |---|--------|-------------|------|
 | 5.1 | [USE Method](module-5.1-use-method/) | Systematic performance analysis: Utilization, Saturation, Errors | 25-30 min |
-| 5.2 | [CPU & Scheduling](module-5.2-cpu-scheduling/) | CPU utilization, load average, CFS scheduler, priorities | 30-35 min |
+| 5.2 | [CPU & Scheduling](module-5.2-cpu-scheduling/) | CPU utilization, load average, CFS scheduler, priorities | 40-55 min |
 | 5.3 | [Memory Management](module-5.3-memory-management/) | Virtual memory, caching, swap, OOM killer | 30-35 min |
 | 5.4 | [I/O Performance](module-5.4-io-performance/) | Disk I/O, filesystems, block devices, storage tuning | 25-30 min |
 

--- a/src/content/docs/linux/operations/performance/module-5.2-cpu-scheduling.md
+++ b/src/content/docs/linux/operations/performance/module-5.2-cpu-scheduling.md
@@ -7,7 +7,7 @@ sidebar:
 lab:
   id: linux-5.2-cpu-scheduling
   url: https://killercoda.com/kubedojo/scenario/linux-5.2-cpu-scheduling
-  duration: "35 min"
+  duration: "40-55 min"
   difficulty: advanced
   environment: ubuntu
 ---


### PR DESCRIPTION
## What
Discrete mechanical consistency fixes from GLM's linux re-audit (#2181). 18 files. (Track-wide complexity-marker FORMAT normalization stays with the infra normalizer.)

- **1.1 kernel-architecture**: frontmatter `difficulty: "advanced"` reconciled to intermediate to match body `[MEDIUM]`.
- **2.1 namespaces**: gained the Complexity/Time header block matching siblings 2.2–2.4 (its marker previously lived only in prose).
- **Time-to-complete drift**: body markers kept as source of truth; subsection index time columns + `lab.duration` frontmatter reconciled to them across everyday-use + operations; everyday-use total corrected.
- **container-primitives 2.1–2.4**: added the missing `lab:` frontmatter blocks (id/url/duration/difficulty/environment) matching sibling sections.

## Verification
- Build green: 2169 pages, 0 errors.
- Cross-family review: codex (OpenAI) author → **cursor/Composer (Kimi) R1: APPROVE_WITH_NITS**. Time-reconciliation direction confirmed correct (body preserved, index/lab updated). One P2 (2.1 header conversion) reviewed + accepted as the intended sibling-matching header fix, content preserved.

Closes #2181

## Learner check
> Create a named network namespace and inspect its default state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)