### PR TITLE
docs(leveling): deterministic complexity-marker normalizer + repo-wide normalization (#2141 #2146 #2181 #2187 #2195)

### DIFF
--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -14,6 +14,39 @@ Minimum requirements:
 
 This gate applies before the 7-dimension score is considered valid.
 
+---
+
+## Complexity Marker Convention (locked)
+
+Every module carries exactly one **complexity marker** in its top-of-module banner.
+The canonical form is a **backticked bracketed tier** inside the body blockquote:
+
+```
+> **Complexity**: `[MEDIUM]`
+```
+
+- **Controlled vocabulary — five tiers only:** `[QUICK]`, `[MEDIUM]`, `[COMPLEX]`,
+  `[ADVANCED]`, `[EXPERT]`. Do not invent tiers or use bare words
+  ("Intermediate", "Advanced"), bare brackets (`[MEDIUM]` without backticks), or
+  a `complexity:` frontmatter key. The **body marker is the single source of truth**;
+  the legacy `complexity:` frontmatter key is dropped.
+- **`[ADVANCED]` is sanctioned** as the tier between `[COMPLEX]` and `[EXPERT]`
+  (production engineering at senior scale) — see Dimension 8, which scores
+  `[COMPLEX]`/`[ADVANCED]`/`[EXPERT]` on the same practitioner-depth band.
+- **`[BEGINNER]` is not a tier.** It maps to `[QUICK]` (the introductory band).
+- Non-canonical spellings map deterministically: `Intermediate`/`[INTERMEDIATE]` →
+  `[MEDIUM]`, `Advanced` → `[ADVANCED]`, `Complex` → `[COMPLEX]`; a range maps to
+  its **ceiling** ("Beginner to intermediate" → `[MEDIUM]`, "Intermediate to
+  Advanced" → `[ADVANCED]`).
+- The banner blockquote format is specified in `.claude/rules/module-quality.md`.
+
+**Enforcement:** `scripts/normalize_complexity_markers.py` rewrites any drifted
+marker token to canonical form and drops the `complexity:` frontmatter key
+(`--check` reports drift, `--write` fixes it). This normalizer is **format-only** —
+it never re-levels a module based on content judgement; a genuinely mislabeled tier
+(e.g. a `[QUICK]` module whose content is medior) is tracked as a separate content
+follow-up, not silently re-tiered. Locked via #2141 / #2146 / #2181 / #2187 / #2195.
+
 > **Pipeline note (v2 quality pipeline)**: the v2 cross-family review (`scripts/quality/prompts.py::review_prompt`) deliberately **suspends** the Citation Gate during the rewrite/review phase because citation insertion is owned by a separate downstream stage (`scripts/citation_backfill.py`). The writer is instructed to preserve any pre-existing `## Sources` section verbatim and not to add a new one. After v2 reaches `COMMITTED`, run `python -m scripts.quality.pipeline backfill-pending` (or invoke `scripts/citation_backfill.py research/inject` per slug) to satisfy the gate. A v2-rewritten module that has not yet been backfilled is **expected** to score low on this rubric until backfill runs — that is not a v2 bug, it is the seam between the two pipelines.
 
 ---

--- a/scripts/normalize_complexity_markers.py
+++ b/scripts/normalize_complexity_markers.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Deterministic complexity-marker normalizer.
+
+Canonical complexity marker (locked convention, see docs/quality-rubric.md and
+issues #2141 #2146 #2181 #2187 #2195): the tier token is a **backticked bracketed
+tier** — one of ``[QUICK]`` ``[MEDIUM]`` ``[COMPLEX]`` ``[ADVANCED]`` ``[EXPERT]`` —
+i.e. written as `` `[MEDIUM]` `` inside the module's header/banner line. The single
+source of truth is the BODY marker; the legacy ``complexity:`` frontmatter key is
+dropped.
+
+What this tool normalizes (deterministic, token-only, container-preserving):
+
+  1. Bare-word tiers          -> backticked bracket, mapped to the controlled vocab:
+       Quick/Medium/Complex/Advanced/Expert (any caps)  -> `[SAME]`
+       Intermediate                                      -> `[MEDIUM]`
+       Beginner                                          -> `[QUICK]`
+       ranges map to their CEILING (spaced OR hyphenated):
+       "Beginner to intermediate" / "Beginner-to-..."    -> `[MEDIUM]`
+       "Intermediate to Advanced" / "Intermediate-to-Advanced" -> `[ADVANCED]`
+  2. Bare bracket   `[MEDIUM]`  (no backticks)            -> `` `[MEDIUM]` ``
+  3. Non-canonical `[BEGINNER]` tier                      -> `` `[QUICK]` `` (mapped)
+  4. Top-level `complexity:` frontmatter key             -> removed (body is SoT)
+
+What it deliberately does NOT do (out of scope; would restructure internally
+consistent per-track layouts and is not asked for by the driving issues):
+
+  * It does not move a marker into a blockquote. A ``## Complexity: [MEDIUM]``
+    heading or a ``| Complexity | ... |`` table cell keeps its container; only the
+    tier TOKEN inside it is canonicalized.
+  * It does not re-LEVEL a module based on content judgement. ``[QUICK]`` stays
+    ``[QUICK]`` even where the audit (e.g. #2141) flags a genuine mislabel — those
+    are tracked as separate content follow-ups.
+
+Guards against false positives on prose:
+  * The "Complexity" label is matched case-sensitively (capital C); lowercase prose
+    "complexity" is ignored.
+  * Tier spellings are title/upper case; lowercase prose "advanced" is ignored.
+  * Only a FRAMED marker (bold ``**Complexity**``, or a line led by ``>``/``#``/``|``)
+    within the first BODY_SCAN_LINES body lines is rewritten, and only the FIRST such
+    marker per file. A bare line-leading ``Complexity: Advanced users…`` prose
+    sentence is NOT framed, so it is left untouched.
+
+Usage:
+  python scripts/normalize_complexity_markers.py            # dry-run report
+  python scripts/normalize_complexity_markers.py --write    # apply in place
+  python scripts/normalize_complexity_markers.py --check    # exit 1 if any drift
+  python scripts/normalize_complexity_markers.py --root src/content/docs/cloud
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+DEFAULT_ROOT = "src/content/docs"
+BODY_SCAN_LINES = 25  # marker banners always sit at the very top of the body
+
+SANCTIONED = ("QUICK", "MEDIUM", "COMPLEX", "ADVANCED", "EXPERT")
+_TIER_RANK = {"QUICK": 0, "MEDIUM": 1, "COMPLEX": 2, "ADVANCED": 3, "EXPERT": 4}
+
+# Bare-word tier synonyms (audience words included). A range "X to Y" (spaced or
+# hyphenated) maps to its CEILING = the higher-ranked of the two tiers.
+_WORD_TO_TIER = {
+    "quick": "QUICK",
+    "beginner": "QUICK",
+    "medium": "MEDIUM",
+    "intermediate": "MEDIUM",
+    "complex": "COMPLEX",
+    "advanced": "ADVANCED",
+    "expert": "EXPERT",
+}
+_TIER_WORD_ALT = "Beginner|Intermediate|Advanced|Complex|Medium|Quick|Expert"
+# Range separator: "to" flanked by whitespace and/or hyphens (spaced OR hyphenated).
+_RANGE_RE = re.compile(r"^(?P<a>[a-z]+)[\s\-]+to[\s\-]+(?P<b>[a-z]+)$", re.IGNORECASE)
+
+_LABEL = r"(?P<label>(?:[#>\s\-\|]*)?\*{0,2}Complexity\*{0,2}\s*[:|]?\*{0,2}\s*)"
+_VALUE = (
+    r"(?P<value>"
+    r"`\[(?:QUICK|MEDIUM|COMPLEX|ADVANCED|EXPERT|BEGINNER|INTERMEDIATE)\]`"   # backticked bracket
+    r"|\[(?:QUICK|MEDIUM|COMPLEX|ADVANCED|EXPERT|BEGINNER|INTERMEDIATE)\]"     # bare bracket
+    # range: two tier words joined by " to " or "-to-" (MUST precede single words)
+    r"|(?i:" + _TIER_WORD_ALT + r")[\s\-]+to[\s\-]+(?i:" + _TIER_WORD_ALT + r")"
+    r"|QUICK|MEDIUM|COMPLEX|ADVANCED|EXPERT"                                   # bareword upper
+    r"|Intermediate|Beginner|Advanced|Complex|Medium|Quick|Expert"            # bareword title
+    r")"
+)
+# Case-sensitive: capital "Complexity" + title/upper single-tier spellings exclude
+# prose; the range group is scoped-insensitive so "Beginner to intermediate" matches.
+_MARKER_RE = re.compile(_LABEL + _VALUE)
+_FM_COMPLEXITY_RE = re.compile(r"^complexity\s*:", re.IGNORECASE)  # top-level key only
+
+
+def canonical_tier(raw: str) -> str:
+    """Map a raw tier token to one of the 5 sanctioned tiers (upper, unbracketed).
+
+    A range ("X to Y" / "X-to-Y") maps to its ceiling (higher-ranked tier).
+    """
+    s = raw.strip().strip("`").strip("[]").strip()
+    m = _RANGE_RE.match(s)
+    if m:
+        t1 = _WORD_TO_TIER.get(m.group("a").lower())
+        t2 = _WORD_TO_TIER.get(m.group("b").lower())
+        if t1 and t2:
+            return t1 if _TIER_RANK[t1] >= _TIER_RANK[t2] else t2
+    low = s.lower()
+    if low in _WORD_TO_TIER:
+        return _WORD_TO_TIER[low]
+    up = s.upper()
+    if up in SANCTIONED:
+        return up
+    raise ValueError(f"unmappable tier token: {raw!r}")
+
+
+def _is_framed(line: str, m: re.Match) -> bool:
+    """A genuine marker banner is bold-framed (**Complexity**) or on a >/#/| line.
+
+    A bare line-leading "Complexity: Advanced users …" prose sentence is NOT framed,
+    so it is left untouched (guards the docstring's no-prose-rewrite contract).
+    """
+    lstr = line.lstrip()
+    if lstr[:1] in (">", "#", "|"):
+        return True
+    if "**Complexity" in m.group("label") or "Complexity**" in line[: m.end("label")]:
+        return True
+    return False
+
+
+def normalize_marker_line(line: str):
+    """Return (new_line, changed, before_token, after_token) for a marker line."""
+    m = _MARKER_RE.search(line)
+    if not m or not _is_framed(line, m):
+        return line, False, None, None
+    raw_val = m.group("value")
+    tier = canonical_tier(raw_val)
+    canonical = f"`[{tier}]`"
+    if raw_val == canonical:
+        return line, False, raw_val, canonical
+    new_line = line[: m.start("value")] + canonical + line[m.end("value") :]
+    return new_line, new_line != line, raw_val, canonical
+
+
+def _split_frontmatter(lines):
+    """Return (fm_start, fm_end) line indices of the YAML frontmatter, or (-1,-1)."""
+    if not lines or lines[0].strip() != "---":
+        return -1, -1
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            return 0, i
+    return -1, -1
+
+
+def process_file(path: str):
+    """Return dict describing the change (or None if nothing to do)."""
+    with open(path, encoding="utf-8") as f:
+        lines = f.readlines()
+
+    fm_start, fm_end = _split_frontmatter(lines)
+    changed = False
+    result = {"path": path, "fm_removed": None, "marker": None}
+
+    # 1) drop top-level frontmatter complexity: key
+    if fm_end > 0:
+        new_fm = []
+        for ln in lines[fm_start + 1 : fm_end]:
+            if _FM_COMPLEXITY_RE.match(ln):
+                result["fm_removed"] = ln.strip()
+                changed = True
+                continue
+            new_fm.append(ln)
+        if result["fm_removed"] is not None:
+            lines = lines[: fm_start + 1] + new_fm + lines[fm_end:]
+            # recompute fm_end after removal
+            fm_start, fm_end = _split_frontmatter(lines)
+
+    body_start = fm_end + 1 if fm_end > 0 else 0
+    # 2) normalize the FIRST framed marker token within the top of the body
+    scanned = 0
+    for idx in range(body_start, len(lines)):
+        if scanned >= BODY_SCAN_LINES:
+            break
+        scanned += 1
+        new_line, ln_changed, before, after = normalize_marker_line(lines[idx])
+        m = _MARKER_RE.search(lines[idx])
+        if m and _is_framed(lines[idx], m):
+            # found the marker banner (whether or not it needs changing) -> stop
+            if ln_changed:
+                lines[idx] = new_line
+                result["marker"] = (before, after, lines[idx].rstrip("\n"))
+                changed = True
+            else:
+                result["marker"] = (before, after, None)  # already canonical
+            break
+
+    if not changed:
+        return None
+    result["new_content"] = "".join(lines)
+    return result
+
+
+def iter_md_files(root: str):
+    for dirpath, _dirs, filenames in os.walk(root):
+        # exclude Ukrainian translation lane
+        if os.sep + "uk" + os.sep in dirpath + os.sep or dirpath.rstrip(os.sep).endswith(os.sep + "uk"):
+            continue
+        parts = os.path.relpath(dirpath, root).split(os.sep)
+        if parts and parts[0] == "uk":
+            continue
+        for fn in filenames:
+            if fn.endswith(".md"):
+                yield os.path.join(dirpath, fn)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Normalize complexity markers to canonical form.")
+    ap.add_argument("--root", default=DEFAULT_ROOT, help="content root to scan")
+    ap.add_argument("--write", action="store_true", help="apply changes in place")
+    ap.add_argument("--check", action="store_true", help="exit 1 if any drift found (no write)")
+    args = ap.parse_args(argv)
+
+    root = args.root
+    if not os.path.isdir(root):
+        # allow running from repo root or elsewhere
+        alt = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), root)
+        if os.path.isdir(alt):
+            root = alt
+        else:
+            print(f"ERROR: root not found: {args.root}", file=sys.stderr)
+            return 2
+
+    changes = []
+    for path in sorted(iter_md_files(root)):
+        try:
+            res = process_file(path)
+        except ValueError as e:
+            print(f"SKIP {path}: {e}", file=sys.stderr)
+            continue
+        if res:
+            changes.append(res)
+
+    n_fm = sum(1 for c in changes if c["fm_removed"])
+    n_marker = sum(1 for c in changes if c["marker"] and c["marker"][2])
+    for c in changes:
+        rel = os.path.relpath(c["path"], root)
+        bits = []
+        if c["fm_removed"]:
+            bits.append(f"fm-drop({c['fm_removed']})")
+        if c["marker"] and c["marker"][2]:
+            bits.append(f"{c['marker'][0]} -> {c['marker'][1]}")
+        print(f"{rel}: {'; '.join(bits)}")
+
+    print(
+        f"\n{len(changes)} files changed  "
+        f"({n_marker} marker tokens, {n_fm} frontmatter keys dropped)",
+        file=sys.stderr,
+    )
+
+    if args.write:
+        for c in changes:
+            with open(c["path"], "w", encoding="utf-8") as f:
+                f.write(c["new_content"])
+        print(f"WROTE {len(changes)} files", file=sys.stderr)
+        return 0
+
+    if args.check:
+        return 1 if changes else 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_normalize_complexity_markers.py
+++ b/scripts/tests/test_normalize_complexity_markers.py
@@ -1,0 +1,160 @@
+"""Regression tests for scripts/normalize_complexity_markers.py.
+
+Covers the deterministic tier-token transform, the false-positive guards (prose
+"complexity"/"advanced" must be left alone), frontmatter-key removal, container
+preservation, and idempotency.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load():
+    module_path = Path(__file__).resolve().parents[1] / "normalize_complexity_markers.py"
+    spec = importlib.util.spec_from_file_location("normalize_complexity_markers", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ncm = _load()
+
+
+@pytest.mark.parametrize(
+    "line,expected",
+    [
+        # already-canonical -> unchanged
+        ("> **Complexity**: `[QUICK]` - Absolute beginner\n", "> **Complexity**: `[QUICK]` - Absolute beginner\n"),
+        ("## Complexity: `[COMPLEX]`\n", "## Complexity: `[COMPLEX]`\n"),
+        ("| **Complexity** | `[QUICK]` - Essential orientation |\n", "| **Complexity** | `[QUICK]` - Essential orientation |\n"),
+        # bare bracket -> backticked (container preserved: heading stays a heading)
+        ("## Complexity: [MEDIUM]\n", "## Complexity: `[MEDIUM]`\n"),
+        ("> **Complexity**: [MEDIUM]\n", "> **Complexity**: `[MEDIUM]`\n"),
+        ("> **Complexity:** [MEDIUM]\n", "> **Complexity:** `[MEDIUM]`\n"),
+        # bareword sanctioned -> backticked bracket
+        ("> **Complexity**: MEDIUM\n", "> **Complexity**: `[MEDIUM]`\n"),
+        ("> **Complexity**: Advanced\n", "> **Complexity**: `[ADVANCED]`\n"),
+        ("> **Complexity**: Complex\n", "> **Complexity**: `[COMPLEX]`\n"),
+        # synonyms
+        ("> **Complexity**: Intermediate\n", "> **Complexity**: `[MEDIUM]`\n"),
+        ("**Complexity**: Intermediate<br>\n", "**Complexity**: `[MEDIUM]`<br>\n"),
+        ("> **Complexity**: [BEGINNER]\n", "> **Complexity**: `[QUICK]`\n"),
+        ("> **Complexity**: `[INTERMEDIATE]`\n", "> **Complexity**: `[MEDIUM]`\n"),
+        # ranges map to the ceiling tier (spaced AND hyphenated, listed and unlisted)
+        ("**Complexity**: Intermediate to Advanced  \n", "**Complexity**: `[ADVANCED]`  \n"),
+        ("> **Complexity:** Beginner to intermediate  \n", "> **Complexity:** `[MEDIUM]`  \n"),
+        # regression #2217-R1: hyphenated range must not partial-replace to `[MEDIUM]`-to-Advanced
+        (
+            "> Track: AI/ML Engineering | Complexity: Intermediate-to-Advanced | Time: 100-120 minutes\n",
+            "> Track: AI/ML Engineering | Complexity: `[ADVANCED]` | Time: 100-120 minutes\n",
+        ),
+        ("> **Complexity**: Beginner-to-Advanced\n", "> **Complexity**: `[ADVANCED]`\n"),
+        ("> **Complexity**: Beginner to Advanced\n", "> **Complexity**: `[ADVANCED]`\n"),
+        # blockquote banner with track prefix, non-bold Complexity
+        (
+            "> Track: AI/ML Engineering | Complexity: Intermediate | Time: 90-120 minutes\n",
+            "> Track: AI/ML Engineering | Complexity: `[MEDIUM]` | Time: 90-120 minutes\n",
+        ),
+        # inline sentence, non-blockquote -> container preserved
+        (
+            "**Complexity:** Advanced. **Time to complete:** 90-120 minutes.\n",
+            "**Complexity:** `[ADVANCED]`. **Time to complete:** 90-120 minutes.\n",
+        ),
+    ],
+)
+def test_normalize_marker_line(line, expected):
+    got, _changed, _b, _a = ncm.normalize_marker_line(line)
+    assert got == expected
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        # prose: lowercase "complexity" -> never a marker
+        "This adds complexity: advanced users can tune it.\n",
+        "The complexity of distributed systems grows quickly.\n",
+        # prose with lowercase tier word after a capital-Complexity mention but unframed
+        "Complexity here is advanced compared to before, in normal prose.\n",
+        # regression #2217-R1 P2: line-leading capital-Complexity prose is NOT a framed
+        # marker (no bold, no >/#/|) -> must be left untouched
+        "Complexity: Advanced users can tune it.\n",
+    ],
+)
+def test_prose_is_not_rewritten(line):
+    got, changed, _b, _a = ncm.normalize_marker_line(line)
+    assert got == line
+    assert changed is False
+
+
+def test_idempotent():
+    line = "> **Complexity**: Intermediate\n"
+    once, _c, _b, _a = ncm.normalize_marker_line(line)
+    twice, changed2, _b2, _a2 = ncm.normalize_marker_line(once)
+    assert once == twice
+    assert changed2 is False
+
+
+@pytest.mark.parametrize(
+    "raw,tier",
+    [
+        ("Intermediate", "MEDIUM"),
+        ("intermediate", "MEDIUM"),
+        ("Beginner", "QUICK"),
+        ("[BEGINNER]", "QUICK"),
+        ("`[INTERMEDIATE]`", "MEDIUM"),
+        ("Beginner to intermediate", "MEDIUM"),
+        ("Intermediate to Advanced", "ADVANCED"),
+        ("Intermediate-to-Advanced", "ADVANCED"),
+        ("Beginner-to-Advanced", "ADVANCED"),
+        ("Beginner to Advanced", "ADVANCED"),
+        ("Advanced to Intermediate", "ADVANCED"),
+        ("MEDIUM", "MEDIUM"),
+        ("`[COMPLEX]`", "COMPLEX"),
+    ],
+)
+def test_canonical_tier(raw, tier):
+    assert ncm.canonical_tier(raw) == tier
+
+
+def test_canonical_tier_rejects_unknown():
+    with pytest.raises(ValueError):
+        ncm.canonical_tier("Legendary")
+
+
+def test_process_file_drops_frontmatter_key(tmp_path):
+    p = tmp_path / "m.md"
+    p.write_text(
+        "---\n"
+        'title: "X"\n'
+        'complexity: "MEDIUM"\n'
+        "sidebar:\n"
+        "  order: 3\n"
+        "---\n"
+        "\n"
+        "> **Complexity**: MEDIUM\n"
+        "\n"
+        "Body mentions complexity: advanced in prose and must not change.\n",
+        encoding="utf-8",
+    )
+    res = ncm.process_file(str(p))
+    assert res is not None
+    out = res["new_content"]
+    assert "complexity:" not in out.split("---\n")[1]  # frontmatter key gone
+    assert "> **Complexity**: `[MEDIUM]`\n" in out  # body token canonicalized
+    assert "complexity: advanced in prose" in out  # prose untouched
+
+
+def test_process_file_noop_when_canonical(tmp_path):
+    p = tmp_path / "m.md"
+    p.write_text(
+        "---\ntitle: X\n---\n\n> **Complexity**: `[MEDIUM]`\n\nBody.\n",
+        encoding="utf-8",
+    )
+    assert ncm.process_file(str(p)) is None

--- a/src/content/docs/ai-ml-engineering/deep-learning/module-1.8-self-supervised-learning.md
+++ b/src/content/docs/ai-ml-engineering/deep-learning/module-1.8-self-supervised-learning.md
@@ -6,7 +6,7 @@ sidebar:
   order: 1009
 ---
 
-> Track: AI/ML Engineering | Complexity: Intermediate | Time: 90-120 minutes
+> Track: AI/ML Engineering | Complexity: `[MEDIUM]` | Time: 90-120 minutes
 > Prerequisites: [Module 1.3.1: Initialization & Signal Propagation](module-1.3.1-initialization-signal-propagation/), [Module 1.4.4: The Transformer Block from Scratch](module-1.4.4-transformer-block-from-scratch/), and [Module 1.3: Model Evaluation, Validation, Leakage & Calibration](../../machine-learning/module-1.3-model-evaluation-validation-leakage-and-calibration/).
 Self-supervised learning, usually shortened to SSL, is the part of deep learning
 where you pretrain a model without human labels by forcing it to predict structure

--- a/src/content/docs/ai-ml-engineering/deep-learning/module-1.9-graph-neural-networks.md
+++ b/src/content/docs/ai-ml-engineering/deep-learning/module-1.9-graph-neural-networks.md
@@ -6,7 +6,7 @@ sidebar:
   order: 1010
 ---
 
-> Track: AI/ML Engineering | Complexity: Intermediate | Time: 90-120 minutes
+> Track: AI/ML Engineering | Complexity: `[MEDIUM]` | Time: 90-120 minutes
 > Prerequisites: [Module 1.3.1: Initialization & Signal Propagation](module-1.3.1-initialization-signal-propagation/), [Module 1.4.4: The Transformer Block from Scratch](module-1.4.4-transformer-block-from-scratch/), and [Module 1.3: Model Evaluation, Validation, Leakage & Calibration](../../machine-learning/module-1.3-model-evaluation-validation-leakage-and-calibration/).
 
 Graph neural networks, usually shortened to GNNs, are the part of deep learning

--- a/src/content/docs/ai-ml-engineering/machine-learning/module-1.1-scikit-learn-api-and-pipelines.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-1.1-scikit-learn-api-and-pipelines.md
@@ -6,7 +6,7 @@ sidebar:
   order: 1
 ---
 
-> **AI/ML Engineering Track** | Complexity: Intermediate | Time: 4-5 hours
+> **AI/ML Engineering Track** | Complexity: `[MEDIUM]` | Time: 4-5 hours
 > **Prerequisites**: Comfortable Python, NumPy, pandas. No prior ML library experience required.
 
 ## Learning Outcomes

--- a/src/content/docs/ai-ml-engineering/machine-learning/module-1.10-dimensionality-reduction.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-1.10-dimensionality-reduction.md
@@ -6,7 +6,7 @@ sidebar:
   order: 10
 ---
 
-> Track: AI/ML Engineering | Complexity: Intermediate | Time: 75-90 minutes
+> Track: AI/ML Engineering | Complexity: `[MEDIUM]` | Time: 75-90 minutes
 > Prerequisites: [Module 1.1: Scikit-learn API & Pipelines](../module-1.1-scikit-learn-api-and-pipelines/), [Module 1.2: Linear & Logistic Regression with Regularization](../module-1.2-linear-and-logistic-regression-with-regularization/), [Module 1.3: Model Evaluation, Validation, Leakage & Calibration](../module-1.3-model-evaluation-validation-leakage-and-calibration/), [Module 1.4: Feature Engineering & Preprocessing](../module-1.4-feature-engineering-and-preprocessing/), [Module 1.7: Naive Bayes, k-NN & SVMs](../module-1.7-naive-bayes-knn-and-svms/), [Module 1.8: Unsupervised Learning: Clustering](../module-1.8-unsupervised-learning-clustering/), and [Module 1.9: Anomaly Detection & Novelty Detection](../module-1.9-anomaly-detection-and-novelty-detection/).
 
 Most teams arrive at dimensionality reduction the same way.

--- a/src/content/docs/ai-ml-engineering/machine-learning/module-1.11-hyperparameter-optimization.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-1.11-hyperparameter-optimization.md
@@ -6,7 +6,7 @@ sidebar:
   order: 11
 ---
 
-> Track: AI/ML Engineering | Complexity: Intermediate | Time: 75-90 minutes
+> Track: AI/ML Engineering | Complexity: `[MEDIUM]` | Time: 75-90 minutes
 > Prerequisites: [Module 1.1: Scikit-learn API & Pipelines](../module-1.1-scikit-learn-api-and-pipelines/), [Module 1.2: Linear & Logistic Regression with Regularization](../module-1.2-linear-and-logistic-regression-with-regularization/), [Module 1.3: Model Evaluation, Validation, Leakage & Calibration](../module-1.3-model-evaluation-validation-leakage-and-calibration/), [Module 1.4: Feature Engineering & Preprocessing](../module-1.4-feature-engineering-and-preprocessing/), [Module 1.5: Decision Trees & Random Forests](../module-1.5-decision-trees-and-random-forests/), [Module 1.6: XGBoost & Gradient Boosting](../module-1.6-xgboost-gradient-boosting/), and [Module 1.10: Dimensionality Reduction](../module-1.10-dimensionality-reduction/).
 
 Most teams arrive at hyperparameter optimization with a goal that sounds

--- a/src/content/docs/ai-ml-engineering/machine-learning/module-1.2-linear-and-logistic-regression-with-regularization.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-1.2-linear-and-logistic-regression-with-regularization.md
@@ -6,7 +6,7 @@ sidebar:
   order: 2
 ---
 
-> **AI/ML Engineering Track** | Complexity: Intermediate | Time: 5-6 hours
+> **AI/ML Engineering Track** | Complexity: `[MEDIUM]` | Time: 5-6 hours
 > **Prerequisites**: [Module 1.1](../module-1.1-scikit-learn-api-and-pipelines/) — sklearn estimator/transformer/Pipeline contract. Comfortable NumPy and pandas.
 
 ## Learning Outcomes

--- a/src/content/docs/ai-ml-engineering/machine-learning/module-1.3-model-evaluation-validation-leakage-and-calibration.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-1.3-model-evaluation-validation-leakage-and-calibration.md
@@ -6,7 +6,7 @@ sidebar:
   order: 3
 ---
 
-> **AI/ML Engineering Track** | Complexity: Intermediate | Time: 5-6 hours
+> **AI/ML Engineering Track** | Complexity: `[MEDIUM]` | Time: 5-6 hours
 > **Prerequisites**: Module 1.1, `Pipeline`, `ColumnTransformer`, `cross_validate`, `train_test_split`, and comfortable NumPy/pandas.
 
 ## Learning Outcomes

--- a/src/content/docs/ai-ml-engineering/machine-learning/module-1.4-feature-engineering-and-preprocessing.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-1.4-feature-engineering-and-preprocessing.md
@@ -6,7 +6,7 @@ sidebar:
   order: 4
 ---
 
-> **AI/ML Engineering Track** | Complexity: Intermediate | Time: 5-6 hours
+> **AI/ML Engineering Track** | Complexity: `[MEDIUM]` | Time: 5-6 hours
 > **Prerequisites**: [Module 1.1](../module-1.1-scikit-learn-api-and-pipelines/) (Pipeline, ColumnTransformer, custom transformers) and [Module 1.3](../module-1.3-model-evaluation-validation-leakage-and-calibration/) (CV-aware fitting, leakage taxonomy). Comfortable NumPy and pandas.
 
 ## Learning Outcomes

--- a/src/content/docs/ai-ml-engineering/machine-learning/module-1.5-decision-trees-and-random-forests.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-1.5-decision-trees-and-random-forests.md
@@ -6,7 +6,7 @@ sidebar:
   order: 5
 ---
 
-> Track: AI/ML Engineering | Complexity: Intermediate | Time: 75-90 minutes
+> Track: AI/ML Engineering | Complexity: `[MEDIUM]` | Time: 75-90 minutes
 > Prerequisites: [Module 1.1: Scikit-learn API & Pipelines](../module-1.1-scikit-learn-api-and-pipelines/), [Module 1.3: Model Evaluation, Validation, Leakage & Calibration](../module-1.3-model-evaluation-validation-leakage-and-calibration/), and [Module 1.4: Feature Engineering & Preprocessing](../module-1.4-feature-engineering-and-preprocessing/).
 
 ## Learning Outcomes

--- a/src/content/docs/ai-ml-engineering/machine-learning/module-1.7-naive-bayes-knn-and-svms.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-1.7-naive-bayes-knn-and-svms.md
@@ -6,7 +6,7 @@ sidebar:
   order: 7
 ---
 
-> Track: AI/ML Engineering | Complexity: Intermediate | Time: 75-90 minutes
+> Track: AI/ML Engineering | Complexity: `[MEDIUM]` | Time: 75-90 minutes
 > Prerequisites: [Module 1.1: Scikit-learn API & Pipelines](../module-1.1-scikit-learn-api-and-pipelines/), [Module 1.3: Model Evaluation, Validation, Leakage & Calibration](../module-1.3-model-evaluation-validation-leakage-and-calibration/), and [Module 1.4: Feature Engineering & Preprocessing](../module-1.4-feature-engineering-and-preprocessing/).
 
 ## Learning Outcomes

--- a/src/content/docs/ai-ml-engineering/machine-learning/module-1.8-unsupervised-learning-clustering.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-1.8-unsupervised-learning-clustering.md
@@ -6,7 +6,7 @@ sidebar:
   order: 8
 ---
 
-> Track: AI/ML Engineering | Complexity: Intermediate | Time: 75-90 minutes
+> Track: AI/ML Engineering | Complexity: `[MEDIUM]` | Time: 75-90 minutes
 > Prerequisites: [Module 1.1: Scikit-learn API & Pipelines](../module-1.1-scikit-learn-api-and-pipelines/), [Module 1.3: Model Evaluation, Validation, Leakage & Calibration](../module-1.3-model-evaluation-validation-leakage-and-calibration/), [Module 1.4: Feature Engineering & Preprocessing](../module-1.4-feature-engineering-and-preprocessing/), and [Module 1.7: Naive Bayes, k-NN & SVMs](../module-1.7-naive-bayes-knn-and-svms/).
 
 ## Learning Outcomes

--- a/src/content/docs/ai-ml-engineering/machine-learning/module-1.9-anomaly-detection-and-novelty-detection.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-1.9-anomaly-detection-and-novelty-detection.md
@@ -7,7 +7,7 @@ sidebar:
   order: 9
 ---
 
-> **Complexity**: Intermediate
+> **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 75-90 minutes
 >

--- a/src/content/docs/ai-ml-engineering/machine-learning/module-2.1-class-imbalance-and-cost-sensitive-learning.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-2.1-class-imbalance-and-cost-sensitive-learning.md
@@ -6,7 +6,7 @@ sidebar:
   order: 21
 ---
 
-> Track: AI/ML Engineering | Complexity: Intermediate | Time: 90-110 minutes
+> Track: AI/ML Engineering | Complexity: `[MEDIUM]` | Time: 90-110 minutes
 > Prerequisites: [Module 1.1: Scikit-learn API & Pipelines](../module-1.1-scikit-learn-api-and-pipelines/), [Module 1.3: Model Evaluation, Validation, Leakage & Calibration](../module-1.3-model-evaluation-validation-leakage-and-calibration/), [Module 1.4: Feature Engineering & Preprocessing](../module-1.4-feature-engineering-and-preprocessing/), [Module 1.7: Naive Bayes, k-NN & SVMs](../module-1.7-naive-bayes-knn-and-svms/), and [Module 1.9: Anomaly Detection & Novelty Detection](../module-1.9-anomaly-detection-and-novelty-detection/).
 
 Class imbalance is one of those topics where the first instinct is almost always wrong. A practitioner sees a 1:50 positive class, reaches for SMOTE, applies it before the train/test split because that is the order the snippet on Stack Overflow uses, and then reports a cross-validated F1 that looks like a small miracle. Production never reproduces it. The model is fine. The data is fine. The evaluation lied, because synthetic minority samples crossed the fold boundary and the held-out metric was scoring on rows that shared neighbors with rows the resampler had used to manufacture training data.

--- a/src/content/docs/ai-ml-engineering/machine-learning/module-2.2-interpretability-and-failure-slicing.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-2.2-interpretability-and-failure-slicing.md
@@ -6,7 +6,7 @@ sidebar:
   order: 22
 ---
 
-> Track: AI/ML Engineering | Complexity: Intermediate | Time: 90-110 minutes
+> Track: AI/ML Engineering | Complexity: `[MEDIUM]` | Time: 90-110 minutes
 > Prerequisites: [Module 1.1: Scikit-learn API & Pipelines](../module-1.1-scikit-learn-api-and-pipelines/), [Module 1.3: Model Evaluation, Validation, Leakage & Calibration](../module-1.3-model-evaluation-validation-leakage-and-calibration/), [Module 1.5: Decision Trees & Random Forests](../module-1.5-decision-trees-and-random-forests/), and [Module 1.6: XGBoost & Gradient Boosting](../module-1.6-xgboost-gradient-boosting/).
 
 The on-call interpretability incident usually begins with a well-intentioned report. A team ships a SHAP appendix to compliance, the appendix lists top drivers for denied applications, and the next meeting treats those SHAP values as if they were causal statements about the world. They are not. SHAP describes what the model did with the features it was given; it does not prove that changing a feature would change the real outcome in the same way. The second version of the same incident is operational instead of legal: a team spends a week reading per-row SHAP plots for 50,000 denials, when the real failure is concentrated in one cohort that a slice table would have surfaced in ten minutes. This module is the corrective. The interpretability tool has to match the question. SHAP describes the model, not reality, and per-row attribution is rarely the right operational tool when the defect lives at the cohort level.

--- a/src/content/docs/ai-ml-engineering/machine-learning/module-2.3-probabilistic-and-bayesian-ml-with-pymc.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-2.3-probabilistic-and-bayesian-ml-with-pymc.md
@@ -6,7 +6,7 @@ sidebar:
   order: 23
 ---
 
-> Track: AI/ML Engineering | Complexity: Intermediate | Time: 90-110 minutes
+> Track: AI/ML Engineering | Complexity: `[MEDIUM]` | Time: 90-110 minutes
 > Prerequisites: [Module 1.2: Linear and Logistic Regression with Regularization](../module-1.2-linear-and-logistic-regression-with-regularization/), [Module 1.3: Model Evaluation, Validation, Leakage & Calibration](../module-1.3-model-evaluation-validation-leakage-and-calibration/), and [Module 1.12: Time Series Forecasting](../module-1.12-time-series-forecasting/). This module also sets up a plain-text forward reference to Module 2.5, conformal prediction and uncertainty quantification.
 
 The on-call story for Bayesian ML rarely starts with a philosophical argument

--- a/src/content/docs/ai-ml-engineering/machine-learning/module-2.4-recommender-systems.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-2.4-recommender-systems.md
@@ -6,7 +6,7 @@ sidebar:
   order: 24
 ---
 
-> Track: AI/ML Engineering | Complexity: Intermediate | Time: 90-110 minutes
+> Track: AI/ML Engineering | Complexity: `[MEDIUM]` | Time: 90-110 minutes
 > Prerequisites: [Module 1.3: Model Evaluation, Validation, Leakage & Calibration](../module-1.3-model-evaluation-validation-leakage-and-calibration/), [Module 1.4: Feature Engineering & Preprocessing](../module-1.4-feature-engineering-and-preprocessing/), [Module 1.7: Naive Bayes, k-NN & SVMs](../module-1.7-naive-bayes-knn-and-svms/), [Module 1.10: Dimensionality Reduction](../module-1.10-dimensionality-reduction/), and [Module 2.1: Class Imbalance & Cost-Sensitive Learning](../module-2.1-class-imbalance-and-cost-sensitive-learning/). This module also sets up a plain-text forward reference to Module 2.5, conformal prediction and uncertainty quantification.
 
 The on-call story for recommender systems starts after the celebration. A team ships a fancy recommender that looked excellent in the notebook. Offline NDCG@10 was high. The dashboard was clean. The model card said the ranking objective matched the product surface. Then the A/B test failed. The first instinct was to blame traffic, seasonality, or a missing feature flag. The deeper review found a plainer problem. The offline split was random, so the same users appeared on both sides. The model was partly memorizing future taste. The popularity baseline was actually beating the new model in production. The offline metric the team celebrated did not match the engagement metric the deployment paid for.

--- a/src/content/docs/ai-ml-engineering/machine-learning/module-2.5-conformal-prediction-and-uncertainty-quantification.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-2.5-conformal-prediction-and-uncertainty-quantification.md
@@ -6,7 +6,7 @@ sidebar:
   order: 25
 ---
 
-> Track: AI/ML Engineering | Complexity: Intermediate | Time: 90-110 minutes
+> Track: AI/ML Engineering | Complexity: `[MEDIUM]` | Time: 90-110 minutes
 > Prerequisites: [Module 1.2: Linear and Logistic Regression with Regularization](../module-1.2-linear-and-logistic-regression-with-regularization/), [Module 1.3: Model Evaluation, Validation, Leakage & Calibration](../module-1.3-model-evaluation-validation-leakage-and-calibration/), and [Module 2.3: Probabilistic & Bayesian ML with PyMC](../module-2.3-probabilistic-and-bayesian-ml-with-pymc/). This module also sets up a plain-text forward reference to Module 2.6, fairness and bias auditing.
 
 The on-call story for conformal prediction usually begins with a team that believes it already has uncertainty. A regression or classification model is in production. The dashboard includes a confidence column. The

--- a/src/content/docs/ai-ml-engineering/machine-learning/module-2.6-fairness-and-bias-auditing.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-2.6-fairness-and-bias-auditing.md
@@ -6,7 +6,7 @@ sidebar:
   order: 26
 ---
 
-> Track: AI/ML Engineering | Complexity: Intermediate | Time: 90-110 minutes
+> Track: AI/ML Engineering | Complexity: `[MEDIUM]` | Time: 90-110 minutes
 > Prerequisites: [Module 1.3: Model Evaluation, Validation, Leakage & Calibration](../module-1.3-model-evaluation-validation-leakage-and-calibration/), [Module 2.2: Interpretability and Failure Slicing](../module-2.2-interpretability-and-failure-slicing/), and [Module 2.5: Conformal Prediction and Uncertainty Quantification](../module-2.5-conformal-prediction-and-uncertainty-quantification/). This module also sets up a plain-text forward reference to Module 2.7, causal inference for ML practitioners.
 
 The on-call incident starts with a chart that nobody expected to matter. The model is live. The overall accuracy is acceptable. The calibration plot from [Module

--- a/src/content/docs/ai-ml-engineering/machine-learning/module-2.7-causal-inference-for-ml-practitioners.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-2.7-causal-inference-for-ml-practitioners.md
@@ -6,7 +6,7 @@ sidebar:
   order: 27
 ---
 
-> Track: AI/ML Engineering | Complexity: Intermediate | Time: 95-115 minutes
+> Track: AI/ML Engineering | Complexity: `[MEDIUM]` | Time: 95-115 minutes
 > Prerequisites: [Module 1.3: Model Evaluation, Validation, Leakage & Calibration](../module-1.3-model-evaluation-validation-leakage-and-calibration/), [Module 2.2: Interpretability and Failure Slicing](../module-2.2-interpretability-and-failure-slicing/), and [Module 2.6: Fairness & Bias Auditing](../module-2.6-fairness-and-bias-auditing/). This is the last Tier-2 module of the Machine Learning track. The next conceptual move is Reinforcement Learning Module 2.1, Offline RL & Imitation Learning, which is forthcoming under issue #677. The forward reference is plain text rather than a link because the destination module has not landed yet.
 
 The on-call message arrives in the form of a question that sounds reasonable. A stakeholder reads the SHAP report from [Module 2.2](../module-2.2-interpretability-and-failure-slicing/), notices that `last_month_revenue` is the top driver of churn predictions, and asks the obvious follow-up. If the team intervenes by giving discounts that lower `last_month_revenue`, will customer churn drop in the same proportion that the SHAP value suggests? The honest answer is that the SHAP plot cannot answer that question. SHAP describes how the trained model uses the feature it was given. It does not establish that changing the feature in the world would change the outcome in the world. The question on the table is causal, not predictive, and the predictive model was never asked to answer it.

--- a/src/content/docs/ai-ml-engineering/mlops/module-1.4-kubernetes-for-ml.md
+++ b/src/content/docs/ai-ml-engineering/mlops/module-1.4-kubernetes-for-ml.md
@@ -5,7 +5,7 @@ sidebar:
   order: 605
 ---
 
-> **Complexity**: Intermediate
+> **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 90-120 minutes
 >

--- a/src/content/docs/ai-ml-engineering/multimodal-ai/module-1.1-voice-audio-ai.md
+++ b/src/content/docs/ai-ml-engineering/multimodal-ai/module-1.1-voice-audio-ai.md
@@ -6,7 +6,7 @@ sidebar:
   order: 902
 ---
 
-**Complexity**: Intermediate to Advanced  
+**Complexity**: `[ADVANCED]`  
 **Reading Time**: 7-8 hours
 **Prerequisites**: Phase 8 complete, basic Python, HTTP APIs, container images, and Kubernetes v1.35+ deployment knowledge.
 

--- a/src/content/docs/ai-ml-engineering/prerequisites/module-1.3-reproducible-python-cuda-rocm-environments.md
+++ b/src/content/docs/ai-ml-engineering/prerequisites/module-1.3-reproducible-python-cuda-rocm-environments.md
@@ -5,7 +5,7 @@ slug: ai-ml-engineering/prerequisites/module-1.3-reproducible-python-cuda-rocm-e
 sidebar:
   order: 103
 ---
-> **Complexity**: Intermediate
+> **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 2-3 hours
 >

--- a/src/content/docs/ai-ml-engineering/reinforcement-learning/module-1.1-rl-practitioner-foundations.md
+++ b/src/content/docs/ai-ml-engineering/reinforcement-learning/module-1.1-rl-practitioner-foundations.md
@@ -6,7 +6,7 @@ sidebar:
   order: 1
 ---
 
-> Track: AI/ML Engineering | Complexity: Intermediate | Time: 75-90 minutes
+> Track: AI/ML Engineering | Complexity: `[MEDIUM]` | Time: 75-90 minutes
 > Prerequisites: [Module 1.1: Scikit-learn API & Pipelines](../../machine-learning/module-1.1-scikit-learn-api-and-pipelines/), [Module 1.3: Model Evaluation, Validation, Leakage & Calibration](../../machine-learning/module-1.3-model-evaluation-validation-leakage-and-calibration/), [Module 1.5: Decision Trees & Random Forests](../../machine-learning/module-1.5-decision-trees-and-random-forests/), and [Module 1.11: Hyperparameter Optimization](../../machine-learning/module-1.11-hyperparameter-optimization/).
 
 Reinforcement learning rarely fails in a dramatic way first.

--- a/src/content/docs/ai-ml-engineering/reinforcement-learning/module-2.1-offline-rl-and-imitation-learning.md
+++ b/src/content/docs/ai-ml-engineering/reinforcement-learning/module-2.1-offline-rl-and-imitation-learning.md
@@ -6,7 +6,7 @@ sidebar:
   order: 21
 ---
 
-> Track: AI/ML Engineering | Complexity: Intermediate-to-Advanced | Time: 100-120 minutes
+> Track: AI/ML Engineering | Complexity: `[ADVANCED]` | Time: 100-120 minutes
 > Prerequisites: [Module 1.1: RL Practitioner Foundations](./module-1.1-rl-practitioner-foundations/), [Module 2.7: Causal Inference for ML Practitioners](../../machine-learning/module-2.7-causal-inference-for-ml-practitioners/), and comfort with supervised validation, sequential data, and Python experiment logs.
 
 The most tempting reinforcement-learning demo is also the least available production workflow. Let an agent explore.

--- a/src/content/docs/ai-ml-engineering/synthesis-apps/module-3.1-llm-native-stack-k8s.md
+++ b/src/content/docs/ai-ml-engineering/synthesis-apps/module-3.1-llm-native-stack-k8s.md
@@ -4,7 +4,7 @@ slug: ai-ml-engineering/synthesis-apps/module-3.1-llm-native-stack-k8s
 sidebar:
   order: 1
 ---
-> **Complexity**: Advanced
+> **Complexity**: `[ADVANCED]`
 >
 > **Time to Complete**: 90-120 min
 >

--- a/src/content/docs/ai-ml-engineering/synthesis-apps/module-3.2-orchestration-layer.md
+++ b/src/content/docs/ai-ml-engineering/synthesis-apps/module-3.2-orchestration-layer.md
@@ -4,7 +4,7 @@ slug: ai-ml-engineering/synthesis-apps/module-3.2-orchestration-layer
 sidebar:
   order: 2
 ---
-> **Complexity**: Advanced
+> **Complexity**: `[ADVANCED]`
 >
 > **Time to Complete**: 90-120 min
 >

--- a/src/content/docs/ai-ml-engineering/synthesis-apps/module-3.3-llm-evals-in-ci.md
+++ b/src/content/docs/ai-ml-engineering/synthesis-apps/module-3.3-llm-evals-in-ci.md
@@ -4,7 +4,7 @@ slug: ai-ml-engineering/synthesis-apps/module-3.3-llm-evals-in-ci
 sidebar:
   order: 3
 ---
-> **Complexity**: Advanced
+> **Complexity**: `[ADVANCED]`
 >
 > **Time to Complete**: 90-120 min
 >

--- a/src/content/docs/ai-ml-engineering/synthesis-apps/module-3.4-agent-observability-otel.md
+++ b/src/content/docs/ai-ml-engineering/synthesis-apps/module-3.4-agent-observability-otel.md
@@ -4,7 +4,7 @@ slug: ai-ml-engineering/synthesis-apps/module-3.4-agent-observability-otel
 sidebar:
   order: 4
 ---
-> **Complexity**: Advanced
+> **Complexity**: `[ADVANCED]`
 >
 > **Time to Complete**: 90-120 min
 >

--- a/src/content/docs/ai/ai-engineering-foundations/module-1.1-prompt-fundamentals.md
+++ b/src/content/docs/ai/ai-engineering-foundations/module-1.1-prompt-fundamentals.md
@@ -7,7 +7,7 @@ revision_pending: false
 citations_verified: true
 ---
 
-> **Complexity**: [COMPLEX]
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: 90-120 min
 >

--- a/src/content/docs/ai/ai-engineering-foundations/module-1.3-prompt-safety-and-evaluation.md
+++ b/src/content/docs/ai/ai-engineering-foundations/module-1.3-prompt-safety-and-evaluation.md
@@ -6,7 +6,7 @@ sidebar:
 revision_pending: false
 ---
 
-> **Complexity**: [COMPLEX]
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: 90-120 min
 >

--- a/src/content/docs/ai/ai-engineering-foundations/module-1.4-prompt-libraries-and-contracts.md
+++ b/src/content/docs/ai/ai-engineering-foundations/module-1.4-prompt-libraries-and-contracts.md
@@ -6,7 +6,7 @@ sidebar:
 revision_pending: false
 ---
 
-> **Complexity**: [COMPLEX]
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: 90-120 min
 >

--- a/src/content/docs/ai/ai-engineering-foundations/module-2.1-context-fundamentals.md
+++ b/src/content/docs/ai/ai-engineering-foundations/module-2.1-context-fundamentals.md
@@ -6,7 +6,7 @@ sidebar:
 revision_pending: false
 ---
 
-> **Complexity**: [COMPLEX]
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: 75-90 min
 >

--- a/src/content/docs/ai/ai-engineering-foundations/module-2.2-repository-engineering-for-agents.md
+++ b/src/content/docs/ai/ai-engineering-foundations/module-2.2-repository-engineering-for-agents.md
@@ -6,7 +6,7 @@ sidebar:
 revision_pending: false
 ---
 
-> **Complexity**: [COMPLEX]
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: 90-120 min
 >

--- a/src/content/docs/ai/ai-engineering-foundations/module-2.3-retrieval-tools-and-memory-boundaries.md
+++ b/src/content/docs/ai/ai-engineering-foundations/module-2.3-retrieval-tools-and-memory-boundaries.md
@@ -7,7 +7,7 @@ citations_verified: true
 revision_pending: false
 ---
 
-> **Complexity**: [COMPLEX]
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: 120-150 min
 >

--- a/src/content/docs/ai/ai-engineering-foundations/module-2.4-dynamic-context-orchestration.md
+++ b/src/content/docs/ai/ai-engineering-foundations/module-2.4-dynamic-context-orchestration.md
@@ -7,7 +7,7 @@ citations_verified: true
 revision_pending: false
 ---
 
-> **Complexity**: [COMPLEX]
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: ~50 minutes
 >

--- a/src/content/docs/ai/ai-engineering-foundations/module-3.1-harness-fundamentals-layers-and-system-of-record.md
+++ b/src/content/docs/ai/ai-engineering-foundations/module-3.1-harness-fundamentals-layers-and-system-of-record.md
@@ -5,7 +5,7 @@ sidebar:
   order: 31
 ---
 
-> **Complexity**: [COMPLEX]
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: ~50 minutes
 >

--- a/src/content/docs/ai/ai-engineering-foundations/module-3.2-guardrails-gates-and-agent-legible-apps.md
+++ b/src/content/docs/ai/ai-engineering-foundations/module-3.2-guardrails-gates-and-agent-legible-apps.md
@@ -7,7 +7,7 @@ citations_verified: true
 revision_pending: false
 ---
 
-> **Complexity**: [COMPLEX]
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: ~55 minutes
 >

--- a/src/content/docs/ai/ai-engineering-foundations/module-3.3-operating-the-harness.md
+++ b/src/content/docs/ai/ai-engineering-foundations/module-3.3-operating-the-harness.md
@@ -7,7 +7,7 @@ citations_verified: true
 revision_pending: false
 ---
 
-> **Complexity**: [COMPLEX]
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: ~50 minutes
 >

--- a/src/content/docs/ai/ai-engineering-foundations/module-4.1-symphony-work-orchestration-as-applied-harness.md
+++ b/src/content/docs/ai/ai-engineering-foundations/module-4.1-symphony-work-orchestration-as-applied-harness.md
@@ -5,7 +5,7 @@ sidebar:
   order: 41
 ---
 
-> **Complexity**: [COMPLEX]
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: ~60 minutes
 >

--- a/src/content/docs/ai/ai-for-kubernetes-platform-work/module-1.1-ai-for-yaml-manifests-config-review.md
+++ b/src/content/docs/ai/ai-for-kubernetes-platform-work/module-1.1-ai-for-yaml-manifests-config-review.md
@@ -7,7 +7,7 @@ sidebar:
   order: 1
 ---
 
-> **Complexity**: MEDIUM
+> **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 50-70 minutes
 >

--- a/src/content/docs/ai/open-models-local-inference/module-1.1-open-models-and-model-hubs.md
+++ b/src/content/docs/ai/open-models-local-inference/module-1.1-open-models-and-model-hubs.md
@@ -7,7 +7,7 @@ sidebar:
 revision_pending: false
 ---
 
-> **Complexity**: `[INTERMEDIATE]`
+> **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 45-60 min
 >

--- a/src/content/docs/cloud/aks-deep-dive/module-7.1-aks-architecture.md
+++ b/src/content/docs/cloud/aks-deep-dive/module-7.1-aks-architecture.md
@@ -4,7 +4,7 @@ slug: cloud/aks-deep-dive/module-7.1-aks-architecture
 sidebar:
   order: 2
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2h | **Prerequisites**: Azure Essentials and basic `kubectl` familiarity. [Cloud Architecture Patterns](../../architecture-patterns/) is a recommended companion, not required first.
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 2h | **Prerequisites**: Azure Essentials and basic `kubectl` familiarity. [Cloud Architecture Patterns](../../architecture-patterns/) is a recommended companion, not required first.
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/aks-deep-dive/module-7.2-aks-networking.md
+++ b/src/content/docs/cloud/aks-deep-dive/module-7.2-aks-networking.md
@@ -5,7 +5,7 @@ sidebar:
   order: 3
 ---
 
-**Complexity**: [COMPLEX] | **Time to Complete**: 3.5h | **Prerequisites**: [Module 7.1: AKS Architecture & Node Management](../module-7.1-aks-architecture/)
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 3.5h | **Prerequisites**: [Module 7.1: AKS Architecture & Node Management](../module-7.1-aks-architecture/)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/aks-deep-dive/module-7.3-aks-identity.md
+++ b/src/content/docs/cloud/aks-deep-dive/module-7.3-aks-identity.md
@@ -4,7 +4,7 @@ slug: cloud/aks-deep-dive/module-7.3-aks-identity
 sidebar:
   order: 4
 ---
-**Complexity**: [ADVANCED] | **Time to Complete**: 2.5h | **Prerequisites**: [Module 7.1: AKS Architecture & Node Management](../module-7.1-aks-architecture/). This is the practical security baseline module before you scale AKS identity and policy controls across teams.
+**Complexity**: `[ADVANCED]` | **Time to Complete**: 2.5h | **Prerequisites**: [Module 7.1: AKS Architecture & Node Management](../module-7.1-aks-architecture/). This is the practical security baseline module before you scale AKS identity and policy controls across teams.
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/aks-deep-dive/module-7.4-aks-production.md
+++ b/src/content/docs/cloud/aks-deep-dive/module-7.4-aks-production.md
@@ -4,7 +4,7 @@ slug: cloud/aks-deep-dive/module-7.4-aks-production
 sidebar:
   order: 5
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2.5h | **Prerequisites**: [Module 7.1: AKS Architecture & Node Management](../module-7.1-aks-architecture/).
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 2.5h | **Prerequisites**: [Module 7.1: AKS Architecture & Node Management](../module-7.1-aks-architecture/).
 This module is focused on production-ready AKS operations where storage reliability, observability signal quality, and scaling behavior must be treated as one coupled reliability system rather than independent checkboxes.
 
 ## What You'll Be Able to Do

--- a/src/content/docs/cloud/architecture-patterns/module-4.4-vpc-topologies.md
+++ b/src/content/docs/cloud/architecture-patterns/module-4.4-vpc-topologies.md
@@ -5,7 +5,7 @@ sidebar:
   order: 5
 ---
 
-> **Complexity**: Advanced
+> **Complexity**: `[ADVANCED]`
 >
 > **Time to Complete**: 3-4 hours
 >

--- a/src/content/docs/cloud/aws-essentials/module-1.1-iam.md
+++ b/src/content/docs/cloud/aws-essentials/module-1.1-iam.md
@@ -4,7 +4,7 @@ slug: cloud/aws-essentials/module-1.1-iam
 sidebar:
   order: 2
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2h | **Prerequisites**: Cloud Native 101. After completing this module, you will be able to perform all of the outcomes listed below and defend those choices during an incident review:
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 2h | **Prerequisites**: Cloud Native 101. After completing this module, you will be able to perform all of the outcomes listed below and defend those choices during an incident review:
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/aws-essentials/module-1.13-data-ingestion.md
+++ b/src/content/docs/cloud/aws-essentials/module-1.13-data-ingestion.md
@@ -5,7 +5,7 @@ sidebar:
   order: 13
 ---
 
-> **Complexity:** [COMPLEX]
+> **Complexity:** `[COMPLEX]`
 >
 > **Time:** 90-120 min
 >

--- a/src/content/docs/cloud/aws-essentials/module-1.2-vpc.md
+++ b/src/content/docs/cloud/aws-essentials/module-1.2-vpc.md
@@ -4,7 +4,7 @@ slug: cloud/aws-essentials/module-1.2-vpc
 sidebar:
   order: 3
 ---
-**Complexity**: [COMPLEX] | **Time to Complete**: 3h | **Prerequisites**: Module 1.1, Linux Networking
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 3h | **Prerequisites**: Module 1.1, Linux Networking
 
 This module is labeled **[COMPLEX]** because VPC networking stacks several independent control planes—CIDR planning, subnet placement, route tables, NAT, security groups, NACLs, and cross-VPC connectivity—into one design surface where a single mistake can silently break production traffic. Budget about three hours if you work through the hands-on CLI exercise and pause on the prediction prompts; you should already be comfortable with Linux networking fundamentals from Module 1.1 and with IAM concepts from the prior AWS Essentials module, because you will attach policies to VPC endpoints and flow-log delivery roles later in the track.
 

--- a/src/content/docs/cloud/aws-essentials/module-1.3-ec2.md
+++ b/src/content/docs/cloud/aws-essentials/module-1.3-ec2.md
@@ -4,7 +4,7 @@ slug: cloud/aws-essentials/module-1.3-ec2
 sidebar:
   order: 4
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2.5h | **Prerequisites**: Module 1.2. After completing this module, you will be able to:
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 2.5h | **Prerequisites**: Module 1.2. After completing this module, you will be able to:
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/aws-essentials/module-1.4-s3.md
+++ b/src/content/docs/cloud/aws-essentials/module-1.4-s3.md
@@ -4,7 +4,7 @@ slug: cloud/aws-essentials/module-1.4-s3
 sidebar:
   order: 5
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2.5h | **Prerequisites**: Module 1.1. This module assumes you already know object-level IAM basics and now focuses on secure storage design, lifecycle discipline, and controlled data sharing patterns.
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 2.5h | **Prerequisites**: Module 1.1. This module assumes you already know object-level IAM basics and now focuses on secure storage design, lifecycle discipline, and controlled data sharing patterns.
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/aws-essentials/module-1.5-route53.md
+++ b/src/content/docs/cloud/aws-essentials/module-1.5-route53.md
@@ -4,7 +4,7 @@ slug: cloud/aws-essentials/module-1.5-route53
 sidebar:
   order: 6
 ---
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 ## Time to Complete: 1.5 hours
 
 ---

--- a/src/content/docs/cloud/aws-essentials/module-1.6-ecr.md
+++ b/src/content/docs/cloud/aws-essentials/module-1.6-ecr.md
@@ -4,7 +4,7 @@ slug: cloud/aws-essentials/module-1.6-ecr
 sidebar:
   order: 7
 ---
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 ## Time to Complete: 1 hour
 
 ---

--- a/src/content/docs/cloud/aws-essentials/module-1.7-ecs-fargate.md
+++ b/src/content/docs/cloud/aws-essentials/module-1.7-ecs-fargate.md
@@ -4,7 +4,7 @@ slug: cloud/aws-essentials/module-1.7-ecs-fargate
 sidebar:
   order: 8
 ---
-## Complexity: [COMPLEX]
+## Complexity: `[COMPLEX]`
 ## Time to Complete: 3 hours
 
 ---

--- a/src/content/docs/cloud/aws-essentials/module-1.8-lambda.md
+++ b/src/content/docs/cloud/aws-essentials/module-1.8-lambda.md
@@ -4,7 +4,7 @@ slug: cloud/aws-essentials/module-1.8-lambda
 sidebar:
   order: 9
 ---
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 ## Time to Complete: 2 hours
 
 ---

--- a/src/content/docs/cloud/azure-essentials/module-3.1-entra-id.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.1-entra-id.md
@@ -4,7 +4,7 @@ slug: cloud/azure-essentials/module-3.1-entra-id
 sidebar:
   order: 2
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2.5h | **Prerequisites**: Cloud Native 101. You will use this module after you can already read and create resources in Azure, because the module assumes comfort with role and identity fundamentals.
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 2.5h | **Prerequisites**: Cloud Native 101. You will use this module after you can already read and create resources in Azure, because the module assumes comfort with role and identity fundamentals.
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/azure-essentials/module-3.10-monitor.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.10-monitor.md
@@ -4,7 +4,7 @@ slug: cloud/azure-essentials/module-3.10-monitor
 sidebar:
   order: 11
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2.5h | **Prerequisites**: Module 3.3 (VMs), Module 3.1 (Entra ID). This module balances practical incident-readiness with conceptual grounding so you can configure monitoring both quickly and correctly under pressure.
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 2.5h | **Prerequisites**: Module 3.3 (VMs), Module 3.1 (Entra ID). This module balances practical incident-readiness with conceptual grounding so you can configure monitoring both quickly and correctly under pressure.
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/azure-essentials/module-3.11-cicd.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.11-cicd.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 ## What You'll Be Able to Do
 
-**Complexity**: [MEDIUM] | **Time to Complete**: 2h | **Prerequisites**: Module 3.6 (ACR), Module 3.7 (Container Apps), Module 3.1 (Entra ID)
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 2h | **Prerequisites**: Module 3.6 (ACR), Module 3.7 (Container Apps), Module 3.1 (Entra ID)
 
 When you finish this module, you will be able to design, secure, and operate CI/CD pipelines that build container images and deploy them to Azure using either Azure DevOps Pipelines or GitHub Actions. The learning outcomes below map directly to the hands-on exercise and quiz, so you can verify each skill as you go.
 

--- a/src/content/docs/cloud/azure-essentials/module-3.13-application-gateway.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.13-application-gateway.md
@@ -5,7 +5,7 @@ sidebar:
   order: 14
 ---
 
-> **Complexity:** [COMPLEX]  
+> **Complexity:** `[COMPLEX]`  
 > **Time:** 60-90 min  
 > **Prereqs:** [3.2-vnet](../module-3.2-vnet/), [3.5-dns](../module-3.5-dns/), [3.10-monitor](../module-3.10-monitor/)  
 > Start this module by naming who controls each control boundary, because governance is the operational shortcut that prevents ownership disputes during incidents.

--- a/src/content/docs/cloud/azure-essentials/module-3.14-app-service.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.14-app-service.md
@@ -4,7 +4,7 @@ slug: cloud/azure-essentials/module-3.14-app-service
 sidebar:
   order: 15
 ---
-**Complexity**: [COMPLEX] | **Time:** 90-120 min | **Prerequisites**: [3.7-aci-aca](../module-3.7-aci-aca/) (Container Apps), [3.8-functions](../module-3.8-functions/), [3.9-key-vault](../module-3.9-key-vault/), [3.10-monitor](../module-3.10-monitor/)
+**Complexity**: `[COMPLEX]` | **Time:** 90-120 min | **Prerequisites**: [3.7-aci-aca](../module-3.7-aci-aca/) (Container Apps), [3.8-functions](../module-3.8-functions/), [3.9-key-vault](../module-3.9-key-vault/), [3.10-monitor](../module-3.10-monitor/)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/azure-essentials/module-3.15-event-hub-event-grid.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.15-event-hub-event-grid.md
@@ -5,7 +5,7 @@ sidebar:
   order: 16
 ---
 
-> **Complexity:** [COMPLEX]
+> **Complexity:** `[COMPLEX]`
 >
 > **Time:** 90-120 min
 >

--- a/src/content/docs/cloud/azure-essentials/module-3.16-azure-sql.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.16-azure-sql.md
@@ -5,7 +5,7 @@ sidebar:
   order: 17
 ---
 
-> **Complexity**: [COMPLEX]
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: 90-120 min
 >

--- a/src/content/docs/cloud/azure-essentials/module-3.17-backup-site-recovery.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.17-backup-site-recovery.md
@@ -5,7 +5,7 @@ sidebar:
   order: 18
 ---
 
-> **Complexity**: [COMPLEX]
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: 90-120 min
 >

--- a/src/content/docs/cloud/azure-essentials/module-3.2-vnet.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.2-vnet.md
@@ -4,7 +4,7 @@ slug: cloud/azure-essentials/module-3.2-vnet
 sidebar:
   order: 3
 ---
-> **Complexity**: [COMPLEX] | **Time to Complete**: 3h | **Prerequisites**: Module 3.1 (Entra ID & RBAC)
+> **Complexity**: `[COMPLEX]` | **Time to Complete**: 3h | **Prerequisites**: Module 3.1 (Entra ID & RBAC)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/azure-essentials/module-3.4-blob.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.4-blob.md
@@ -4,7 +4,7 @@ slug: cloud/azure-essentials/module-3.4-blob
 sidebar:
   order: 5
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2h | **Prerequisites**: Module 3.1 (Entra ID & RBAC). You should be comfortable assigning Entra ID RBAC roles and running `az` commands with `--auth-mode login` before starting.
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 2h | **Prerequisites**: Module 3.1 (Entra ID & RBAC). You should be comfortable assigning Entra ID RBAC roles and running `az` commands with `--auth-mode login` before starting.
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/azure-essentials/module-3.5-dns.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.5-dns.md
@@ -4,7 +4,7 @@ slug: cloud/azure-essentials/module-3.5-dns
 sidebar:
   order: 6
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 1.5h | **Prerequisites**: Module 3.2 (Virtual Networks)
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 1.5h | **Prerequisites**: Module 3.2 (Virtual Networks)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/azure-essentials/module-3.6-acr.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.6-acr.md
@@ -5,7 +5,7 @@ sidebar:
   order: 7
 ---
 
-**Complexity**: [MEDIUM] | **Time to Complete**: 2h | **Prerequisites**: Module 3.3 (Virtual Machines), Module 3.1 (Microsoft Entra ID)
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 2h | **Prerequisites**: Module 3.3 (Virtual Machines), Module 3.1 (Microsoft Entra ID)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/azure-essentials/module-3.7-aci-aca.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.7-aci-aca.md
@@ -5,7 +5,7 @@ sidebar:
   order: 8
 ---
 
-> **Complexity:** [COMPLEX]
+> **Complexity:** `[COMPLEX]`
 >
 > **Time to Complete:** 3 hours
 >

--- a/src/content/docs/cloud/azure-essentials/module-3.8-functions.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.8-functions.md
@@ -5,7 +5,7 @@ sidebar:
   order: 9
 ---
 
-**Complexity**: [MEDIUM] | **Time to Complete**: 2h | **Prerequisites**: Module 3.4 (Blob Storage), Module 3.1 (Entra ID).
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 2h | **Prerequisites**: Module 3.4 (Blob Storage), Module 3.1 (Entra ID).
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/azure-essentials/module-3.9-key-vault.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.9-key-vault.md
@@ -4,7 +4,7 @@ slug: cloud/azure-essentials/module-3.9-key-vault
 sidebar:
   order: 10
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 1.5h | **Prerequisites**: Module 3.1 (Entra ID & RBAC)
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 1.5h | **Prerequisites**: Module 3.1 (Entra ID & RBAC)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/eks-deep-dive/module-5.2-eks-networking.md
+++ b/src/content/docs/cloud/eks-deep-dive/module-5.2-eks-networking.md
@@ -4,7 +4,7 @@ slug: cloud/eks-deep-dive/module-5.2-eks-networking
 sidebar:
   order: 3
 ---
-**Complexity**: [COMPLEX] | **Time to Complete**: 3.5h | **Prerequisites**: Module 5.1 (EKS Architecture & Control Plane)
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 3.5h | **Prerequisites**: Module 5.1 (EKS Architecture & Control Plane)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/eks-deep-dive/module-5.3-eks-identity.md
+++ b/src/content/docs/cloud/eks-deep-dive/module-5.3-eks-identity.md
@@ -4,7 +4,7 @@ slug: cloud/eks-deep-dive/module-5.3-eks-identity
 sidebar:
   order: 4
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 1.5h | **Prerequisites**: Module 5.1 (EKS Architecture & Control Plane). After completing this module, you will be able to:
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 1.5h | **Prerequisites**: Module 5.1 (EKS Architecture & Control Plane). After completing this module, you will be able to:
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/eks-deep-dive/module-5.4-eks-storage.md
+++ b/src/content/docs/cloud/eks-deep-dive/module-5.4-eks-storage.md
@@ -4,7 +4,7 @@ slug: cloud/eks-deep-dive/module-5.4-eks-storage
 sidebar:
   order: 5
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2h | **Prerequisites**: Module 5.1 (EKS Architecture & Control Plane)
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 2h | **Prerequisites**: Module 5.1 (EKS Architecture & Control Plane)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/enterprise-hybrid/module-10.10-enterprise-finops.md
+++ b/src/content/docs/cloud/enterprise-hybrid/module-10.10-enterprise-finops.md
@@ -4,7 +4,7 @@ slug: cloud/enterprise-hybrid/module-10.10-enterprise-finops
 sidebar:
   order: 11
 ---
-**Complexity**: [COMPLEX] | **Time to Complete**: 2h | **Prerequisites**: Cloud Essentials (AWS/Azure/GCP), Kubernetes Resource Management, Enterprise Landing Zones (Module 10.1)
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 2h | **Prerequisites**: Cloud Essentials (AWS/Azure/GCP), Kubernetes Resource Management, Enterprise Landing Zones (Module 10.1)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/enterprise-hybrid/module-10.11-cloud-custodian.md
+++ b/src/content/docs/cloud/enterprise-hybrid/module-10.11-cloud-custodian.md
@@ -4,7 +4,7 @@ slug: cloud/enterprise-hybrid/module-10.11-cloud-custodian
 sidebar:
   order: 12
 ---
-> **Complexity**: [COMPLEX]
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: 45-60 minutes
 >

--- a/src/content/docs/cloud/enterprise-hybrid/module-10.2-governance.md
+++ b/src/content/docs/cloud/enterprise-hybrid/module-10.2-governance.md
@@ -5,7 +5,7 @@ sidebar:
   order: 3
 ---
 
-**Complexity**: [COMPLEX] | **Time to Complete**: 2.5h | **Prerequisites**: Enterprise Landing Zones (Module 10.1), Kubernetes RBAC basics, YAML/JSON fundamentals
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 2.5h | **Prerequisites**: Enterprise Landing Zones (Module 10.1), Kubernetes RBAC basics, YAML/JSON fundamentals
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/enterprise-hybrid/module-10.3-compliance.md
+++ b/src/content/docs/cloud/enterprise-hybrid/module-10.3-compliance.md
@@ -5,7 +5,7 @@ sidebar:
   order: 4
 ---
 
-**Complexity**: [COMPLEX] | **Time to Complete**: 2h | **Prerequisites**: Cloud Governance & Policy as Code (Module 10.2), Kubernetes Security Basics, `jq` utility
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 2h | **Prerequisites**: Cloud Governance & Policy as Code (Module 10.2), Kubernetes Security Basics, `jq` utility
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/enterprise-hybrid/module-10.4-hybrid.md
+++ b/src/content/docs/cloud/enterprise-hybrid/module-10.4-hybrid.md
@@ -4,7 +4,7 @@ slug: cloud/enterprise-hybrid/module-10.4-hybrid
 sidebar:
   order: 5
 ---
-**Complexity**: [COMPLEX] | **Time to Complete**: 3h | **Prerequisites**: Enterprise Landing Zones (Module 10.1), Kubernetes networking basics
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 3h | **Prerequisites**: Enterprise Landing Zones (Module 10.1), Kubernetes networking basics
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/enterprise-hybrid/module-10.5-fleet-management.md
+++ b/src/content/docs/cloud/enterprise-hybrid/module-10.5-fleet-management.md
@@ -4,7 +4,7 @@ slug: cloud/enterprise-hybrid/module-10.5-fleet-management
 sidebar:
   order: 6
 ---
-**Complexity**: [COMPLEX] | **Time to Complete**: 2.5h | **Prerequisites**: Hybrid Cloud Architecture (Module 10.4), GitOps Basics (ArgoCD/Flux)
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 2.5h | **Prerequisites**: Hybrid Cloud Architecture (Module 10.4), GitOps Basics (ArgoCD/Flux)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/enterprise-hybrid/module-10.6-cluster-api.md
+++ b/src/content/docs/cloud/enterprise-hybrid/module-10.6-cluster-api.md
@@ -5,7 +5,7 @@ sidebar:
   order: 7
 ---
 
-**Complexity**: [COMPLEX] | **Time to Complete**: 3h | **Prerequisites**: Multi-Cloud Fleet Management (Module 10.5), Kubernetes Custom Resources, Infrastructure as Code Basics
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 3h | **Prerequisites**: Multi-Cloud Fleet Management (Module 10.5), Kubernetes Custom Resources, Infrastructure as Code Basics
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/enterprise-hybrid/module-10.7-multi-cloud-mesh.md
+++ b/src/content/docs/cloud/enterprise-hybrid/module-10.7-multi-cloud-mesh.md
@@ -5,7 +5,7 @@ sidebar:
   order: 8
 ---
 
-**Complexity**: [COMPLEX] | **Time to Complete**: 3h | **Prerequisites**: Kubernetes Networking, Service Mesh Basics, Hybrid Cloud Architecture (Module 10.4)
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 3h | **Prerequisites**: Kubernetes Networking, Service Mesh Basics, Hybrid Cloud Architecture (Module 10.4)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/enterprise-hybrid/module-10.8-enterprise-gitops.md
+++ b/src/content/docs/cloud/enterprise-hybrid/module-10.8-enterprise-gitops.md
@@ -4,7 +4,7 @@ slug: cloud/enterprise-hybrid/module-10.8-enterprise-gitops
 sidebar:
   order: 9
 ---
-**Complexity**: [COMPLEX] | **Time to Complete**: 2.5h | **Prerequisites**: GitOps Basics (ArgoCD/Flux), Kubernetes RBAC, Multi-Cloud Fleet Management (Module 10.5)
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 2.5h | **Prerequisites**: GitOps Basics (ArgoCD/Flux), Kubernetes RBAC, Multi-Cloud Fleet Management (Module 10.5)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/enterprise-hybrid/module-10.9-zero-trust.md
+++ b/src/content/docs/cloud/enterprise-hybrid/module-10.9-zero-trust.md
@@ -4,7 +4,7 @@ slug: cloud/enterprise-hybrid/module-10.9-zero-trust
 sidebar:
   order: 10
 ---
-**Complexity**: [COMPLEX] | **Time to Complete**: 2.5h | **Prerequisites**: Kubernetes Networking, Identity & Access Management, Service Mesh Basics
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 2.5h | **Prerequisites**: Kubernetes Networking, Identity & Access Management, Service Mesh Basics
 
 In a hybrid cloud portfolio, zero trust is not a single feature you switch on after the fact; it is a design discipline that affects service boundaries, identity, policy evaluation, and operational workflows. In practice, the strongest teams apply these constraints before introducing new services, and the result is fewer emergency exceptions and clearer responsibility between platform, security, and application owners.
 

--- a/src/content/docs/cloud/gcp-essentials/module-2.1-iam.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.1-iam.md
@@ -4,7 +4,7 @@ slug: cloud/gcp-essentials/module-2.1-iam
 sidebar:
   order: 2
 ---
-> **Complexity**: [MEDIUM] | **Time to Complete**: 2h | **Prerequisites**: Cloud Native 101
+> **Complexity**: `[MEDIUM]` | **Time to Complete**: 2h | **Prerequisites**: Cloud Native 101
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/gcp-essentials/module-2.10-operations.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.10-operations.md
@@ -4,7 +4,7 @@ slug: cloud/gcp-essentials/module-2.10-operations
 sidebar:
   order: 11
 ---
-> **Complexity**: [MEDIUM] | **Time to Complete**: 2.5h | **Prerequisites**: Module 2.3 (Compute Engine), Module 2.7 (Cloud Run)
+> **Complexity**: `[MEDIUM]` | **Time to Complete**: 2.5h | **Prerequisites**: Module 2.3 (Compute Engine), Module 2.7 (Cloud Run)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/gcp-essentials/module-2.11-cloud-build.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.11-cloud-build.md
@@ -4,7 +4,7 @@ slug: cloud/gcp-essentials/module-2.11-cloud-build
 sidebar:
   order: 12
 ---
-**Complexity**: [COMPLEX] | **Time to Complete**: 2.5h | **Prerequisites**: Module 2.6 (Artifact Registry), Module 2.7 (Cloud Run)
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 2.5h | **Prerequisites**: Module 2.6 (Artifact Registry), Module 2.7 (Cloud Run)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/gcp-essentials/module-2.12-patterns.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.12-patterns.md
@@ -5,7 +5,7 @@ sidebar:
   order: 13
 ---
 
-**Complexity**: [COMPLEX] | **Time to Complete**: 1.5 hours | **Prerequisites**: [Modules 2.1–2.11](../module-2.11-cloud-build/)
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 1.5 hours | **Prerequisites**: [Modules 2.1–2.11](../module-2.11-cloud-build/)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/gcp-essentials/module-2.2-vpc.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.2-vpc.md
@@ -4,7 +4,7 @@ slug: cloud/gcp-essentials/module-2.2-vpc
 sidebar:
   order: 3
 ---
-**Complexity**: [COMPLEX] | **Time to Complete**: 3h | **Prerequisites**: Module 2.1 (IAM & Resource Hierarchy)
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 3h | **Prerequisites**: Module 2.1 (IAM & Resource Hierarchy)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/gcp-essentials/module-2.3-compute.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.3-compute.md
@@ -4,7 +4,7 @@ slug: cloud/gcp-essentials/module-2.3-compute
 sidebar:
   order: 4
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2.5h | **Prerequisites**: Module 2.2 (VPC Networking). This module assumes a networking baseline and is designed to move you from “single instances” into controlled, production-like compute operations with predictable behavior.
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 2.5h | **Prerequisites**: Module 2.2 (VPC Networking). This module assumes a networking baseline and is designed to move you from “single instances” into controlled, production-like compute operations with predictable behavior.
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/gcp-essentials/module-2.4-gcs.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.4-gcs.md
@@ -4,7 +4,7 @@ slug: cloud/gcp-essentials/module-2.4-gcs
 sidebar:
   order: 5
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 1.5h | **Prerequisites**: Module 2.1 (IAM & Resource Hierarchy). This module assumes you can read IAM bindings and organization policies; you will apply those concepts directly to bucket design, lifecycle automation, and disaster-recovery placement.
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 1.5h | **Prerequisites**: Module 2.1 (IAM & Resource Hierarchy). This module assumes you can read IAM bindings and organization policies; you will apply those concepts directly to bucket design, lifecycle automation, and disaster-recovery placement.
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/gcp-essentials/module-2.5-dns.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.5-dns.md
@@ -4,7 +4,7 @@ slug: cloud/gcp-essentials/module-2.5-dns
 sidebar:
   order: 6
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 1.5h | **Prerequisites**: Module 2.2 (VPC Networking)
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 1.5h | **Prerequisites**: Module 2.2 (VPC Networking)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/gcp-essentials/module-2.6-artifact-registry.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.6-artifact-registry.md
@@ -4,7 +4,7 @@ slug: cloud/gcp-essentials/module-2.6-artifact-registry
 sidebar:
   order: 7
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 1h | **Prerequisites**: Module 2.1 (IAM & Resource Hierarchy)
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 1h | **Prerequisites**: Module 2.1 (IAM & Resource Hierarchy)
 
 This module sits at the intersection of security, developer experience, and cost management because every container deployment depends on a registry that teams often treat as invisible infrastructure until it breaks a build, blocks a deploy, or leaks an artifact.
 

--- a/src/content/docs/cloud/gcp-essentials/module-2.7-cloud-run.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.7-cloud-run.md
@@ -5,7 +5,7 @@ sidebar:
   order: 8
 ---
 
-**Complexity**: [COMPLEX] | **Time to Complete**: 2.5h | **Prerequisites**: Module 2.1 (IAM), Module 2.6 (Artifact Registry)
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 2.5h | **Prerequisites**: Module 2.1 (IAM), Module 2.6 (Artifact Registry)
 
 ## Learning Outcomes
 

--- a/src/content/docs/cloud/gcp-essentials/module-2.8-cloud-functions.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.8-cloud-functions.md
@@ -4,7 +4,7 @@ slug: cloud/gcp-essentials/module-2.8-cloud-functions
 sidebar:
   order: 9
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2h | **Prerequisites**: Module 2.4 (GCS), Module 2.7 (Cloud Run). This module assumes you can create buckets and deploy Cloud Run services from Module 2.7, because Cloud Run functions share that execution plane.
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 2h | **Prerequisites**: Module 2.4 (GCS), Module 2.7 (Cloud Run). This module assumes you can create buckets and deploy Cloud Run services from Module 2.7, because Cloud Run functions share that execution plane.
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/gcp-essentials/module-2.9-secret-manager.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.9-secret-manager.md
@@ -4,7 +4,7 @@ slug: cloud/gcp-essentials/module-2.9-secret-manager
 sidebar:
   order: 10
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 1.5h | **Prerequisites**: Module 2.1 (IAM & Resource Hierarchy) — you should be comfortable creating service accounts, granting IAM roles, and enabling GCP APIs before storing production credentials in Secret Manager.
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 1.5h | **Prerequisites**: Module 2.1 (IAM & Resource Hierarchy) — you should be comfortable creating service accounts, granting IAM roles, and enabling GCP APIs before storing production credentials in Secret Manager.
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/gke-deep-dive/module-6.1-gke-architecture.md
+++ b/src/content/docs/cloud/gke-deep-dive/module-6.1-gke-architecture.md
@@ -4,7 +4,7 @@ slug: cloud/gke-deep-dive/module-6.1-gke-architecture
 sidebar:
   order: 2
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2h | **Prerequisites**: GCP Essentials — expect to run real `gcloud` commands against a billing-enabled project and delete clusters when finished. [Cloud Architecture Patterns](../../architecture-patterns/) is a recommended companion, not required first.
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 2h | **Prerequisites**: GCP Essentials — expect to run real `gcloud` commands against a billing-enabled project and delete clusters when finished. [Cloud Architecture Patterns](../../architecture-patterns/) is a recommended companion, not required first.
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/gke-deep-dive/module-6.2-gke-networking.md
+++ b/src/content/docs/cloud/gke-deep-dive/module-6.2-gke-networking.md
@@ -4,7 +4,7 @@ slug: cloud/gke-deep-dive/module-6.2-gke-networking
 sidebar:
   order: 3
 ---
-**Complexity**: [COMPLEX] | **Time to Complete**: 3h | **Prerequisites**: Module 6.1 (GKE Architecture). Expect to reason about CIDR math, Google Cloud load balancer objects, and Kubernetes policy objects in the same narrative—this is integrative networking design, not a single-feature checklist.
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 3h | **Prerequisites**: Module 6.1 (GKE Architecture). Expect to reason about CIDR math, Google Cloud load balancer objects, and Kubernetes policy objects in the same narrative—this is integrative networking design, not a single-feature checklist.
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/gke-deep-dive/module-6.3-gke-identity.md
+++ b/src/content/docs/cloud/gke-deep-dive/module-6.3-gke-identity.md
@@ -4,7 +4,7 @@ slug: cloud/gke-deep-dive/module-6.3-gke-identity
 sidebar:
   order: 4
 ---
-> **Complexity**: [MEDIUM] | **Time to Complete**: 2.5h | **Prerequisites**: [Module 6.1 (GKE Architecture)](../module-6.1-gke-architecture/)
+> **Complexity**: `[MEDIUM]` | **Time to Complete**: 2.5h | **Prerequisites**: [Module 6.1 (GKE Architecture)](../module-6.1-gke-architecture/)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/gke-deep-dive/module-6.4-gke-storage.md
+++ b/src/content/docs/cloud/gke-deep-dive/module-6.4-gke-storage.md
@@ -4,7 +4,7 @@ slug: cloud/gke-deep-dive/module-6.4-gke-storage
 sidebar:
   order: 5
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2h | **Prerequisites**: Module 6.1 (GKE Architecture)
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 2h | **Prerequisites**: Module 6.1 (GKE Architecture)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/gke-deep-dive/module-6.5-gke-fleet.md
+++ b/src/content/docs/cloud/gke-deep-dive/module-6.5-gke-fleet.md
@@ -4,7 +4,7 @@ slug: cloud/gke-deep-dive/module-6.5-gke-fleet
 sidebar:
   order: 6
 ---
-**Complexity**: [COMPLEX] | **Time to Complete**: 3h | **Prerequisites**: Module 6.1 (GKE Architecture)
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 3h | **Prerequisites**: Module 6.1 (GKE Architecture)
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/hyperscaler-rosetta-stone.md
+++ b/src/content/docs/cloud/hyperscaler-rosetta-stone.md
@@ -3,7 +3,7 @@ title: "The Hyperscaler Rosetta Stone"
 sidebar:
   order: 2
 ---
-**Complexity**: [MEDIUM]
+**Complexity**: `[MEDIUM]`
 **Time to Complete**: 2 hours
 **Prerequisites**: Cloud Native 101 (containers, Docker basics)
 

--- a/src/content/docs/cloud/managed-services/module-9.1-databases.md
+++ b/src/content/docs/cloud/managed-services/module-9.1-databases.md
@@ -4,7 +4,7 @@ slug: cloud/managed-services/module-9.1-databases
 sidebar:
   order: 2
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2h | **Prerequisites**: Cloud Essentials (any provider), Kubernetes networking basics
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 2h | **Prerequisites**: Cloud Essentials (any provider), Kubernetes networking basics
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/managed-services/module-9.10-analytics.md
+++ b/src/content/docs/cloud/managed-services/module-9.10-analytics.md
@@ -4,7 +4,7 @@ slug: cloud/managed-services/module-9.10-analytics
 sidebar:
   order: 11
 ---
-**Complexity**: [COMPLEX] | **Time to Complete**: 2.5h | **Prerequisites**: Module 9.4 (Object Storage), Module 9.7 (Streaming Pipelines), SQL basics
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 2.5h | **Prerequisites**: Module 9.4 (Object Storage), Module 9.7 (Streaming Pipelines), SQL basics
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/managed-services/module-9.2-message-brokers.md
+++ b/src/content/docs/cloud/managed-services/module-9.2-message-brokers.md
@@ -4,7 +4,7 @@ slug: cloud/managed-services/module-9.2-message-brokers
 sidebar:
   order: 3
 ---
-**Complexity**: [COMPLEX] | **Time to Complete**: 2.5h | **Prerequisites**: Module 9.1 (Relational Database Integration), Kubernetes Deployments and Services
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 2.5h | **Prerequisites**: Module 9.1 (Relational Database Integration), Kubernetes Deployments and Services
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/managed-services/module-9.3-serverless.md
+++ b/src/content/docs/cloud/managed-services/module-9.3-serverless.md
@@ -4,7 +4,7 @@ slug: cloud/managed-services/module-9.3-serverless
 sidebar:
   order: 4
 ---
-**Complexity**: [COMPLEX] | **Time to Complete**: 2h | **Prerequisites**: Module 9.2 (Message Brokers), Kubernetes Services and Ingress basics
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 2h | **Prerequisites**: Module 9.2 (Message Brokers), Kubernetes Services and Ingress basics
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/managed-services/module-9.4-object-storage.md
+++ b/src/content/docs/cloud/managed-services/module-9.4-object-storage.md
@@ -4,7 +4,7 @@ slug: cloud/managed-services/module-9.4-object-storage
 sidebar:
   order: 5
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2h | **Prerequisites**: Module 9.1 (Databases), Kubernetes PersistentVolumes and CSI concepts — you should understand when to use a PVC versus an HTTP API before choosing object storage patterns for pods.
+**Complexity**: `[MEDIUM]` | **Time to Complete**: 2h | **Prerequisites**: Module 9.1 (Databases), Kubernetes PersistentVolumes and CSI concepts — you should understand when to use a PVC versus an HTTP API before choosing object storage patterns for pods.
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/managed-services/module-9.5-caching.md
+++ b/src/content/docs/cloud/managed-services/module-9.5-caching.md
@@ -4,7 +4,7 @@ slug: cloud/managed-services/module-9.5-caching
 sidebar:
   order: 6
 ---
-**Complexity**: [COMPLEX] | **Time to Complete**: 2h | **Prerequisites**: Module 9.1 (Databases), Module 9.4 (Object Storage), Redis fundamentals, and basic Kubernetes Service networking
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 2h | **Prerequisites**: Module 9.1 (Databases), Module 9.4 (Object Storage), Redis fundamentals, and basic Kubernetes Service networking
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/managed-services/module-9.6-search.md
+++ b/src/content/docs/cloud/managed-services/module-9.6-search.md
@@ -4,7 +4,7 @@ slug: cloud/managed-services/module-9.6-search
 sidebar:
   order: 7
 ---
-**Complexity**: [COMPLEX] | **Time to Complete**: 2.5h | **Prerequisites**: Module 9.2 (Message Brokers), Kubernetes logging concepts, JSON/HTTP API basics
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 2.5h | **Prerequisites**: Module 9.2 (Message Brokers), Kubernetes logging concepts, JSON/HTTP API basics
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/managed-services/module-9.7-streaming.md
+++ b/src/content/docs/cloud/managed-services/module-9.7-streaming.md
@@ -4,7 +4,7 @@ slug: cloud/managed-services/module-9.7-streaming
 sidebar:
   order: 8
 ---
-**Complexity**: [COMPLEX] | **Time to Complete**: 3h | **Prerequisites**: Module 9.2 (Message Brokers), Module 9.6 (Search & Analytics), distributed systems basics
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 3h | **Prerequisites**: Module 9.2 (Message Brokers), Module 9.6 (Search & Analytics), distributed systems basics
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/managed-services/module-9.8-secrets-deep.md
+++ b/src/content/docs/cloud/managed-services/module-9.8-secrets-deep.md
@@ -4,7 +4,7 @@ slug: cloud/managed-services/module-9.8-secrets-deep
 sidebar:
   order: 9
 ---
-**Complexity**: [COMPLEX] | **Time to Complete**: 2h | **Prerequisites**: Module 9.1 (Databases), Kubernetes RBAC, cloud IAM basics
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 2h | **Prerequisites**: Module 9.1 (Databases), Kubernetes RBAC, cloud IAM basics
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/cloud/managed-services/module-9.9-api-gateways.md
+++ b/src/content/docs/cloud/managed-services/module-9.9-api-gateways.md
@@ -5,7 +5,7 @@ sidebar:
   order: 10
 ---
 
-**Complexity**: [COMPLEX] | **Time to Complete**: 2.5h | **Prerequisites**: Module 9.3 (Serverless Interoperability), Kubernetes Ingress and Services, HTTP/TLS basics
+**Complexity**: `[COMPLEX]` | **Time to Complete**: 2.5h | **Prerequisites**: Module 9.3 (Serverless Interoperability), Kubernetes Ingress and Services, HTTP/TLS basics
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/k8s/cgoa/module-1.1-exam-strategy-and-blueprint-review.md
+++ b/src/content/docs/k8s/cgoa/module-1.1-exam-strategy-and-blueprint-review.md
@@ -7,7 +7,7 @@ sidebar:
   order: 101
 ---
 
-> **CGOA Track** | **Complexity**: Medium | **Time to Complete**: 90 minutes | **Prerequisites**: No Kubernetes operations experience required, but basic Git and CI/CD vocabulary will help
+> **CGOA Track** | **Complexity**: `[MEDIUM]` | **Time to Complete**: 90 minutes | **Prerequisites**: No Kubernetes operations experience required, but basic Git and CI/CD vocabulary will help
 
 ## Learning Outcomes
 

--- a/src/content/docs/k8s/cgoa/module-1.4-practice-questions-set-1.md
+++ b/src/content/docs/k8s/cgoa/module-1.4-practice-questions-set-1.md
@@ -8,7 +8,7 @@ revision_pending: false
 ---
 
 > **CGOA Track** | Practice questions | Set 1  
-> **Complexity:** Beginner to intermediate  
+> **Complexity:** `[MEDIUM]`  
 > **Estimated time:** 45-60 minutes  
 > **Prerequisites:** Basic Kubernetes objects, Git pull requests, YAML manifests, and the CGOA introduction modules
 

--- a/src/content/docs/k8s/cgoa/module-1.5-practice-questions-set-2.md
+++ b/src/content/docs/k8s/cgoa/module-1.5-practice-questions-set-2.md
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 > **CGOA Track** | Practice questions | Set 2
-> **Complexity:** Beginner to intermediate
+> **Complexity:** `[MEDIUM]`
 > **Estimated time:** 60-75 minutes
 > **Prerequisites:** CGOA modules 1.1 through 1.4, basic Kubernetes objects, Git pull requests, YAML manifests, and the idea that controllers reconcile desired state
 

--- a/src/content/docs/k8s/cks/part1-cluster-setup/module-1.3-ingress-security.md
+++ b/src/content/docs/k8s/cks/part1-cluster-setup/module-1.3-ingress-security.md
@@ -12,7 +12,7 @@ lab:
   environment: kubernetes
 ---
 
-> **Complexity**: Advanced
+> **Complexity**: `[ADVANCED]`
 >
 > **Time to Complete**: 35 min
 >

--- a/src/content/docs/k8s/cks/part3-system-hardening/module-3.2-seccomp.md
+++ b/src/content/docs/k8s/cks/part3-system-hardening/module-3.2-seccomp.md
@@ -6,7 +6,7 @@ sidebar:
 revision_pending: false
 ---
 
-> **Complexity**: Complex
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: 75 minutes
 >

--- a/src/content/docs/k8s/cnpa/module-1.5-practice-questions-set-2.md
+++ b/src/content/docs/k8s/cnpa/module-1.5-practice-questions-set-2.md
@@ -6,7 +6,7 @@ sidebar:
   order: 105
 ---
 
-> **CNPA Track** | Practice questions | Set 2 | Complexity: Medium | Time: 75 minutes | Prerequisites: CNPA modules 1.1 through 1.4, basic Kubernetes objects, and platform engineering vocabulary
+> **CNPA Track** | Practice questions | Set 2 | Complexity: `[MEDIUM]` | Time: 75 minutes | Prerequisites: CNPA modules 1.1 through 1.4, basic Kubernetes objects, and platform engineering vocabulary
 
 This second practice set focuses on comparison traps: platform engineering versus traditional operations, reconciliation versus one-time deployment, guardrails versus unrestricted access, and measurement that proves the platform is useful rather than merely busy. Read the explanations as carefully as the answers, because the exam often rewards the learner who can explain why three plausible answers are still weaker than the best answer.
 

--- a/src/content/docs/linux/foundations/everyday-use/module-0.1-cli-power-user.md
+++ b/src/content/docs/linux/foundations/everyday-use/module-0.1-cli-power-user.md
@@ -12,7 +12,7 @@ lab:
   environment: "ubuntu"
 ---
 
-**Complexity:** [QUICK]. **Time to Complete:** 45 minutes. **Prerequisites:** Zero to Terminal (Module 0.8). This module assumes you can open a shell, move through directories, and run basic commands, then shows how those small skills become repeatable investigation workflows.
+**Complexity:** `[QUICK]`. **Time to Complete:** 45 minutes. **Prerequisites:** Zero to Terminal (Module 0.8). This module assumes you can open a shell, move through directories, and run basic commands, then shows how those small skills become repeatable investigation workflows.
 
 ## Learning Outcomes
 

--- a/src/content/docs/linux/foundations/system-essentials/module-1.3-filesystem-hierarchy.md
+++ b/src/content/docs/linux/foundations/system-essentials/module-1.3-filesystem-hierarchy.md
@@ -12,7 +12,7 @@ lab:
   environment: "ubuntu"
 ---
 
-**Complexity**: Intermediate<br>
+**Complexity**: `[MEDIUM]`<br>
 **Time to complete**: 45 minutes<br>
 **Prerequisites**: [Module 1.1: Kernel & Architecture](../module-1.1-kernel-architecture/) and [Module 1.2: Processes & systemd](../module-1.2-processes-systemd/)
 

--- a/src/content/docs/on-premises/ai-ml-infrastructure/module-9.2-private-ai-training.md
+++ b/src/content/docs/on-premises/ai-ml-infrastructure/module-9.2-private-ai-training.md
@@ -8,7 +8,7 @@ sidebar:
   order: 92
 ---
 
-> **Complexity**: Advanced
+> **Complexity**: `[ADVANCED]`
 >
 > **Time to Complete**: 120-150 minutes
 >

--- a/src/content/docs/on-premises/ai-ml-infrastructure/module-9.3-private-llm-serving.md
+++ b/src/content/docs/on-premises/ai-ml-infrastructure/module-9.3-private-llm-serving.md
@@ -8,7 +8,7 @@ sidebar:
 revision_pending: false
 ---
 
-> **Complexity**: Advanced
+> **Complexity**: `[ADVANCED]`
 >
 > **Time to Complete**: 90-120 minutes
 >

--- a/src/content/docs/on-premises/ai-ml-infrastructure/module-9.4-private-mlops-platform.md
+++ b/src/content/docs/on-premises/ai-ml-infrastructure/module-9.4-private-mlops-platform.md
@@ -8,7 +8,7 @@ sidebar:
 revision_pending: false
 ---
 
-> **Complexity**: Complex
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: 3-4 hours
 >

--- a/src/content/docs/on-premises/ai-ml-infrastructure/module-9.6-high-performance-storage-ai.md
+++ b/src/content/docs/on-premises/ai-ml-infrastructure/module-9.6-high-performance-storage-ai.md
@@ -8,7 +8,7 @@ sidebar:
   order: 96
 ---
 
-> **Complexity**: Complex
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: 90-120 minutes
 >

--- a/src/content/docs/on-premises/multi-cluster/module-5.1-private-cloud.md
+++ b/src/content/docs/on-premises/multi-cluster/module-5.1-private-cloud.md
@@ -5,7 +5,7 @@ sidebar:
   order: 2
 ---
 
-> **On-Premises Multi-Cluster** | Complexity: `[INTERMEDIATE]` | Time: 45-55 min | Covers OpenStack, VMware, CloudStack, oVirt, Kubernetes integration, and operational dependencies for private cloud platforms.
+> **On-Premises Multi-Cluster** | Complexity: `[MEDIUM]` | Time: 45-55 min | Covers OpenStack, VMware, CloudStack, oVirt, Kubernetes integration, and operational dependencies for private cloud platforms.
 
 ## Prerequisites
 

--- a/src/content/docs/on-premises/operations/module-7.8-observability-at-scale.md
+++ b/src/content/docs/on-premises/operations/module-7.8-observability-at-scale.md
@@ -8,7 +8,7 @@ sidebar:
   order: 78
 ---
 
-**Complexity:** Advanced. **Time to complete:** 90-120 minutes. **Prerequisites:** Prometheus fundamentals, Kubernetes operations, basic object storage concepts, and comfort reading YAML manifests.
+**Complexity:** `[ADVANCED]`. **Time to complete:** 90-120 minutes. **Prerequisites:** Prometheus fundamentals, Kubernetes operations, basic object storage concepts, and comfort reading YAML manifests.
 
 ## Learning Outcomes
 

--- a/src/content/docs/on-premises/storage/module-4.3-local-storage.md
+++ b/src/content/docs/on-premises/storage/module-4.3-local-storage.md
@@ -6,7 +6,7 @@ sidebar:
   order: 4
 ---
 
-> **Complexity**: `[INTERMEDIATE]` | Time: 60 minutes
+> **Complexity**: `[MEDIUM]` | Time: 60 minutes
 >
 > **Prerequisites**: [Module 4.1: Storage Architecture](../module-4.1-storage-architecture/), [Module 4.2: Ceph & Rook](../module-4.2-ceph-rook/)
 

--- a/src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.4-ai-storage.md
+++ b/src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.4-ai-storage.md
@@ -5,7 +5,7 @@ sidebar:
   order: 5
 revision_pending: false
 ---
-> **Complexity**: MEDIUM
+> **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 3 hours
 >

--- a/src/content/docs/platform/disciplines/data-ai/data-engineering/module-1.7-event-streaming-fundamentals.md
+++ b/src/content/docs/platform/disciplines/data-ai/data-engineering/module-1.7-event-streaming-fundamentals.md
@@ -5,7 +5,7 @@ sidebar:
   order: 8
 revision_pending: false
 ---
-> **Complexity**: `[INTERMEDIATE]`
+> **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 3 hours
 >

--- a/src/content/docs/platform/disciplines/data-ai/data-engineering/module-1.8-cloudevents-event-driven-arch.md
+++ b/src/content/docs/platform/disciplines/data-ai/data-engineering/module-1.8-cloudevents-event-driven-arch.md
@@ -5,7 +5,7 @@ sidebar:
   order: 9
 revision_pending: false
 ---
-> **Complexity**: Advanced
+> **Complexity**: `[ADVANCED]`
 >
 > **Time to Complete**: 3.5 hours
 >

--- a/src/content/docs/platform/disciplines/delivery-automation/iac/module-6.3-iac-security.md
+++ b/src/content/docs/platform/disciplines/delivery-automation/iac/module-6.3-iac-security.md
@@ -6,7 +6,7 @@ sidebar:
   order: 4
 ---
 
-## Complexity: [COMPLEX]
+## Complexity: `[COMPLEX]`
 ## Time to Complete: 70 minutes
 
 ## Prerequisites

--- a/src/content/docs/platform/disciplines/delivery-automation/iac/module-6.5-drift-remediation.md
+++ b/src/content/docs/platform/disciplines/delivery-automation/iac/module-6.5-drift-remediation.md
@@ -5,7 +5,7 @@ slug: platform/disciplines/delivery-automation/iac/module-6.5-drift-remediation
 sidebar:
   order: 6
 ---
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 ## Time to Complete: 45 minutes
 
 ---

--- a/src/content/docs/platform/disciplines/delivery-automation/iac/module-6.6-iac-cost-management.md
+++ b/src/content/docs/platform/disciplines/delivery-automation/iac/module-6.6-iac-cost-management.md
@@ -4,7 +4,7 @@ slug: platform/disciplines/delivery-automation/iac/module-6.6-iac-cost-managemen
 sidebar:
   order: 7
 ---
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 ## Time to Complete: 45 minutes
 
 ---

--- a/src/content/docs/platform/toolkits/cicd-delivery/source-control/module-11.1-gitlab.md
+++ b/src/content/docs/platform/toolkits/cicd-delivery/source-control/module-11.1-gitlab.md
@@ -5,7 +5,7 @@ slug: platform/toolkits/cicd-delivery/source-control/module-11.1-gitlab
 sidebar:
   order: 2
 ---
-## Complexity: [COMPLEX]
+## Complexity: `[COMPLEX]`
 ## Time to Complete: 50-60 minutes
 
 ---

--- a/src/content/docs/platform/toolkits/cicd-delivery/source-control/module-11.2-gitea-forgejo.md
+++ b/src/content/docs/platform/toolkits/cicd-delivery/source-control/module-11.2-gitea-forgejo.md
@@ -6,7 +6,7 @@ sidebar:
   order: 3
 ---
 
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 
 ## Time to Complete: 55-70 minutes
 

--- a/src/content/docs/platform/toolkits/cicd-delivery/source-control/module-11.3-github-advanced.md
+++ b/src/content/docs/platform/toolkits/cicd-delivery/source-control/module-11.3-github-advanced.md
@@ -6,7 +6,7 @@ sidebar:
   order: 4
 ---
 
-## Complexity: [COMPLEX]
+## Complexity: `[COMPLEX]`
 ## Time to Complete: 50-60 minutes
 
 ---

--- a/src/content/docs/platform/toolkits/data-ai-platforms/cloud-native-databases/module-15.1-cockroachdb.md
+++ b/src/content/docs/platform/toolkits/data-ai-platforms/cloud-native-databases/module-15.1-cockroachdb.md
@@ -6,7 +6,7 @@ sidebar:
   order: 2
 ---
 
-## Complexity: [COMPLEX]
+## Complexity: `[COMPLEX]`
 
 ## Time to Complete: 65-80 minutes
 

--- a/src/content/docs/platform/toolkits/data-ai-platforms/cloud-native-databases/module-15.2-cloudnativepg.md
+++ b/src/content/docs/platform/toolkits/data-ai-platforms/cloud-native-databases/module-15.2-cloudnativepg.md
@@ -6,7 +6,7 @@ sidebar:
   order: 3
 ---
 
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 
 ## Time to Complete: 50-60 minutes
 

--- a/src/content/docs/platform/toolkits/data-ai-platforms/cloud-native-databases/module-15.3-serverless-databases.md
+++ b/src/content/docs/platform/toolkits/data-ai-platforms/cloud-native-databases/module-15.3-serverless-databases.md
@@ -5,7 +5,7 @@ slug: platform/toolkits/data-ai-platforms/cloud-native-databases/module-15.3-ser
 sidebar:
   order: 4
 ---
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 ## Time to Complete: 40-45 minutes
 
 ---

--- a/src/content/docs/platform/toolkits/data-ai-platforms/cloud-native-databases/module-15.4-vitess.md
+++ b/src/content/docs/platform/toolkits/data-ai-platforms/cloud-native-databases/module-15.4-vitess.md
@@ -5,7 +5,7 @@ slug: platform/toolkits/data-ai-platforms/cloud-native-databases/module-15.4-vit
 sidebar:
   order: 5
 ---
-## Complexity: [COMPLEX]
+## Complexity: `[COMPLEX]`
 ## Time to Complete: 50-55 minutes
 
 ---

--- a/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.10-bentoml.md
+++ b/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.10-bentoml.md
@@ -6,7 +6,7 @@ sidebar:
   order: 11
 ---
 
-## Complexity: [COMPLEX]
+## Complexity: `[COMPLEX]`
 
 **Time to Complete**: 50-60 min
 

--- a/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.4-vllm.md
+++ b/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.4-vllm.md
@@ -6,7 +6,7 @@ sidebar:
   order: 5
 ---
 
-## Complexity: [COMPLEX]
+## Complexity: `[COMPLEX]`
 
 **Time to Complete**: 90 minutes  
 **Prerequisites**: Module 9.1 (Kubeflow basics), Kubernetes GPU scheduling basics, transformer inference basics, and comfort reading Prometheus metrics  

--- a/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.5-ray-serve.md
+++ b/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.5-ray-serve.md
@@ -6,7 +6,7 @@ sidebar:
   order: 6
 ---
 
-## Complexity: [COMPLEX]
+## Complexity: `[COMPLEX]`
 
 **Time to Complete**: 90 minutes  
 **Prerequisites**: Module 9.4 (vLLM), Basic Python, Kubernetes workload fundamentals, familiarity with CPU and GPU resource requests

--- a/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.6-langchain-llamaindex.md
+++ b/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.6-langchain-llamaindex.md
@@ -6,7 +6,7 @@ sidebar:
   order: 7
 ---
 
-## Complexity: [COMPLEX]
+## Complexity: `[COMPLEX]`
 
 **Time to Complete**: 90 minutes
 

--- a/src/content/docs/platform/toolkits/developer-experience/devex-tools/module-8.5-gitpod-codespaces.md
+++ b/src/content/docs/platform/toolkits/developer-experience/devex-tools/module-8.5-gitpod-codespaces.md
@@ -5,7 +5,7 @@ slug: platform/toolkits/developer-experience/devex-tools/module-8.5-gitpod-codes
 sidebar:
   order: 6
 ---
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 ## Time to Complete: 45-50 minutes
 
 ---

--- a/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.1-terraform.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.1-terraform.md
@@ -6,7 +6,7 @@ sidebar:
   order: 2
 ---
 
-## Complexity: [COMPLEX]
+## Complexity: `[COMPLEX]`
 
 ## Time to Complete: 60 minutes
 

--- a/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.10-nitric.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.10-nitric.md
@@ -5,7 +5,7 @@ slug: platform/toolkits/infrastructure-networking/iac-tools/module-7.10-nitric
 sidebar:
   order: 11
 ---
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 ## Time to Complete: 60-75 minutes
 
 ---

--- a/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.11-hcp-terraform-workflows.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.11-hcp-terraform-workflows.md
@@ -5,7 +5,7 @@ slug: platform/toolkits/infrastructure-networking/iac-tools/module-7.11-hcp-terr
 sidebar:
   order: 12
 ---
-> **Complexity**: [COMPLEX]
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: 60-70 min
 >

--- a/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.12-ansible-operator-sdk.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.12-ansible-operator-sdk.md
@@ -4,7 +4,7 @@ slug: platform/toolkits/infrastructure-networking/iac-tools/module-7.12-ansible-
 sidebar:
   order: 13
 ---
-> **Complexity**: [COMPLEX]
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: ~90 minutes
 >

--- a/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.13-advanced-watches-yaml.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.13-advanced-watches-yaml.md
@@ -4,7 +4,7 @@ slug: platform/toolkits/infrastructure-networking/iac-tools/module-7.13-advanced
 sidebar:
   order: 14
 ---
-> **Complexity**: [COMPLEX]
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: ~100 minutes
 >

--- a/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.14-awx-tower-eda.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.14-awx-tower-eda.md
@@ -5,7 +5,7 @@ sidebar:
   order: 15
 ---
 
-> **Complexity**: [COMPLEX]
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: ~120 minutes
 >

--- a/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.15-helm-ansible-go-operator-decision.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.15-helm-ansible-go-operator-decision.md
@@ -5,7 +5,7 @@ sidebar:
   order: 16
 ---
 
-> **Complexity**: [COMPLEX]
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: ~90 minutes
 >

--- a/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.17-testing-ansible-operators.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.17-testing-ansible-operators.md
@@ -4,7 +4,7 @@ slug: platform/toolkits/infrastructure-networking/iac-tools/module-7.17-testing-
 sidebar:
   order: 18
 ---
-> **Complexity**: [COMPLEX]
+> **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: ~100 minutes
 >

--- a/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.2-opentofu.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.2-opentofu.md
@@ -6,7 +6,7 @@ sidebar:
   order: 3
 ---
 
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 
 ## Time to Complete: 50 minutes
 

--- a/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.3-pulumi.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.3-pulumi.md
@@ -6,7 +6,7 @@ sidebar:
   order: 4
 ---
 
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 
 ## Time to Complete: 45 minutes
 

--- a/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.4-ansible.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.4-ansible.md
@@ -6,7 +6,7 @@ sidebar:
   order: 5
 ---
 
-## Complexity: [COMPLEX]
+## Complexity: `[COMPLEX]`
 
 ## Time to Complete: 90 minutes
 

--- a/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.6-bicep.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.6-bicep.md
@@ -5,7 +5,7 @@ slug: platform/toolkits/infrastructure-networking/iac-tools/module-7.6-bicep
 sidebar:
   order: 7
 ---
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 ## Time to Complete: 75 minutes
 
 ---

--- a/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.7-winglang.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.7-winglang.md
@@ -6,7 +6,7 @@ sidebar:
   order: 8
 ---
 
-## Complexity: [COMPLEX]
+## Complexity: `[COMPLEX]`
 
 ## Time to Complete: 50-55 minutes
 

--- a/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.8-sst.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.8-sst.md
@@ -6,7 +6,7 @@ sidebar:
   order: 9
 ---
 
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 
 ## Time to Complete: 45-50 minutes
 

--- a/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.9-system-initiative.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.9-system-initiative.md
@@ -5,7 +5,7 @@ slug: platform/toolkits/infrastructure-networking/iac-tools/module-7.9-system-in
 sidebar:
   order: 10
 ---
-## Complexity: [COMPLEX]
+## Complexity: `[COMPLEX]`
 
 ## Time to Complete: 50-55 minutes
 

--- a/src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/module-14.4-talos.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/module-14.4-talos.md
@@ -6,7 +6,7 @@ sidebar:
   order: 5
 ---
 
-## Complexity: [COMPLEX]
+## Complexity: `[COMPLEX]`
 ## Time to Complete: 55-70 minutes
 
 ---

--- a/src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/module-14.6-managed-kubernetes.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/module-14.6-managed-kubernetes.md
@@ -6,7 +6,7 @@ sidebar:
   order: 7
 ---
 
-## Complexity: [COMPLEX]
+## Complexity: `[COMPLEX]`
 
 ## Time to Complete: 55-60 minutes
 

--- a/src/content/docs/platform/toolkits/infrastructure-networking/storage/module-16.2-minio.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/storage/module-16.2-minio.md
@@ -6,7 +6,7 @@ sidebar:
   order: 3
 ---
 
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 
 ## Time to Complete: 55-70 minutes
 

--- a/src/content/docs/platform/toolkits/infrastructure-networking/storage/module-16.3-longhorn.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/storage/module-16.3-longhorn.md
@@ -6,7 +6,7 @@ sidebar:
   order: 4
 ---
 
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 
 ## Time to Complete: 55-70 minutes
 

--- a/src/content/docs/platform/toolkits/observability-intelligence/observability/module-1.11-ebpf-tracing-tools.md
+++ b/src/content/docs/platform/toolkits/observability-intelligence/observability/module-1.11-ebpf-tracing-tools.md
@@ -7,7 +7,7 @@ sidebar:
 revision_pending: false
 ---
 
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 
 **Time to Complete**: 50 minutes, plus extra lab time if you need to install kernel headers, create a disposable Kubernetes cluster, or request temporary debugging privileges.
 

--- a/src/content/docs/platform/toolkits/observability-intelligence/observability/module-1.6-pixie.md
+++ b/src/content/docs/platform/toolkits/observability-intelligence/observability/module-1.6-pixie.md
@@ -6,7 +6,7 @@ sidebar:
   order: 7
 ---
 
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 
 **Time to Complete**: 90 minutes
 

--- a/src/content/docs/platform/toolkits/observability-intelligence/observability/module-1.7-hubble.md
+++ b/src/content/docs/platform/toolkits/observability-intelligence/observability/module-1.7-hubble.md
@@ -6,7 +6,7 @@ sidebar:
   order: 8
 ---
 
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 
 **Time to Complete**: 90 minutes
 

--- a/src/content/docs/platform/toolkits/observability-intelligence/observability/module-1.9-continuous-profiling.md
+++ b/src/content/docs/platform/toolkits/observability-intelligence/observability/module-1.9-continuous-profiling.md
@@ -2,7 +2,6 @@
 revision_pending: false
 title: "Module 1.9: Continuous Profiling - The 4th Pillar of Observability"
 slug: platform/toolkits/observability-intelligence/observability/module-1.9-continuous-profiling
-complexity: "[MEDIUM]"
 time_to_complete: "60-75 minutes"
 prerequisites: "Module 1.1: Prometheus; Module 1.2: OpenTelemetry; Module 1.5: Distributed Tracing; Basic Kubernetes 1.35 workload operations"
 sidebar:

--- a/src/content/docs/platform/toolkits/security-quality/code-quality/module-12.1-sonarqube.md
+++ b/src/content/docs/platform/toolkits/security-quality/code-quality/module-12.1-sonarqube.md
@@ -6,7 +6,7 @@ sidebar:
   order: 2
 ---
 
-## Complexity: [COMPLEX]
+## Complexity: `[COMPLEX]`
 
 ## Time to Complete: 50-60 minutes
 

--- a/src/content/docs/platform/toolkits/security-quality/code-quality/module-12.2-semgrep.md
+++ b/src/content/docs/platform/toolkits/security-quality/code-quality/module-12.2-semgrep.md
@@ -5,7 +5,7 @@ slug: platform/toolkits/security-quality/code-quality/module-12.2-semgrep
 sidebar:
   order: 3
 ---
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 ## Time to Complete: 60-75 minutes
 
 ---

--- a/src/content/docs/platform/toolkits/security-quality/code-quality/module-12.3-codeql.md
+++ b/src/content/docs/platform/toolkits/security-quality/code-quality/module-12.3-codeql.md
@@ -6,7 +6,7 @@ sidebar:
   order: 4
 ---
 
-## Complexity: [COMPLEX]
+## Complexity: `[COMPLEX]`
 ## Time to Complete: 60-75 minutes
 
 ---

--- a/src/content/docs/platform/toolkits/security-quality/code-quality/module-12.4-snyk.md
+++ b/src/content/docs/platform/toolkits/security-quality/code-quality/module-12.4-snyk.md
@@ -5,7 +5,7 @@ slug: platform/toolkits/security-quality/code-quality/module-12.4-snyk
 sidebar:
   order: 5
 ---
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 ## Time to Complete: 45-50 minutes
 
 ---

--- a/src/content/docs/platform/toolkits/security-quality/code-quality/module-12.5-trivy.md
+++ b/src/content/docs/platform/toolkits/security-quality/code-quality/module-12.5-trivy.md
@@ -5,7 +5,7 @@ slug: platform/toolkits/security-quality/code-quality/module-12.5-trivy
 sidebar:
   order: 6
 ---
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 ## Time to Complete: 45-50 minutes
 
 ---

--- a/src/content/docs/platform/toolkits/security-quality/security-tools/module-4.5-tetragon.md
+++ b/src/content/docs/platform/toolkits/security-quality/security-tools/module-4.5-tetragon.md
@@ -5,7 +5,7 @@ slug: platform/toolkits/security-quality/security-tools/module-4.5-tetragon
 sidebar:
   order: 6
 ---
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 
 This module sits at medium complexity because it combines kernel-level concepts, Kubernetes custom resources, and operational judgment about when to enforce versus observe. You should arrive with working familiarity from [Module 4.3 Falco](../module-4.3-falco/), the [eBPF Fundamentals](/platform/foundations/ebpf/module-1.1-ebpf-fundamentals/) track, Linux syscall behavior, and baseline Kubernetes security primitives such as namespaces, service accounts, and DaemonSets. Plan roughly ninety minutes to read the theory, study the policy examples, and reason through the layered architecture with Falco. The learning path emphasizes design trade-offs—when kernel enforcement helps, when it creates risk, and how to roll out policies without breaking legitimate workloads.
 

--- a/src/content/docs/platform/toolkits/security-quality/security-tools/module-4.6-kubearmor.md
+++ b/src/content/docs/platform/toolkits/security-quality/security-tools/module-4.6-kubearmor.md
@@ -6,7 +6,7 @@ sidebar:
   order: 7
 ---
 
-## Complexity: [MEDIUM]
+## Complexity: `[MEDIUM]`
 
 **Time to Complete**: 90 minutes
 

--- a/src/content/docs/prerequisites/git-deep-dive/module-1-git-internals.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-1-git-internals.md
@@ -6,7 +6,7 @@ sidebar:
   order: 1
 ---
 
-> **Complexity**: [MEDIUM]
+> **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 90 minutes
 >

--- a/src/content/docs/prerequisites/git-deep-dive/module-10-gitops-bridge.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-10-gitops-bridge.md
@@ -1,7 +1,6 @@
 ---
 title: "Module 10: Bridge to GitOps — The Infrastructure Source"
 description: "Transitioning from manual infrastructure management to declarative, Git-driven continuous reconciliation."
-complexity: "MEDIUM"
 timeToComplete: "60 minutes"
 revision_pending: false
 sidebar:

--- a/src/content/docs/prerequisites/git-deep-dive/module-2-advanced-merging.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-2-advanced-merging.md
@@ -4,13 +4,12 @@ sidebar:
   order: 2
 description: "Mastering Git merge strategies, conflict resolution, and branching models for Kubernetes infrastructure."
 timeToComplete: "75 minutes"
-complexity: "MEDIUM"
 prerequisites: ["Module 1 (Git Internals)"]
 nextModule: "[Module 3: History as a Choice](../module-3-interactive-rebasing/)"
 revision_pending: false
 ---
 
-> **Complexity**: MEDIUM
+> **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 75 minutes
 >

--- a/src/content/docs/prerequisites/git-deep-dive/module-3-interactive-rebasing.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-3-interactive-rebasing.md
@@ -6,7 +6,7 @@ sidebar:
 revision_pending: false
 ---
 
-> **Complexity**: [MEDIUM]
+> **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 90 minutes
 >

--- a/src/content/docs/prerequisites/git-deep-dive/module-4-undo-recovery.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-4-undo-recovery.md
@@ -5,7 +5,7 @@ sidebar:
 revision_pending: false
 ---
 
-> **Complexity**: [MEDIUM]
+> **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 60 minutes
 >

--- a/src/content/docs/prerequisites/git-deep-dive/module-5-worktrees-stashing.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-5-worktrees-stashing.md
@@ -1,6 +1,5 @@
 ---
 title: "Module 5: Multi-Tasking Mastery - Worktrees and Stashing"
-complexity: MEDIUM
 time_to_complete: "60 minutes"
 prerequisites: "Module 4 of Git Deep Dive"
 next_module: "[Module 6: The Digital Detective](../module-6-troubleshooting/)"
@@ -9,7 +8,7 @@ sidebar:
   order: 5
 ---
 
-> **Complexity**: [MEDIUM]
+> **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 60 minutes
 >

--- a/src/content/docs/prerequisites/git-deep-dive/module-6-troubleshooting.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-6-troubleshooting.md
@@ -6,7 +6,7 @@ sidebar:
 revision_pending: false
 ---
 
-> **Complexity**: [MEDIUM]
+> **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 90 minutes
 >

--- a/src/content/docs/prerequisites/git-deep-dive/module-7-remotes-prs.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-7-remotes-prs.md
@@ -7,7 +7,7 @@ sidebar:
   order: 7
 ---
 
-> **Complexity**: [MEDIUM]
+> **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 90 minutes
 >

--- a/src/content/docs/prerequisites/git-deep-dive/module-8-scale.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-8-scale.md
@@ -5,7 +5,7 @@ revision_pending: false
 sidebar:
   order: 8
 ---
-> **Complexity**: [MEDIUM]
+> **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 90 minutes
 >

--- a/src/content/docs/prerequisites/git-deep-dive/module-9-hooks-rerere.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-9-hooks-rerere.md
@@ -7,7 +7,7 @@ sidebar:
   order: 9
 ---
 
-> **Complexity**: [MEDIUM]
+> **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 75 minutes
 >

--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.1-first-cluster.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.1-first-cluster.md
@@ -11,7 +11,7 @@ lab:
   difficulty: "beginner"
   environment: "kubernetes"
 ---
-> **Complexity**: [MEDIUM]
+> **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 45-60 minutes
 >

--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.3-pods.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.3-pods.md
@@ -11,7 +11,7 @@ lab:
   difficulty: "beginner"
   environment: "kubernetes"
 ---
-> **Complexity**: [MEDIUM]
+> **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 60-75 minutes
 >

--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.7-namespaces-labels.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.7-namespaces-labels.md
@@ -5,7 +5,7 @@ revision_pending: false
 sidebar:
   order: 8
 ---
-> **Complexity**: [MEDIUM]
+> **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 50-60 minutes
 >

--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.8-yaml-kubernetes.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.8-yaml-kubernetes.md
@@ -5,7 +5,7 @@ sidebar:
   order: 9
 revision_pending: false
 ---
-> **Complexity**: [MEDIUM]
+> **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 60-75 minutes
 >

--- a/src/content/docs/prerequisites/modern-devops/module-1.2-gitops.md
+++ b/src/content/docs/prerequisites/modern-devops/module-1.2-gitops.md
@@ -6,7 +6,7 @@ sidebar:
   order: 3
 ---
 
-> **Complexity**: [MEDIUM]
+> **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 60-75 minutes
 >

--- a/src/content/docs/prerequisites/modern-devops/module-1.3-cicd-pipelines.md
+++ b/src/content/docs/prerequisites/modern-devops/module-1.3-cicd-pipelines.md
@@ -6,7 +6,7 @@ sidebar:
   order: 4
 ---
 
-> **Complexity:** [MEDIUM]
+> **Complexity:** `[MEDIUM]`
 >
 > **Time to Complete:** 60-75 minutes
 >

--- a/src/content/docs/prerequisites/modern-devops/module-1.5-platform-engineering.md
+++ b/src/content/docs/prerequisites/modern-devops/module-1.5-platform-engineering.md
@@ -6,7 +6,7 @@ sidebar:
 revision_pending: false
 ---
 
-> **Complexity**: [MEDIUM]
+> **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 60-75 minutes
 >

--- a/src/content/docs/prerequisites/zero-to-terminal/module-0.6-git-basics.md
+++ b/src/content/docs/prerequisites/zero-to-terminal/module-0.6-git-basics.md
@@ -6,7 +6,7 @@ sidebar:
   order: 7
 ---
 
-> **Complexity**: [BEGINNER]
+> **Complexity**: `[QUICK]`
 >
 > **Time to Complete**: 60 minutes
 >


### PR DESCRIPTION
## What

Builds a **deterministic Python normalizer** (`scripts/normalize_complexity_markers.py`) and applies it repo-wide to rewrite every drifted complexity marker to the **locked canonical form**: a backticked bracketed tier `[TIER]` from the five-tier controlled vocabulary, with the legacy `complexity:` frontmatter key dropped (body marker is the single source of truth).

Resolves the **marker/leveling** ACs of #2141, #2146, #2181, #2187, #2195.

## Canonical form (locked)

```
> **Complexity**: `[MEDIUM]`
```

Controlled vocabulary — five tiers only: `[QUICK]` `[MEDIUM]` `[COMPLEX]` `[ADVANCED]` `[EXPERT]`.
- `[ADVANCED]` **is** sanctioned (band between COMPLEX and EXPERT).
- `[BEGINNER]` is **not** a tier → maps to `[QUICK]`.
- Documented in `docs/quality-rubric.md` (new "Complexity Marker Convention (locked)" section).

## Design decisions

- **Token-only, container-preserving.** The normalizer canonicalizes only the tier TOKEN in place. A `## Complexity:` heading or a `| Complexity |` table cell keeps its container; only the token inside is fixed. Forcing every marker into a blockquote would restructure internally-consistent per-track layouts (platform-toolkits headings, k8s-cert exam tables) the driving issues never targeted — that axis is a deliberate non-goal, flagged for a possible follow-up.
- **Never re-levels on content judgement.** `[QUICK]` stays `[QUICK]` even where an audit (e.g. #2141) flags a genuine mislabel; those are separate content follow-ups.
- **Deterministic maps:** `Intermediate`/`[INTERMEDIATE]` → `[MEDIUM]`; `Advanced` → `[ADVANCED]`; `Complex` → `[COMPLEX]`; `[BEGINNER]` → `[QUICK]`; ranges → **ceiling** ("Beginner to intermediate" → `[MEDIUM]`, "Intermediate to Advanced" → `[ADVANCED]`).
- **False-positive guards:** case-sensitive `Complexity` label + title/upper tier spellings + framed-banner-only + first-marker-only within the top of the body. Prose like "this adds complexity: advanced tuning" is left untouched. `uk/` (translation lane) excluded entirely.

## Change set

**188 files** — 186 marker tokens canonicalized + 4 `complexity:` frontmatter keys dropped.

| Track | files | Track | files |
|---|---|---|---|
| cloud | 66 | ai | 13 |
| platform | 48 | on-premises | 7 |
| ai-ml-engineering | 28 | k8s (cks/cgoa/cnpa) | 6 |
| prerequisites | 18 | linux | 2 |

Semantic tier remaps (the non-cosmetic changes): 24× `Intermediate → [MEDIUM]`, 11× `Advanced → [ADVANCED]`, 4× `[INTERMEDIATE] → [MEDIUM]`, 3× `Complex → [COMPLEX]`, 2× `Beginner to intermediate → [MEDIUM]`, 1× `Intermediate to Advanced → [ADVANCED]`, 1× `[BEGINNER] → [QUICK]`. Remainder are bare-bracket → backticked-bracket (already-correct vocab).

## Verification

- `npm run build` → **2169 pages, 0 errors**.
- `scripts/tests/test_normalize_complexity_markers.py` → **33 passed** (transform, prose-guard, idempotency, frontmatter-drop, container-preservation).
- `ruff check` clean.
- Idempotent: re-running `--check` on this branch reports zero drift.

## Coordination / review

Touches **content**, which the curriculum lane owns — @curriculum-lane please sanity-check the tier maps. Diffs are surgical (one marker line per file). No overlap with the in-flight `cloud-2187-mechanical` / `linux-2181-mechanical` work (those touched headers/frontmatter/links, not marker tokens) or `k8s-2161-kcna` (KCNA markers were already canonical → 0 files changed there).

The `docs/quality-rubric.md` change contains the leveling-table rationale the #2141/#2146 ACs asked to document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)