### PR TITLE
docs(ai-ml): dedupe prereqs-1.2 header + normalize prereqs complexity banners (#2195)

### DIFF
--- a/src/content/docs/ai-ml-engineering/prerequisites/module-1.2-home-ai-workstation-fundamentals.md
+++ b/src/content/docs/ai-ml-engineering/prerequisites/module-1.2-home-ai-workstation-fundamentals.md
@@ -7,10 +7,8 @@ sidebar:
 ---
 
 > **AI/ML Engineering Track** | Complexity: `[MEDIUM]` | Time: 2-3 hours
-
-**Reading Time**: 2-3 hours
-
-**Prerequisites**: Module 1.1 complete, basic comfort with terminal commands, package installation, reading system specifications, and willingness to record evidence before upgrading hardware
+>
+> **Prerequisites**: Module 1.1 complete, basic comfort with terminal commands, package installation, reading system specifications, and willingness to record evidence before upgrading hardware
 
 ---
 

--- a/src/content/docs/ai-ml-engineering/prerequisites/module-1.3-reproducible-python-cuda-rocm-environments.md
+++ b/src/content/docs/ai-ml-engineering/prerequisites/module-1.3-reproducible-python-cuda-rocm-environments.md
@@ -5,9 +5,7 @@ slug: ai-ml-engineering/prerequisites/module-1.3-reproducible-python-cuda-rocm-e
 sidebar:
   order: 103
 ---
-> **Complexity**: `[MEDIUM]`
->
-> **Time to Complete**: 2-3 hours
+> **AI/ML Engineering Track** | Complexity: `[MEDIUM]` | Time: 2-3 hours
 >
 > **Prerequisites**: [Module 1.1: Prerequisites & Environment Setup](./module-1.1-prerequisites-environment-setup/), [Module 1.2: Home AI Workstation Fundamentals](./module-1.2-home-ai-workstation-fundamentals/), basic command-line navigation, and comfort editing small text files.
 

--- a/src/content/docs/ai-ml-engineering/prerequisites/module-1.4-notebooks-scripts-project-layouts.md
+++ b/src/content/docs/ai-ml-engineering/prerequisites/module-1.4-notebooks-scripts-project-layouts.md
@@ -6,10 +6,8 @@ sidebar:
   order: 104
 ---
 > **AI/ML Engineering Track** | Complexity: `[MEDIUM]` | Time: 2-3 hours
----
-**Reading Time**: 2-3 hours, including the refactor exercise, dependency-file inspection, and a clean-shell rerun of the starter project.
-
-**Prerequisites**: Modules 1.1 through 1.3 complete
+>
+> **Prerequisites**: Modules 1.1 through 1.3 complete
 
 ---
 


### PR DESCRIPTION
## What
Residual mechanical cleanup for #2195 (ai-ml-engineering prerequisites). The issue's other two parts — 6 modules missing header blocks, and bare-`Intermediate` marker drift — were **already resolved** (headers by `e7dae7dc0` #2194/#2196/#2195; markers by the #2141 normalizer). Only the header-dup / prose-form residual remained.

## Changes
- **module-1.2**: removed duplicate `**Reading Time**` line (banner already carries Time); folded Prerequisites into the banner blockquote.
- **module-1.3**: normalized `> **Complexity**: [MEDIUM]` + `Time to Complete` prose into the canonical `> **AI/ML Engineering Track** | Complexity: \`[MEDIUM]\` | Time: …` banner.
- **module-1.4**: caught by the grep-ALL sweep (not in the issue list) — same dup `Reading Time` + plain Prerequisites, folded into banner.

## Verification
- `npm run build`: 2169 pages, **0 errors**.
- Cross-family review: authored by cursor (`auto`/Kimi), reviewed inline by orchestrator (opus, Anthropic family) — mechanical formatting only.

Refs #2195