### PR TITLE
feat(dispatch): claude + sources-MCP author lane (draft/edit, write tools, --effort) (#2134)

### DIFF
--- a/scripts/agent_runtime/adapters/claude.py
+++ b/scripts/agent_runtime/adapters/claude.py
@@ -162,8 +162,13 @@ class ClaudeAdapter:
         effort = tc.get("effort")
         if model:
             suffix_match = re.match(r"^(.*)-(high|medium|low)$", model)
-            if suffix_match and not effort:
-                model, effort = suffix_match.group(1), suffix_match.group(2)
+            if suffix_match:
+                # Always strip the effort suffix from the model id (it is not a
+                # real API model id). The suffix supplies the effort ONLY when no
+                # explicit tool_config["effort"] was given — explicit wins.
+                model = suffix_match.group(1)
+                if not effort:
+                    effort = suffix_match.group(2)
             cmd.extend(["--model", model])
         if isinstance(effort, str) and effort and effort != "default":
             cmd.extend(["--effort", effort])

--- a/scripts/agent_runtime/adapters/claude.py
+++ b/scripts/agent_runtime/adapters/claude.py
@@ -151,9 +151,22 @@ class ClaudeAdapter:
         if isinstance(permission_mode, str) and permission_mode:
             cmd.extend(["--permission-mode", permission_mode])
 
-        # Model override
+        # Model override + reasoning effort (#2134). Effort can be supplied two
+        # ways: an explicit ``tool_config["effort"]`` (mirrors the codex/qwen/
+        # deepseek convention), or an effort SUFFIX on the model slug
+        # (``claude-sonnet-5-high`` -> model ``claude-sonnet-5`` + effort
+        # ``high``, mirroring the agy ``gemini-3.1-pro-high`` slug). Claude Code's
+        # headless CLI accepts ``--effort <level>``. Real model ids
+        # (claude-sonnet-4-6, claude-opus-4-8, ...) never end in a bare
+        # -high/-medium/-low token, so the suffix strip is unambiguous.
+        effort = tc.get("effort")
         if model:
+            suffix_match = re.match(r"^(.*)-(high|medium|low)$", model)
+            if suffix_match and not effort:
+                model, effort = suffix_match.group(1), suffix_match.group(2)
             cmd.extend(["--model", model])
+        if isinstance(effort, str) and effort and effort != "default":
+            cmd.extend(["--effort", effort])
 
         # Output format
         cmd.extend(["--output-format", tc.get("output_format", "text")])

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -198,25 +198,61 @@ def _pace_gemini_calls() -> None:
 # MCP tools for Ukrainian translations (shared RAG server)
 # ---------------------------------------------------------------------------
 
-# Claude with MCP: Ukrainian verification + quality tools
+# Claude with MCP: Ukrainian verification + quality tools.
+# Server name is ``sources`` (the live server in .mcp.json), so tool names are
+# ``mcp__sources__*`` — the old ``mcp__rag__*`` prefix pointed at a server that
+# no longer exists, so no tool resolved (#2134). ``search_etymology`` is served
+# as ``search_esum`` (ESUM — Ukrainian etymological dictionary) on this server.
+#
+# NOTE: kept as a single literal string (adjacent-string concatenation, one
+# ast.Constant) because dispatch_smart._load_dispatch_str_constant reads it via
+# ast.literal_eval — do NOT rewrite as variable concatenation.
 CLAUDE_TRANSLATION_TOOLS = (
-    "mcp__rag__verify_word,"
-    "mcp__rag__verify_words,"
-    "mcp__rag__verify_lemma,"
-    "mcp__rag__search_text,"
-    "mcp__rag__search_literary,"
-    "mcp__rag__query_pravopys,"
-    "mcp__rag__search_style_guide,"
-    "mcp__rag__query_cefr_level,"
-    "mcp__rag__search_definitions,"
-    "mcp__rag__search_etymology,"
-    "mcp__rag__search_idioms,"
-    "mcp__rag__search_synonyms,"
-    "mcp__rag__translate_en_uk,"
-    "mcp__rag__query_grac,"
-    "mcp__rag__query_ulif,"
-    "mcp__rag__query_r2u,"
+    "mcp__sources__verify_word,"
+    "mcp__sources__verify_words,"
+    "mcp__sources__verify_lemma,"
+    "mcp__sources__search_text,"
+    "mcp__sources__search_literary,"
+    "mcp__sources__query_pravopys,"
+    "mcp__sources__search_style_guide,"
+    "mcp__sources__query_cefr_level,"
+    "mcp__sources__search_definitions,"
+    "mcp__sources__search_esum,"
+    "mcp__sources__search_idioms,"
+    "mcp__sources__search_synonyms,"
+    "mcp__sources__translate_en_uk,"
+    "mcp__sources__query_grac,"
+    "mcp__sources__query_ulif,"
+    "mcp__sources__query_r2u,"
     "Read"
+)
+
+# Claude AUTHORING with MCP (draft/edit task classes): write-capable tools plus
+# the same ``sources`` verification tools, so a Sonnet author can corpus-verify
+# Ukrainian terminology at write time (#2134). Kept SEPARATE from the read-only
+# CLAUDE_TRANSLATION_TOOLS so the review/search lane never gains write access.
+# Same literal-string constraint as above (read via ast.literal_eval).
+CLAUDE_MCP_AUTHOR_TOOLS = (
+    "Write,"
+    "Edit,"
+    "MultiEdit,"
+    "Read,"
+    "mcp__sources__verify_word,"
+    "mcp__sources__verify_words,"
+    "mcp__sources__verify_lemma,"
+    "mcp__sources__search_text,"
+    "mcp__sources__search_literary,"
+    "mcp__sources__query_pravopys,"
+    "mcp__sources__search_style_guide,"
+    "mcp__sources__query_cefr_level,"
+    "mcp__sources__search_definitions,"
+    "mcp__sources__search_esum,"
+    "mcp__sources__search_idioms,"
+    "mcp__sources__search_synonyms,"
+    "mcp__sources__translate_en_uk,"
+    "mcp__sources__query_grac,"
+    "mcp__sources__query_ulif,"
+    "mcp__sources__query_r2u"
 )
 
 # ---------------------------------------------------------------------------

--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -109,7 +109,10 @@ MCP_CONFIG_PATH = PRIMARY_REPO / ".mcp.json"
 MCP_SUPPORTED_AGENTS = frozenset({"claude", "deepseek"})
 HERMES_MCP_AGENTS = frozenset({"deepseek"})
 HERMES_MCP_TASK_CLASSES = frozenset({"draft", "edit"})
-CLAUDE_MCP_TASK_CLASSES = frozenset({"review", "search"})
+# review/search -> read-only sources tools; draft/edit -> write-capable author
+# tools (both curated in scripts/dispatch.py). See _import_dispatch_mcp_constants.
+CLAUDE_MCP_TASK_CLASSES = frozenset({"review", "search", "draft", "edit"})
+CLAUDE_MCP_AUTHOR_TASK_CLASSES = frozenset({"draft", "edit"})
 
 # Skill auto-loading — R2 follow-up to PR #1575 and the agents_extensions/
 # layout introduced there.
@@ -391,34 +394,46 @@ def _available_hermes_mcp_servers() -> list[str]:
     )
 
 
-def _load_claude_translation_tools() -> str:
-    """Read ``CLAUDE_TRANSLATION_TOOLS`` from ``scripts/dispatch.py`` without importing it."""
+def _load_dispatch_str_constant(name: str) -> str:
+    """Read a module-level string constant from ``scripts/dispatch.py`` without
+    importing it (dispatch.py is a CLI with import-time side effects). The named
+    constant must be a plain string literal (read via ast.literal_eval)."""
     dispatch_path = REPO / "scripts" / "dispatch.py"
     tree = ast.parse(dispatch_path.read_text(encoding="utf-8"))
     for node in tree.body:
         if not isinstance(node, ast.Assign):
             continue
         for target in node.targets:
-            if isinstance(target, ast.Name) and target.id == "CLAUDE_TRANSLATION_TOOLS":
+            if isinstance(target, ast.Name) and target.id == name:
                 value = ast.literal_eval(node.value)
                 if isinstance(value, str):
                     return value
-                raise ValueError("CLAUDE_TRANSLATION_TOOLS must be a string")
-    raise ValueError("CLAUDE_TRANSLATION_TOOLS not found in scripts/dispatch.py")
+                raise ValueError(f"{name} must be a string")
+    raise ValueError(f"{name} not found in scripts/dispatch.py")
 
 
-def _import_dispatch_mcp_constants() -> tuple[str, str]:
-    """Reuse the curated RAG allowlist from ``scripts/dispatch.py``."""
-    return str(MCP_CONFIG_PATH), _load_claude_translation_tools()
+def _import_dispatch_mcp_constants(task_class: str) -> tuple[str, str]:
+    """Return (mcp_config_path, allowed_tools) for a claude MCP dispatch.
+
+    Authoring classes (draft/edit) get the write-capable
+    ``CLAUDE_MCP_AUTHOR_TOOLS``; read classes (review/search) get the read-only
+    ``CLAUDE_TRANSLATION_TOOLS``. Both are curated in scripts/dispatch.py (#2134).
+    """
+    constant = (
+        "CLAUDE_MCP_AUTHOR_TOOLS"
+        if task_class in CLAUDE_MCP_AUTHOR_TASK_CLASSES
+        else "CLAUDE_TRANSLATION_TOOLS"
+    )
+    return str(MCP_CONFIG_PATH), _load_dispatch_str_constant(constant)
 
 
-def _build_mcp_tool_config(agent: str, mcp_server: str) -> dict | None:
+def _build_mcp_tool_config(agent: str, mcp_server: str, task_class: str) -> dict | None:
     """Build adapter ``tool_config`` for MCP tool access."""
     sys.path.insert(0, str(REPO / "scripts"))
     from agent_runtime.tool_config import build_mcp_tool_config
 
     if agent == "claude":
-        mcp_config_path, allowed_tools = _import_dispatch_mcp_constants()
+        mcp_config_path, allowed_tools = _import_dispatch_mcp_constants(task_class)
         tool_config, _diagnostics = build_mcp_tool_config(
             agent,
             mcp_servers=[mcp_server],
@@ -998,12 +1013,11 @@ def main() -> int:
         if args.agent == "claude":
             if args.task_class not in CLAUDE_MCP_TASK_CLASSES:
                 p.error(
-                    f"--mcp is only supported for read task classes "
-                    f"({', '.join(sorted(CLAUDE_MCP_TASK_CLASSES))}) on claude; "
-                    f"got task_class={args.task_class!r}. Write classes would "
-                    f"either cripple claude (allowedTools restricted to RAG+Read, "
-                    f"no write) or silently scope-creep; use the write-mode "
-                    f"dispatch.py --mcp path for translation authoring."
+                    f"--mcp on claude is supported for "
+                    f"{', '.join(sorted(CLAUDE_MCP_TASK_CLASSES))} task classes "
+                    f"(review/search use the read-only sources allowlist; "
+                    f"draft/edit use the write-capable author allowlist, #2134); "
+                    f"got task_class={args.task_class!r}."
                 )
         elif args.agent in HERMES_MCP_AGENTS:
             if args.task_class not in HERMES_MCP_TASK_CLASSES:
@@ -1035,7 +1049,9 @@ def main() -> int:
             )
 
     tool_config = (
-        _build_mcp_tool_config(args.agent, args.mcp) if args.mcp else None
+        _build_mcp_tool_config(args.agent, args.mcp, args.task_class)
+        if args.mcp
+        else None
     )
 
     # Codex always runs in danger mode — read-only starves it of

--- a/tests/dispatch_smart/test_claude_mcp_author.py
+++ b/tests/dispatch_smart/test_claude_mcp_author.py
@@ -1,0 +1,89 @@
+"""Regression tests for #2134 — clean Sonnet + sources-MCP author lane.
+
+Covers the three gaps closed by #2134:
+  1. draft/edit are MCP-enabled task classes for claude and resolve the
+     WRITE-capable author allowlist (Write/Edit/MultiEdit) rather than the
+     read-only review allowlist.
+  2. the curated tool names target the live ``sources`` server
+     (``mcp__sources__*``), not the dead ``mcp__rag__*`` prefix.
+  3. reasoning effort is plumbed to Claude Code's ``--effort`` flag, including
+     via a ``-high``/``-medium``/``-low`` model-slug suffix.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+import dispatch_smart  # noqa: E402
+from agent_runtime.adapters.claude import ClaudeAdapter  # noqa: E402
+
+
+def test_draft_and_edit_are_claude_mcp_task_classes() -> None:
+    assert {"draft", "edit"} <= dispatch_smart.CLAUDE_MCP_TASK_CLASSES
+    assert {"review", "search"} <= dispatch_smart.CLAUDE_MCP_TASK_CLASSES
+    assert dispatch_smart.CLAUDE_MCP_AUTHOR_TASK_CLASSES == frozenset({"draft", "edit"})
+
+
+def test_author_classes_get_write_capable_tools() -> None:
+    _, draft_tools = dispatch_smart._import_dispatch_mcp_constants("draft")
+    _, edit_tools = dispatch_smart._import_dispatch_mcp_constants("edit")
+    for tools in (draft_tools, edit_tools):
+        assert "Write" in tools.split(",")
+        assert "Edit" in tools.split(",")
+        assert "MultiEdit" in tools.split(",")
+        # authors still get the sources verification tools
+        assert "mcp__sources__verify_word" in tools
+
+
+def test_read_classes_stay_read_only() -> None:
+    _, review_tools = dispatch_smart._import_dispatch_mcp_constants("review")
+    tool_set = review_tools.split(",")
+    assert "Write" not in tool_set
+    assert "Edit" not in tool_set
+    assert "MultiEdit" not in tool_set
+    assert "mcp__sources__verify_word" in tool_set
+
+
+def test_tools_target_sources_server_not_dead_rag_prefix() -> None:
+    _, review_tools = dispatch_smart._import_dispatch_mcp_constants("review")
+    _, author_tools = dispatch_smart._import_dispatch_mcp_constants("draft")
+    for tools in (review_tools, author_tools):
+        assert "mcp__rag__" not in tools
+        assert "mcp__sources__" in tools
+
+
+def _model_and_effort(cmd: list[str]) -> tuple[str | None, str | None]:
+    model = cmd[cmd.index("--model") + 1] if "--model" in cmd else None
+    effort = cmd[cmd.index("--effort") + 1] if "--effort" in cmd else None
+    return model, effort
+
+
+def test_effort_suffix_is_stripped_to_effort_flag() -> None:
+    plan = ClaudeAdapter().build_invocation(
+        prompt="x", mode="workspace-write", cwd=Path("."),
+        model="claude-sonnet-5-high", task_id="t", session_id=None,
+        tool_config={},
+    )
+    assert _model_and_effort(plan.cmd) == ("claude-sonnet-5", "high")
+
+
+def test_plain_model_id_is_not_stripped() -> None:
+    plan = ClaudeAdapter().build_invocation(
+        prompt="x", mode="read-only", cwd=Path("."),
+        model="claude-opus-4-8", task_id="t", session_id=None,
+        tool_config={},
+    )
+    model, effort = _model_and_effort(plan.cmd)
+    assert model == "claude-opus-4-8"
+    assert effort is None
+
+
+def test_explicit_effort_in_tool_config_wins() -> None:
+    plan = ClaudeAdapter().build_invocation(
+        prompt="x", mode="read-only", cwd=Path("."),
+        model="claude-sonnet-5", task_id="t", session_id=None,
+        tool_config={"effort": "medium"},
+    )
+    assert _model_and_effort(plan.cmd) == ("claude-sonnet-5", "medium")

--- a/tests/dispatch_smart/test_claude_mcp_author.py
+++ b/tests/dispatch_smart/test_claude_mcp_author.py
@@ -87,3 +87,15 @@ def test_explicit_effort_in_tool_config_wins() -> None:
         tool_config={"effort": "medium"},
     )
     assert _model_and_effort(plan.cmd) == ("claude-sonnet-5", "medium")
+
+
+def test_suffix_is_stripped_even_when_explicit_effort_set() -> None:
+    """Model slug carries a -high suffix AND explicit effort is given: the suffix
+    must still be stripped from --model (it is not a real model id), and the
+    explicit effort wins. Regression for the codex R1 finding on #2227/#2134."""
+    plan = ClaudeAdapter().build_invocation(
+        prompt="x", mode="read-only", cwd=Path("."),
+        model="claude-sonnet-5-high", task_id="t", session_id=None,
+        tool_config={"effort": "medium"},
+    )
+    assert _model_and_effort(plan.cmd) == ("claude-sonnet-5", "medium")


### PR DESCRIPTION
Closes #2134. Wires the clean Sonnet + `sources` MCP authoring lane that the s189 A/B chose as the UK default translation author, closing the 3 confirmed gaps.

## Changes
1. **draft/edit enabled for claude+MCP.** `CLAUDE_MCP_TASK_CLASSES` gains `draft`/`edit`; `_build_mcp_tool_config` is now task-class-aware — authoring classes get the new **write-capable** `CLAUDE_MCP_AUTHOR_TOOLS` (Write/Edit/MultiEdit/Read + sources tools), review/search keep the read-only `CLAUDE_TRANSLATION_TOOLS`. Kept separate so the review lane never gains write.
2. **Stale `mcp__rag__*` → `mcp__sources__*`** (the `rag` server no longer exists, so no tool resolved). Also `search_etymology` → `search_esum` (the real tool on the sources server).
3. **Effort plumbing.** Claude Code's headless CLI accepts `--effort <level>`; the adapter now emits it from `tool_config["effort"]` or a `-high`/`-medium`/`-low` model-slug suffix (e.g. `claude-sonnet-5-high` → `--model claude-sonnet-5 --effort high`). Plain model ids are untouched.

## Verification
- `ruff` clean; `pytest tests/dispatch_smart/` = 27 passed (20 existing + 7 new).
- **Dry-run resolved** `draft --agent claude --model claude-sonnet-5-high --mcp sources`: gate accepts draft, `allowed_tools_count=20` (4 write/read + 16 sources), `--mcp-config .mcp.json` set, `--model claude-sonnet-5 --effort high`.
- `sources` confirmed registered in `.mcp.json`.

## Learner check
n/a — infra/dispatch plumbing, no curriculum content.

Regression test: tests/dispatch_smart/test_claude_mcp_author.py (references #2134; asserts draft/edit resolve write-capable author tools, review stays read-only, no dead mcp__rag__ prefix, and --effort suffix/flag plumbing)