### PR TITLE
refactor(dispatch): retire the gemini default → agy at runtime (#2125 routing)

### DIFF
--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -96,7 +96,12 @@ AGENTS: dict[str, AgentEntry] = {
     },
     "gemini": {
         "adapter": "scripts.agent_runtime.adapters.gemini:GeminiAdapter",
-        "default_model": GEMINI_WRITER_MODEL,
+        # Decoupled from GEMINI_WRITER_MODEL (which is now the agy slug
+        # gemini-3.1-pro-high, #2125): the GeminiAdapter invokes the retired
+        # gemini-cli, so its default must stay a gemini-cli model id, not an agy
+        # display slug. This whole entry is dead residual pending removal (#2125
+        # follow-up) — gemini-cli has no binary — but keep it internally coherent.
+        "default_model": "gemini-3.1-pro-preview",
         "cost_tier": "low",
         "capabilities": frozenset({
             "content_writing",

--- a/scripts/dedupe_audit.py
+++ b/scripts/dedupe_audit.py
@@ -21,7 +21,7 @@ REPO_ROOT = Path(__file__).parent.parent
 CONTENT_ROOT = REPO_ROOT / "src" / "content" / "docs"
 
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
-from dispatch import GEMINI_WRITER_MODEL, dispatch_gemini_with_retry  # noqa: E402
+from dispatch import GEMINI_WRITER_MODEL, dispatch_agy  # noqa: E402
 
 
 def extract_title_and_topics(path: Path) -> tuple[str, list[str]]:
@@ -93,7 +93,7 @@ Output ONLY JSON in this format:
 ]}}
 """
 
-    ok, output = dispatch_gemini_with_retry(prompt, model=GEMINI_WRITER_MODEL, timeout=120)
+    ok, output = dispatch_agy(prompt, model=GEMINI_WRITER_MODEL, timeout=120)
     if not ok:
         return {"error": "dispatch_failed"}
 

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -88,9 +88,11 @@ GH_CHAR_LIMIT = 64000
 # Model defaults
 # ---------------------------------------------------------------------------
 
-# 2026-04-18: Google still exposes Gemini 3 Pro as preview-only, so pin the
-# currently tested writer alias here until a GA replacement is available.
-GEMINI_WRITER_MODEL = "gemini-3.1-pro-preview"
+# The default pipeline writer/reviewer model. gemini-cli is retired (#2125); the
+# Google lane is now agy (Antigravity), whose display slug is gemini-3.1-pro-high.
+# Callers that dispatch this model route it via dispatch_agy (the `agy`
+# subcommand), NOT the retired gemini-cli path.
+GEMINI_WRITER_MODEL = "gemini-3.1-pro-high"
 GEMINI_DEFAULT_MODEL = "gemini-3-flash-preview"
 GEMINI_REVIEW_MODEL = "gemini-3.1-pro-preview"  # Pro for reviews — hallucinations on Flash cost real iteration time
 GEMINI_FALLBACK_MODEL = "auto"

--- a/scripts/expand_module.py
+++ b/scripts/expand_module.py
@@ -19,7 +19,7 @@ for candidate in (REPO_ROOT, SCRIPTS_DIR):
 
 import module_sections  # noqa: E402
 import rubric_gaps  # noqa: E402
-from dispatch import dispatch_codex_patch, dispatch_gemini_with_retry  # noqa: E402
+from dispatch import dispatch_agy, dispatch_codex_patch  # noqa: E402
 
 DOCS_ROOT = REPO_ROOT / "src" / "content" / "docs"
 PROVENANCE_PREFIX = "<!-- v4:generated"
@@ -299,7 +299,7 @@ def _dispatch_codex_section(prompt: str) -> tuple[bool, str]:
 
 
 def _dispatch_gemini_section(prompt: str) -> tuple[bool, str]:
-    return dispatch_gemini_with_retry(prompt, timeout=900)
+    return dispatch_agy(prompt, timeout=900)
 
 
 def handler_quiz(doc: module_sections.ModuleDocument, module_key: str) -> HandlerResult:

--- a/scripts/lab_pipeline.py
+++ b/scripts/lab_pipeline.py
@@ -25,9 +25,9 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 from dispatch import (  # noqa: E402
     GEMINI_WRITER_MODEL,
     _is_rate_limited,
+    dispatch_agy,
     dispatch_claude,
     dispatch_codex,
-    dispatch_gemini_with_retry,
 )
 
 CONTENT_ROOT = REPO_ROOT / "src" / "content" / "docs"
@@ -117,8 +117,9 @@ class ModuleResolution:
 
 
 def dispatch_auto(prompt: str, model: str, timeout: int = 900) -> tuple[bool, str]:
+    # gemini-* slugs are agy (Antigravity) display models; gemini-cli retired (#2125).
     if model.startswith("gemini"):
-        return dispatch_gemini_with_retry(prompt, model=model, timeout=timeout)
+        return dispatch_agy(prompt, model=model, timeout=timeout)
     if model.startswith("claude"):
         return dispatch_claude(prompt, model=model, timeout=timeout)
     if model.startswith("codex") or "codex" in model or model.startswith("gpt-"):

--- a/scripts/lab_pipeline.py
+++ b/scripts/lab_pipeline.py
@@ -8,10 +8,8 @@ import fcntl
 import json
 import os
 import re
-import shutil
 import subprocess
 import sys
-import tempfile
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime

--- a/scripts/on-prem/phase2-write-only.py
+++ b/scripts/on-prem/phase2-write-only.py
@@ -51,7 +51,7 @@ REPO_ROOT = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 VENV_PYTHON = str((REPO_ROOT / ".venv" / "bin" / "python").resolve())
 
-from dispatch import GEMINI_WRITER_MODEL, dispatch_gemini_with_retry  # type: ignore  # noqa: E402
+from dispatch import GEMINI_WRITER_MODEL, dispatch_agy  # type: ignore  # noqa: E402
 
 CONTENT_ROOT = REPO_ROOT / "src" / "content" / "docs" / "on-premises"
 LOG_FILE = REPO_ROOT / ".pipeline" / "on-prem-logs" / "phase2-write-only.log"
@@ -348,7 +348,8 @@ def extract_first_json_object(text: str) -> dict | None:
 def dispatch_writer(prompt: str, writer_model: str) -> tuple[bool, str]:
     """Dispatch to whichever writer model is configured. Routes by model name."""
     if writer_model.startswith("gemini"):
-        return dispatch_gemini_with_retry(prompt, model=writer_model, timeout=900)
+        # gemini-* slugs route to the agy Google lane; gemini-cli retired (#2125).
+        return dispatch_agy(prompt, model=writer_model, timeout=900)
     if writer_model.startswith("gpt-") or writer_model == "codex":
         cmd = [
             "codex", "--search", "exec", "--skip-git-repo-check",

--- a/scripts/quality/citations.py
+++ b/scripts/quality/citations.py
@@ -228,8 +228,11 @@ without spawning subprocesses. Production uses :func:`default_verifier`.
 
 
 def default_verifier(prompt: str) -> DispatchResult:
-    """Production verifier — Gemini-flash, short per-URL timeout."""
-    return dispatch("gemini", prompt, timeout=60, model="gemini-3-flash-preview")
+    """Production verifier — agy flash (Google lane), short per-URL timeout.
+
+    gemini-cli is retired (#2125); the flash-tier review model on the agy lane
+    is gemini-3.5-flash-high."""
+    return dispatch("agy", prompt, timeout=60, model="gemini-3.5-flash-high")
 
 
 def verify_citation(

--- a/scripts/quality/dispatchers.py
+++ b/scripts/quality/dispatchers.py
@@ -31,9 +31,12 @@ _REPO_ROOT = primary_checkout_root(Path(__file__).resolve().parents[2])
 _VENV_PYTHON = str(_REPO_ROOT / ".venv" / "bin" / "python")
 _DISPATCH_CLI = str(_REPO_ROOT / "scripts" / "dispatch.py")
 
-Agent = Literal["codex", "claude", "gemini"]
+# "agy" is the Google lane (Antigravity) that replaced the retired gemini-cli
+# (#2125). "gemini" is retained as a still-accepted agent string for the legacy
+# dispatch path / opt-in callers; no default routes to it (see tiebreaker_agent).
+Agent = Literal["codex", "claude", "agy", "gemini"]
 
-VALID_AGENTS: frozenset[str] = frozenset({"codex", "claude", "gemini"})
+VALID_AGENTS: frozenset[str] = frozenset({"codex", "claude", "agy", "gemini"})
 
 # Timeouts by role, not agent. The citation-verify path is per-URL so
 # it gets a short timeout; writer/reviewer dispatches are per-module so
@@ -192,8 +195,12 @@ def writer_for_index(module_index: int) -> tuple[Agent, Agent]:
 def tiebreaker_agent() -> Agent:
     """Agent invoked when Codex↔Claude retry loop hits the cap.
 
-    Gemini is the third party because it's cheap, fast, and outside
-    the writer/reviewer rotation so its verdict is structurally
-    independent.
+    The agy (Antigravity) Google lane is the third party — outside the
+    codex/claude writer/reviewer rotation, so its verdict is structurally
+    independent (replaces the retired gemini-cli, #2125). The tiebreaker is
+    dispatched via ``dispatch(reviewer, ...)`` in stages.py WITHOUT an explicit
+    model, so it resolves to ``dispatch.py``'s ``AGY_DEFAULT_MODEL``
+    (gemini-3.1-pro-high). See #2125 note: to pin the flash review model here
+    the tiebreaker dispatch would need to pass ``model=``.
     """
-    return "gemini"
+    return "agy"

--- a/scripts/quality/queue.py
+++ b/scripts/quality/queue.py
@@ -41,8 +41,11 @@ from .state import (
 # neither resolves, default to tertiary so a human picks instead of silently
 # routing to whichever the order ended up.
 
-PRIMARY_BEGINNER = "gemini-3.1-pro-preview"
-PRIMARY_ADVANCED = "gemini-3.1-pro-preview"
+# Primary writer is now the agy (Antigravity) Google lane, model
+# gemini-3.1-pro-high — gemini-cli is retired (#2125). The model id is an agy
+# display slug, dispatched via the `agy` subcommand in scripts/dispatch.py.
+PRIMARY_BEGINNER = "gemini-3.1-pro-high"
+PRIMARY_ADVANCED = "gemini-3.1-pro-high"
 TERTIARY = "claude-opus-4-8"
 
 # Map writer-model identifiers (returned by route_writer / stored in the
@@ -51,7 +54,7 @@ TERTIARY = "claude-opus-4-8"
 # vocabulary. Adding a writer means adding an entry here AND a
 # corresponding case in scripts/dispatch.py.
 _MODEL_TO_AGENT: dict[str, tuple[str, str]] = {
-    PRIMARY_BEGINNER: ("gemini", PRIMARY_BEGINNER),
+    PRIMARY_BEGINNER: ("agy", PRIMARY_BEGINNER),
     TERTIARY: ("claude", TERTIARY),
 }
 
@@ -123,7 +126,7 @@ def _tertiary_writer() -> str:
     """Resolve the tertiary writer, honouring a runtime degraded fallback.
     """
     fallback = os.environ.get("KUBEDOJO_TERTIARY_FALLBACK", "").lower().strip()
-    if fallback in {"gemini", "gemini-3.1-pro-preview"}:
+    if fallback in {"gemini", "agy", "gemini-3.1-pro-preview", "gemini-3.1-pro-high"}:
         return PRIMARY_BEGINNER
     return TERTIARY
 

--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -151,7 +151,7 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 from checks import structural, ukrainian, gaps
 from dispatch import (
     GEMINI_WRITER_MODEL,
-    dispatch_gemini_with_retry,
+    dispatch_agy,
     dispatch_claude,
     dispatch_codex,
     _is_rate_limited,
@@ -167,9 +167,12 @@ from uk_sync import (
 
 
 def dispatch_auto(prompt: str, model: str, timeout: int = 900) -> tuple[bool, str]:
-    """Route to Gemini, Claude, or Codex based on model name."""
+    """Route to agy (Google lane), Claude, or Codex based on model name.
+
+    ``gemini-*`` model slugs are agy (Antigravity) display models and route to
+    dispatch_agy — gemini-cli is retired (#2125)."""
     if model.startswith("gemini"):
-        return dispatch_gemini_with_retry(prompt, model=model, timeout=timeout)
+        return dispatch_agy(prompt, model=model, timeout=timeout)
     if model.startswith("claude"):
         return dispatch_claude(prompt, model=model, timeout=timeout)
     if model.startswith("codex") or "codex" in model or model.startswith("gpt-"):

--- a/tests/test_expand_module.py
+++ b/tests/test_expand_module.py
@@ -177,7 +177,7 @@ def test_handler_quiz_injection(monkeypatch) -> None:
 
 
 def test_handler_thin_multi_pass_crosses_target(monkeypatch) -> None:
-    monkeypatch.setattr(expand_module, "dispatch_gemini_with_retry", lambda prompt, timeout=900: (True, _big_gemini_addition()))
+    monkeypatch.setattr(expand_module, "dispatch_agy", lambda prompt, timeout=900: (True, _big_gemini_addition()))
     doc = module_sections.parse_module(THIN_FIXTURE)
 
     result = expand_module.handler_thin(doc, THIN_MODULE_KEY, target_loc=600, max_thin_passes=5)
@@ -189,7 +189,7 @@ def test_handler_thin_multi_pass_crosses_target(monkeypatch) -> None:
 
 
 def test_handler_thin_max_passes_cap(monkeypatch) -> None:
-    monkeypatch.setattr(expand_module, "dispatch_gemini_with_retry", lambda prompt, timeout=900: (True, _tiny_gemini_addition()))
+    monkeypatch.setattr(expand_module, "dispatch_agy", lambda prompt, timeout=900: (True, _tiny_gemini_addition()))
     doc = module_sections.parse_module(THIN_FIXTURE)
 
     result = expand_module.handler_thin(doc, THIN_MODULE_KEY, target_loc=600, max_thin_passes=2)
@@ -264,7 +264,7 @@ def test_gap_skip_reasons_do_not_dispatch(monkeypatch, tmp_path: Path) -> None:
         raise AssertionError("dispatch should not run for skipped gaps")
 
     monkeypatch.setattr(expand_module, "dispatch_codex_patch", _fail_dispatch)
-    monkeypatch.setattr(expand_module, "dispatch_gemini_with_retry", _fail_dispatch)
+    monkeypatch.setattr(expand_module, "dispatch_agy", _fail_dispatch)
 
     result = expand_module.expand_module(
         "platform/foo/module-1.1-skip-fixture",
@@ -297,7 +297,7 @@ def test_expand_module_integration_shape_and_file_content(monkeypatch, tmp_path:
         raise AssertionError(prompt)
 
     monkeypatch.setattr(expand_module, "dispatch_codex_patch", _fake_codex)
-    monkeypatch.setattr(expand_module, "dispatch_gemini_with_retry", lambda prompt, timeout=900: (True, _big_gemini_addition()))
+    monkeypatch.setattr(expand_module, "dispatch_agy", lambda prompt, timeout=900: (True, _big_gemini_addition()))
 
     result = expand_module.expand_module(
         THIN_MODULE_KEY,

--- a/tests/test_quality_dispatchers.py
+++ b/tests/test_quality_dispatchers.py
@@ -24,8 +24,9 @@ def test_writer_for_index_returns_codex_writes_claude_reviews_for_every_index() 
         assert dispatchers.writer_for_index(idx) == ("codex", "claude"), idx
 
 
-def test_tiebreaker_is_gemini() -> None:
-    assert dispatchers.tiebreaker_agent() == "gemini"
+def test_tiebreaker_is_agy() -> None:
+    # gemini-cli retired (#2125); the independent third-party lane is now agy.
+    assert dispatchers.tiebreaker_agent() == "agy"
 
 
 def test_dispatch_rejects_unknown_agent() -> None:

--- a/tests/test_quality_queue.py
+++ b/tests/test_quality_queue.py
@@ -40,8 +40,8 @@ def _seed_module(repo: Path, rel: str, *, complexity: str | None = None, with_st
 
 
 def test_model_to_agent_known_models():
-    assert queue.model_to_agent(queue.PRIMARY_BEGINNER) == ("gemini", queue.PRIMARY_BEGINNER)
-    assert queue.model_to_agent(queue.PRIMARY_ADVANCED) == ("gemini", queue.PRIMARY_ADVANCED)
+    assert queue.model_to_agent(queue.PRIMARY_BEGINNER) == ("agy", queue.PRIMARY_BEGINNER)
+    assert queue.model_to_agent(queue.PRIMARY_ADVANCED) == ("agy", queue.PRIMARY_ADVANCED)
     assert queue.model_to_agent(queue.TERTIARY) == ("claude", queue.TERTIARY)
 
 

--- a/tests/test_quality_stages.py
+++ b/tests/test_quality_stages.py
@@ -225,7 +225,7 @@ def test_route_rewrite_when_score_below_threshold(fake_repo, monkeypatch):
     st = state.load_state(slug)
     assert st["stage"] == "WRITE_PENDING"
     assert st["route"]["track"] == "rewrite"
-    assert st["writer"] == "gemini"  # module_index=0 → even → gemini writes
+    assert st["writer"] == "agy"  # queue PRIMARY writer → agy Google lane (#2125)
     assert st["reviewer"] == "claude"
 
 
@@ -277,7 +277,7 @@ def test_write_one_happy_path_creates_worktree_commit(fake_repo, monkeypatch):
     st = state.load_state(slug)
     assert st["stage"] == "WRITE_DONE"
     assert st["write"]["commit_sha"]
-    assert st["write"]["agent"] == "gemini"
+    assert st["write"]["agent"] == "agy"
     # The worktree should exist with the new content.
     wt = worktree.worktree_dir(fake_repo, slug)
     assert wt.exists()
@@ -605,25 +605,25 @@ def test_review_changes_tiebreaker_after_cap(fake_repo, monkeypatch):
     stages.handle_review_changes(slug)
     st = state.load_state(slug)
     assert st["stage"] == "REVIEW_PENDING"
-    assert st["reviewer"] == "gemini"
+    assert st["reviewer"] == "agy"  # tiebreaker is agy now (#2125)
     assert st["retry_count"] == stages.RETRY_CAP  # not bumped past cap
 
 
 def test_review_changes_tiebreaker_also_changes_fails_terminally(fake_repo, monkeypatch):
-    """Tiebreaker (gemini) returning CHANGES must mark FAILED, not loop.
+    """Tiebreaker (agy) returning CHANGES must mark FAILED, not loop.
 
     Regression for the infinite-tiebreaker bug caught while running
     9.4 in the #378 recovery: previously, every call after the
     tiebreaker's CHANGES re-routed back to tiebreaker forever (only
     ``run_module``'s max_cycles eventually bailed, after wasting ~5
-    Gemini calls per module).
+    tiebreaker calls per module).
     """
     slug = _bootstrap(fake_repo)
     st = state.load_state(slug)
     st["stage"] = "REVIEW_CHANGES"
     st["retry_count"] = stages.RETRY_CAP
     st["writer"] = "codex"
-    st["reviewer"] = "gemini"  # tiebreaker already ran
+    st["reviewer"] = "agy"  # tiebreaker already ran (agy, #2125)
     st["review"] = {
         "verdict": "changes_requested",
         "must_fix": ["scaffold complexity is missing", "no inline prompts", "two facts wrong"],


### PR DESCRIPTION
Runtime routing repoint for #2125 (builds on Phase 0, PR #2228 — the general `agy` subcommand). Retires the **gemini default** across every runtime dispatch path (gemini-cli is gone); routes to the agy Google lane.

## Atomic runtime repoint (model-id + routing-to-agy only)
- **dispatch.py**: `GEMINI_WRITER_MODEL` `gemini-3.1-pro-preview` → `gemini-3.1-pro-high` (agy slug — the linchpin; all its consumers now default to the agy writer).
- **quality/queue.py**: `PRIMARY_BEGINNER/ADVANCED` → `gemini-3.1-pro-high`; `_MODEL_TO_AGENT` → `("agy", …)`; degraded-fallback set accepts agy.
- **quality/dispatchers.py**: `tiebreaker_agent()` → `"agy"`; `agy` added to `Agent`/`VALID_AGENTS`.
- **quality/citations.py**: `default_verifier` → `dispatch("agy", model="gemini-3.5-flash-high")`.
- **v1_pipeline / lab_pipeline `dispatch_auto`, dedupe_audit, on-prem/phase2 `dispatch_writer`, expand_module**: `gemini-*` slugs now route to `dispatch_agy` (were the dead `dispatch_gemini_with_retry`).

## ⚠️ Flag (per your Phase-C guardrail)
The tiebreaker is dispatched via `dispatch(reviewer, …)` in `stages.py` **without** `model=`, so the agy tiebreaker resolves to `AGY_DEFAULT_MODEL` (`gemini-3.1-pro-high`, the *pro* model), **not** `gemini-3.5-flash-high`. Acceptable for a high-stakes tiebreaker; pinning the flash model there would require a logic change (pass `model=` at the tiebreaker dispatch) — flagging rather than doing it.

## Not in this PR (remaining #2125 cleanup — issue stays open)
`gemini` stays a valid agent string; the `gemini` subcommand + `adapters/gemini.py` + registry entry + the `ab` subsystem gemini lane + opt-in argparse `choices=[…,"gemini"]` (verify_citations/check_unsourced/dispatch_prose_review/dispatch_research_verdict) remain — no default routes to them. Removal is the follow-up (Phase A/residual).

## Verification
- `ruff` clean on all 9 changed source files (pre-existing F541 debt in v1_pipeline's CLI-help section is untouched; CI doesn't gate ruff).
- **159 tests pass** across quality-stages/dispatchers/queue, dispatch-agy, expand-module, citations, v1-pipeline, pipeline-v4.
- **Dry-run-resolved** the chain: `queue.model_to_agent(PRIMARY_BEGINNER)` → `("agy", "gemini-3.1-pro-high")` → `AgyAdapter` → `"Gemini 3.1 Pro (High)"`; `tiebreaker_agent()` → `agy`.

## Learner check
n/a — infra/dispatch plumbing, no curriculum content.

Regression test: tests/test_quality_stages.py + tests/test_quality_queue.py + tests/test_quality_dispatchers.py (updated to assert the agy writer/tiebreaker/model_to_agent routing; reference #2125)