### PR TITLE
refactor(dispatch): repoint #388-pilot + calibration Wave B off retired gemini → agy (#2230)

### DIFF
--- a/scripts/calibration/models.py
+++ b/scripts/calibration/models.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 Family = Literal["anthropic", "openai", "google", "deepseek", "alibaba", "xai"]
-ProviderCli = Literal["claude-cli", "codex-cli", "agy-cli", "gemini-cli", "hermes"]
+ProviderCli = Literal["claude-cli", "codex-cli", "agy-cli", "hermes"]
 EffortMechanism = Literal[
     "native_flag",
     "cli_config",
@@ -97,21 +97,20 @@ ANCHORS: tuple[CalibrationModel, ...] = (
         "B",
         "claude-sonnet-4-6",
     ),
-    # Wave B uses gemini-cli for gemini-3.1-pro-preview because agy-cli
-    # does not expose pro-preview models.
-    # After 2026-06-18 (gemini-cli cutover to agy), this row may need to
-    # migrate or be retired.
-    # Tracked in #1365.
+    # Wave B google frontier: migrated from the retired gemini-cli to the agy
+    # lane (agy exposes gemini-3.1-pro via the -high suffix, same mechanism as
+    # the Wave A agy row). gemini-cli has no binary after the 2026-06-18 cutover.
+    # Tracked in #1365 / retired in #2125.
     CalibrationModel(
         "google",
-        "gemini-cli",
+        "agy-cli",
         "gemini-3.1-pro",
-        "3.1-pro-preview",
+        "3.1-pro",
         "high",
         "model_name_suffix",
         "high",
         "B",
-        "gemini-3.1-pro-preview",
+        "gemini-3.1-pro-high",
     ),
     CalibrationModel(
         "deepseek",

--- a/scripts/calibration/run_cell.py
+++ b/scripts/calibration/run_cell.py
@@ -100,13 +100,6 @@ def build_dispatch_plan(model: CalibrationModel) -> DispatchPlan:
             mode="danger",
             model=model.canonical_string,
         )
-    if model.provider_cli == "gemini-cli" and model.effort_mechanism == "model_name_suffix":
-        return DispatchPlan(
-            kind="runtime",
-            agent_name="gemini",
-            mode="read-only",
-            model=model.canonical_string,
-        )
     if model.provider_cli == "hermes" and model.effort_mechanism == "prompt_prefix_hint":
         if model.family == "deepseek":
             agent_name = "deepseek"

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -98,7 +98,7 @@ GEMINI_REVIEW_MODEL = "gemini-3.1-pro-preview"  # Pro for reviews — hallucinat
 GEMINI_FALLBACK_MODEL = "auto"
 # Reviews: NO gemini-family fallback. When the review model (gemini-3.1-pro-preview)
 # is rate-limited / capacity-out on every tier, return failure so the upstream
-# caller (e.g. scripts/quality/dispatch_388_pilot.py:dispatch_gemini_review)
+# caller (e.g. scripts/quality/dispatch_388_pilot.py:dispatch_agy_review)
 # can fall through to the cross-family claude-sonnet-4-6 path via
 # dispatch_claude_review.
 #

--- a/scripts/quality/dispatch_388_pilot.py
+++ b/scripts/quality/dispatch_388_pilot.py
@@ -5,7 +5,7 @@ For each module path in --input (default scripts/quality/pilot-2026-05-02.txt):
   1. Worktree at .worktrees/codex-388-pilot-<slug> from origin/main
   2. Codex (gpt-5.5, mode=danger) rewrites per module-rewriter-388.md,
      runs verifier, commits, pushes, opens PR
-  3. Gemini cross-family review on the PR (read-only)
+  3. Cross-family review on the PR (agy — the Google lane — with claude/qwen fallback)
   4. APPROVE       -> squash-merge with --delete-branch
      APPROVE_WITH_NITS -> log + post review; orchestrator triages (C3 fix-up lane)
      NEEDS CHANGES -> log + hold; orchestrator decides (re-dispatch vs inline)
@@ -305,7 +305,7 @@ def orchestrator_open_pr(slug: str, module_path: str, codex_response: str) -> in
     return pr_num
 
 
-def gemini_review_prompt(pr_num: int, module_path: str) -> str:
+def cross_family_review_prompt(pr_num: int, module_path: str) -> str:
     return f"""Adversary cross-family review of PR #{pr_num} on KubeDojo.
 
 This is a #388 Day 2 pilot rewrite of: {module_path}
@@ -342,33 +342,13 @@ Keep the review under 700 words. If any LAB RUNNABILITY check fails, the floor i
 """
 
 
-def dispatch_gemini_review(pr_num: int, module_path: str, slug: str):
-    log({"event": "gemini_review_start", "pr": pr_num, "module": module_path})
-    try:
-        result = invoke(
-            agent_name="gemini",
-            prompt=gemini_review_prompt(pr_num, module_path),
-            mode="workspace-write",  # needs gh shell access
-            cwd=REPO,
-            task_id=f"388-pilot-review-{slug}",
-            entrypoint="dispatch",
-            hard_timeout=900,
-        )
-    except Exception as e:  # noqa: BLE001
-        log({"event": "gemini_error", "pr": pr_num, "error": repr(e)})
-        return None, "ERROR"
-    text = result.response or ""
-    log({"event": "gemini_done", "pr": pr_num, "ok": result.ok, "response_excerpt": text[-2000:]})
-    return text, classify_verdict(text)
-
-
 def dispatch_claude_review(pr_num: int, module_path: str, slug: str):
-    """Fallback when Gemini fails. Headless Claude (sonnet) cross-family review."""
+    """Fallback when the primary reviewer fails. Headless Claude (sonnet) cross-family review."""
     log({"event": "claude_review_start", "pr": pr_num, "module": module_path})
     try:
         result = invoke(
             agent_name="claude",
-            prompt=gemini_review_prompt(pr_num, module_path),  # reuse same prompt
+            prompt=cross_family_review_prompt(pr_num, module_path),  # reuse same prompt
             mode="read-only",
             cwd=REPO,
             model="claude-sonnet-4-6",
@@ -387,24 +367,24 @@ def dispatch_claude_review(pr_num: int, module_path: str, slug: str):
 def dispatch_qwen_review(pr_num: int, module_path: str, slug: str):
     """Cross-family review via Qwen 3.6 (hermes openrouter).
 
-    Qwen is a peer cross-family reviewer alongside gemini-pro and claude-sonnet.
-    Uses the same prompt (gemini_review_prompt). Qwen's strengths: independent
+    Qwen is a peer cross-family reviewer alongside agy and claude-sonnet.
+    Uses the same prompt (cross_family_review_prompt). Qwen's strengths: independent
     family and hermes terminal/file toolsets so it can curl URLs and inspect
     the diff itself.
 
     Selection:
         - Primary: set ``KUBEDOJO_388_PRIMARY_REVIEWER=qwen`` to make this the
           first-pass reviewer in the cascade.
-        - Tertiary: if gemini and claude both return ERROR/UNCLEAR, qwen is
+        - Tertiary: if agy and claude both return ERROR/UNCLEAR, qwen is
           the third-line reviewer.
         - Manual: callable directly from one-off review scripts (mirrors
-          dispatch_gemini_review / dispatch_claude_review shape).
+          dispatch_agy_review / dispatch_claude_review shape).
     """
     log({"event": "qwen_review_start", "pr": pr_num, "module": module_path})
     try:
         result = invoke(
             agent_name="qwen",
-            prompt=gemini_review_prompt(pr_num, module_path),  # reuse same prompt
+            prompt=cross_family_review_prompt(pr_num, module_path),  # reuse same prompt
             mode="workspace-write",  # qwen benefits from terminal+file tools (curl, gh pr diff)
             cwd=REPO,
             task_id=f"388-pilot-review-qwen-{slug}",
@@ -435,7 +415,7 @@ def dispatch_deepseek_review(pr_num: int, module_path: str, slug: str):
     try:
         result = invoke(
             agent_name="deepseek",
-            prompt=gemini_review_prompt(pr_num, module_path),  # reuse same prompt
+            prompt=cross_family_review_prompt(pr_num, module_path),  # reuse same prompt
             mode="workspace-write",  # deepseek benefits from terminal+file access
             cwd=REPO,
             model="deepseek-v4-pro",
@@ -454,14 +434,11 @@ def dispatch_deepseek_review(pr_num: int, module_path: str, slug: str):
 def dispatch_agy_review(pr_num: int, module_path: str, slug: str):
     """Cross-family review via Agy (Antigravity CLI — Google).
 
-    Agy is the gemini-cli replacement for Google One / unpaid tier; rolls out
-    fully on 2026-06-18 per #1350. Run-time:
+    Agy is the Google lane (it replaced the retired gemini-cli per #1350/#2125)
+    for the Google One / unpaid tier. Run-time:
     - mode=danger required (dispatch_smart enforces this for agy)
     - no `model=` arg — agy picks model via its TUI panel (env override:
       KUBEDOJO_AGY_MODEL; adapter default gemini-3.5-flash-high)
-    - rate-limit signature is distinct from gemini-cli (separate counter),
-      so agy can run as a peer reviewer alongside gemini without sharing
-      the OAuth quota.
 
     Failure shapes and how they surface to the cascade:
     - Quota-exhausted: invoke returns ok=False, response="" — this function
@@ -478,7 +455,7 @@ def dispatch_agy_review(pr_num: int, module_path: str, slug: str):
     try:
         result = invoke(
             agent_name="agy",
-            prompt=gemini_review_prompt(pr_num, module_path),  # reuse same prompt
+            prompt=cross_family_review_prompt(pr_num, module_path),  # reuse same prompt
             mode="danger",  # required for agy in headless dispatch
             cwd=REPO,
             task_id=f"388-pilot-review-agy-{slug}",
@@ -494,7 +471,7 @@ def dispatch_agy_review(pr_num: int, module_path: str, slug: str):
 
 
 def classify_verdict(text: str) -> str:
-    """Classify a gemini review into APPROVE / APPROVE_WITH_NITS / NEEDS CHANGES / UNCLEAR.
+    """Classify a reviewer's verdict into APPROVE / APPROVE_WITH_NITS / NEEDS CHANGES / UNCLEAR.
 
     Order matters: must check APPROVE WITH NITS BEFORE APPROVE so the
     longer phrase wins (otherwise nits silently auto-merge — see #388
@@ -514,7 +491,7 @@ def classify_verdict(text: str) -> str:
 def post_review_comment(pr_num: int, body: str) -> None:
     subprocess.run(
         ["gh", "pr", "comment", str(pr_num), "--body",
-         f"## Gemini cross-family review (#388 pilot)\n\n{body}"],
+         f"## Cross-family review (#388 pilot)\n\n{body}"],
         cwd=REPO, check=False,
     )
 
@@ -531,7 +508,7 @@ def build_reviewer_cascade(primary_reviewer: str) -> list[tuple[str, Callable]]:
     if primary_reviewer == "claude":
         return [
             ("claude", dispatch_claude_review),
-            ("gemini", dispatch_gemini_review),
+            ("agy", dispatch_agy_review),
             ("qwen", dispatch_qwen_review),
         ]
     if primary_reviewer == "deepseek":
@@ -541,24 +518,16 @@ def build_reviewer_cascade(primary_reviewer: str) -> list[tuple[str, Callable]]:
             ("qwen", dispatch_qwen_review),
         ]
     if primary_reviewer == "qwen":
-        # qwen → gemini → claude
+        # qwen → agy → claude
         return [
             ("qwen", dispatch_qwen_review),
-            ("gemini", dispatch_gemini_review),
-            ("claude", dispatch_claude_review),
-        ]
-    if primary_reviewer == "agy":
-        # agy → claude → qwen. Gemini is on a SHARED Google OAuth pool with
-        # agy pre-2026-06-18 (separate counter on Google side but auth-flow
-        # collisions can still happen) — fall to claude first.
-        return [
             ("agy", dispatch_agy_review),
             ("claude", dispatch_claude_review),
-            ("qwen", dispatch_qwen_review),
         ]
-    # default: gemini
+    # default (also handles the retired "gemini" value): agy → claude → qwen.
+    # agy is the Google lane (gemini-cli retired, #2125); fall to claude first.
     return [
-        ("gemini", dispatch_gemini_review),
+        ("agy", dispatch_agy_review),
         ("claude", dispatch_claude_review),
         ("qwen", dispatch_qwen_review),
     ]
@@ -685,7 +654,7 @@ def main(argv: list[str] | None = None) -> int:
                 log({"event": "module_skip", "module": module_path, "reason": "pr_creation_failed"})
                 continue
         # Reviewer cascade. Primary defaults to claude; override via
-        # KUBEDOJO_388_PRIMARY_REVIEWER (gemini | claude | qwen | deepseek | agy).
+        # KUBEDOJO_388_PRIMARY_REVIEWER (claude | agy | qwen | deepseek).
         # Cascade order is always primary → claude → qwen/deepseek fallback
         # depending on the configured primary.
         primary = os.environ.get("KUBEDOJO_388_PRIMARY_REVIEWER", "claude").lower()

--- a/scripts/quality/stages.py
+++ b/scripts/quality/stages.py
@@ -187,10 +187,11 @@ def route_one(slug: str) -> None:
       ``ROUTED`` with track=structural.
     * Otherwise → ``ROUTED`` with track=rewrite.
 
-    Writer assignment is queue-driven (per #388 routing rule): Gemini
-    for beginner tracks, Codex for advanced, Claude as tertiary
-    fallback. Reviewer is the universal cross-family default — Claude
-    for any non-Claude writer, Codex when the writer is Claude.
+    Writer assignment is queue-driven (per #388 routing rule): agy (the
+    Google lane that replaced the retired gemini-cli, #2125) for beginner
+    tracks, Codex for advanced, Claude as tertiary fallback. Reviewer is
+    the universal cross-family default — Claude for any non-Claude writer,
+    agy when the writer is Claude.
     """
     # Phase 1 (no lease): read state + density + missing-section list to
     # decide the cleanup-only short-circuit. We skip ``queue.ensure_queued``
@@ -289,7 +290,10 @@ def route_one(slug: str) -> None:
         if claim_result.writer is None:
             return  # blocked, no transition; retry on next sweep
         agent, writer_model = queue.model_to_agent(claim_result.writer)
-        reviewer = "claude" if agent != "claude" else "gemini"
+        # Cross-family reviewer: claude reviews non-claude authors; when the
+        # author IS claude, route to agy (the Google lane that replaced the
+        # retired gemini-cli, #2125) so the review stays cross-family.
+        reviewer = "claude" if agent != "claude" else "agy"
 
         state.transition(
             st, "AUDITED", "ROUTED",

--- a/tests/test_dispatch_388_pilot.py
+++ b/tests/test_dispatch_388_pilot.py
@@ -125,7 +125,7 @@ def test_main_chain_calls_backfill_after_merge_and_continues_on_failure(tmp_path
 
     with patch("scripts.quality.dispatch_388_pilot.make_worktree", return_value=tmp_path), \
          patch("scripts.quality.dispatch_388_pilot.dispatch_codex", return_value=codex_result), \
-         patch("scripts.quality.dispatch_388_pilot.dispatch_gemini_review", return_value=("VERDICT: APPROVE", "APPROVE")), \
+         patch("scripts.quality.dispatch_388_pilot.dispatch_agy_review", return_value=("VERDICT: APPROVE", "APPROVE")), \
          patch("scripts.quality.dispatch_388_pilot.merge_pr", return_value="abc123"), \
          patch("scripts.quality.dispatch_388_pilot.dispatch_backfill", side_effect=[False, True]) as mock_backfill, \
          patch("scripts.quality.dispatch_388_pilot.post_review_comment"), \
@@ -214,13 +214,14 @@ def test_dispatch_backfill_sha_regex_parses_ok_line():
 @pytest.mark.parametrize(
     ("primary", "expected"),
     [
-        ("claude", ["claude", "gemini", "qwen"]),
-        ("qwen", ["qwen", "gemini", "claude"]),
+        ("claude", ["claude", "agy", "qwen"]),
+        ("qwen", ["qwen", "agy", "claude"]),
         ("deepseek", ["deepseek", "claude", "qwen"]),
-        ("gemini", ["gemini", "claude", "qwen"]),
-        # #1350 Phase 1 carryover: agy is a peer-Google adapter post-2026-06-18
-        # and a viable primary reviewer; cascade skips gemini (shared OAuth)
-        # and falls to claude → qwen.
+        # gemini-cli is retired (#2125); a legacy "gemini" primary falls to the
+        # default cascade, which is now the agy (Google) lane → claude → qwen.
+        ("gemini", ["agy", "claude", "qwen"]),
+        # agy is the Google lane (replaced gemini-cli, #2125) and a viable
+        # primary reviewer; cascade falls to claude → qwen.
         ("agy", ["agy", "claude", "qwen"]),
     ],
 )
@@ -246,7 +247,7 @@ def test_dispatch_agy_review_uses_danger_mode(monkeypatch: pytest.MonkeyPatch) -
 
     monkeypatch.setattr(pilot, "invoke", fake_invoke)
     monkeypatch.setattr(pilot, "log", lambda _event: None)
-    monkeypatch.setattr(pilot, "gemini_review_prompt", lambda *_a, **_kw: "test prompt")
+    monkeypatch.setattr(pilot, "cross_family_review_prompt", lambda *_a, **_kw: "test prompt")
 
     text, verdict = pilot.dispatch_agy_review(pr_num=1234, module_path="x.md", slug="agy-test")
 
@@ -295,7 +296,7 @@ def test_dispatch_agy_review_failure_paths(
 
     monkeypatch.setattr(pilot, "invoke", fake_invoke)
     monkeypatch.setattr(pilot, "log", lambda _event: None)
-    monkeypatch.setattr(pilot, "gemini_review_prompt", lambda *_a, **_kw: "test prompt")
+    monkeypatch.setattr(pilot, "cross_family_review_prompt", lambda *_a, **_kw: "test prompt")
 
     text, verdict = pilot.dispatch_agy_review(pr_num=1234, module_path="x.md", slug="agy-fail")
 
@@ -314,7 +315,7 @@ def test_dispatch_agy_review_invoke_exception_returns_error(
 
     monkeypatch.setattr(pilot, "invoke", fake_invoke)
     monkeypatch.setattr(pilot, "log", lambda _event: None)
-    monkeypatch.setattr(pilot, "gemini_review_prompt", lambda *_a, **_kw: "test prompt")
+    monkeypatch.setattr(pilot, "cross_family_review_prompt", lambda *_a, **_kw: "test prompt")
 
     text, verdict = pilot.dispatch_agy_review(pr_num=1234, module_path="x.md", slug="agy-exc")
 

--- a/tests/test_dispatch_388_yaml_queue.py
+++ b/tests/test_dispatch_388_yaml_queue.py
@@ -30,7 +30,7 @@ def test_yaml_queue_dispatch_writes_budget_sidecar_and_defaults_to_5000(tmp_path
 
     codex_result = MagicMock(ok=True, response="Opened PR: https://github.com/org/repo/pull/1")
     with patch.object(pilot, "dispatch_codex", return_value=codex_result) as mock_codex, \
-         patch.object(pilot, "dispatch_gemini_review", return_value=("VERDICT: APPROVE", "APPROVE")), \
+         patch.object(pilot, "dispatch_agy_review", return_value=("VERDICT: APPROVE", "APPROVE")), \
          patch.object(pilot, "merge_pr", return_value="abc123"), \
          patch.object(pilot, "dispatch_backfill", return_value=True), \
          patch.object(pilot, "make_worktree", return_value=tmp_path), \

--- a/tests/test_dispatch_gemini_timeout.py
+++ b/tests/test_dispatch_gemini_timeout.py
@@ -231,7 +231,7 @@ def test_gemini_with_retry_review_no_gemini_fallback_on_exhaust():
     2026-05-16 multi-model calibration sweep (which measured flash at 0/2 lab
     bug-catch on PR #1229 + 0/2 on PR #1230 N=2 replication), reviews never
     fall back to a same-family cheaper-tier model. Instead, this function
-    returns False so the upstream caller (dispatch_388_pilot.dispatch_gemini_review)
+    returns False so the upstream caller (dispatch_388_pilot.dispatch_agy_review)
     can fall through to dispatch_claude_review (cross-family). See
     GEMINI_REVIEW_FALLBACK_MODEL docstring for full rationale."""
     assert dispatch.GEMINI_REVIEW_FALLBACK_MODEL is None, \

--- a/tests/test_quality_stages.py
+++ b/tests/test_quality_stages.py
@@ -229,6 +229,23 @@ def test_route_rewrite_when_score_below_threshold(fake_repo, monkeypatch):
     assert st["reviewer"] == "claude"
 
 
+def test_route_reviewer_is_agy_when_author_is_claude(fake_repo, monkeypatch):
+    """When the queue assigns Claude as the writer, the cross-family reviewer
+    is agy (the Google lane that replaced the retired gemini-cli, #2125) — not
+    the dead gemini agent. Guards stages.route_one's reviewer selection (#2230)."""
+    slug = _bootstrap(fake_repo)
+    stages.audit_one(slug)
+    # Force the queue to hand back a Claude author for this slug.
+    monkeypatch.setattr(
+        stages.queue, "model_to_agent",
+        lambda _writer: ("claude", "claude-opus-4-8"),
+    )
+    stages.route_one(slug)
+    st = state.load_state(slug)
+    assert st["writer"] == "claude"
+    assert st["reviewer"] == "agy"
+
+
 def test_route_skips_rewrite_when_score_high_and_structure_complete(fake_repo, monkeypatch):
     """Score ≥ 4.0 AND all structural sections present → CITATION_CLEANUP_ONLY."""
     slug = _bootstrap(fake_repo)


### PR DESCRIPTION
First safe slice of #2230 (residual gemini-cli cleanup). Repoints the **live callers** that still dispatched to the retired `gemini` runtime agent (routes to `gemini-cli` — no binary since #2125) onto the **agy** Google lane, and fixes the reviewer-default live path.

## Changes
- **`scripts/quality/dispatch_388_pilot.py`** — reviewer cascade default + fallbacks used `agent="gemini"`. Repointed to agy; folded the redundant explicit `agy` primary branch into the default cascade; renamed the shared `gemini_review_prompt` → `cross_family_review_prompt`.
- **`scripts/quality/stages.py`** — `route_one` set the claude-authored reviewer to the dead gemini (`reviewer = … else "gemini"`). Repointed to **agy** (live Google lane, cross-family from claude — same target as the already-agy tiebreaker, #2125). Added `test_route_reviewer_is_agy_when_author_is_claude`; corrected the stale `route_one` docstring.
- **`scripts/calibration/models.py` + `run_cell.py`** — Wave B google-frontier row `provider_cli="gemini-cli"` → `agy-cli` w/ `gemini-3.1-pro-high` (agy exposes 3.1-pro via `-high`, same mechanism as the Wave A agy row; #1365 anticipated this). Removed the unreachable `gemini-cli` dispatch branch + the `"gemini-cli"` `ProviderCli` literal.
- **`scripts/dispatch.py`** — fixed a dangling comment reference left by the rename.
- **tests/** — repointed rename-broken patches (`dispatch_agy_review` / `cross_family_review_prompt`) and updated reviewer-cascade parametrize expectations to the agy cascades.

## Deliberately NOT in this PR
1. **Runtime gemini registry entry + `adapters/gemini.py` + ab-bridge gemini `discuss` lane** — coupled: the ab `discuss` lane resolves gemini via `get_agent_entry("gemini")` (removing the registry entry breaks `test_discuss_gemini_retries_quota_failure_without_api_key`). Removing them changes `ab discuss` 3-agent-deliberation behaviour — co-owned; lands in a coordinated follow-up.
2. **Citation dispatchers** (`citation_residuals` `--agent gemini` default in `CANDIDATE_DISPATCHERS`; `citation_backfill` `dispatch_gemini` branch) — route via the legacy `dispatch.py` gemini subcommand. Repointing means adding agy to that registry + re-defaulting, a distinct subsystem change → #2230's citation-dispatcher slice.

## Review
- **Codex R1: NEEDS CHANGES** → both P1s addressed (rename-broken tests fixed; stages.py reviewer-default repointed + tested; completeness claim narrowed to the accurate scope above). Codex R2 pending.

## Verification
- Lint: `ruff` clean on all changed files.
- Tests: 88 passed across the 4 touched test files (`test_dispatch_388_pilot`, `test_dispatch_388_yaml_queue`, `test_dispatch_gemini_timeout`, `test_quality_stages`); `agent_runtime` (12); calibration selftest `exit=0` fresh root.

Refs #2230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)