### PR TITLE
fix(ci): make UK quality gates skip metadata-only diffs (#2237)

### DIFF
--- a/.github/workflows/uk-quality-checks.yml
+++ b/.github/workflows/uk-quality-checks.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Run Ukrainian Russicism gate
+      - name: Compute changed Ukrainian files (drop metadata-only)
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
@@ -30,25 +30,41 @@ jobs:
           mapfile -t CHANGED_FILES < <(git diff --name-only "origin/${BASE_REF}"...HEAD -- 'src/content/docs/uk/**/*.md')
 
           if [ ${#CHANGED_FILES[@]} -eq 0 ]; then
-            echo "No changed Ukrainian docs files detected; skipping russicism gate."
+            echo "No changed Ukrainian docs files detected."
+            : > "$RUNNER_TEMP/uk_content_files.txt"
             exit 0
           fi
 
-          echo "Checking ${#CHANGED_FILES[@]} changed Ukrainian files"
-          for path in "${CHANGED_FILES[@]}"; do
-            echo "- $path"
-          done
+          echo "Changed Ukrainian files: ${#CHANGED_FILES[@]}"
+          # Drop files whose diff only touches frontmatter metadata (e.g. the
+          # en_commit provenance backfill, #2237). The gates full-scan every file
+          # they receive, so re-scanning a metadata-only touch would surface a
+          # translation's PRE-EXISTING russicisms/structural issues that the PR
+          # never introduced. Both downstream gates read the filtered list.
+          python3 scripts/quality/filter_content_changed.py \
+            --base-ref "origin/${BASE_REF}" "${CHANGED_FILES[@]}" \
+            > "$RUNNER_TEMP/uk_content_files.txt"
 
-          python3 scripts/quality/check_uk_changed.py "${CHANGED_FILES[@]}"
+          CONTENT_COUNT=$(grep -c . "$RUNNER_TEMP/uk_content_files.txt" || true)
+          echo "Content-changed after metadata filter: ${CONTENT_COUNT}"
+          sed 's/^/- /' "$RUNNER_TEMP/uk_content_files.txt"
+
+      - name: Run Ukrainian Russicism gate
+        run: |
+          set -euo pipefail
+          mapfile -t CONTENT_FILES < "$RUNNER_TEMP/uk_content_files.txt"
+          if [ ${#CONTENT_FILES[@]} -eq 0 ]; then
+            echo "No content-changed Ukrainian files; skipping russicism gate."
+            exit 0
+          fi
+          python3 scripts/quality/check_uk_changed.py "${CONTENT_FILES[@]}"
 
       - name: Run calque detector (v2 — structural FAIL, calque advisory)
-        env:
-          BASE_REF: ${{ github.base_ref }}
         run: |
           set -euo pipefail
-          mapfile -t CHANGED_FILES < <(git diff --name-only "origin/${BASE_REF}"...HEAD -- 'src/content/docs/uk/**/*.md')
-          if [ ${#CHANGED_FILES[@]} -eq 0 ]; then
-            echo "No changed UK files; skipping calque detector."
+          mapfile -t CONTENT_FILES < "$RUNNER_TEMP/uk_content_files.txt"
+          if [ ${#CONTENT_FILES[@]} -eq 0 ]; then
+            echo "No content-changed UK files; skipping calque detector."
             exit 0
           fi
-          python3 scripts/checks/uk_calque_v2.py "${CHANGED_FILES[@]}"
+          python3 scripts/checks/uk_calque_v2.py "${CONTENT_FILES[@]}"

--- a/scripts/quality/filter_content_changed.py
+++ b/scripts/quality/filter_content_changed.py
@@ -75,13 +75,19 @@ def added_new_side_lines(base_ref: str, path: Path) -> list[tuple[int, str]] | N
 
     added: list[tuple[int, str]] = []
     new_lineno = 0
+    in_hunk = False
     for line in proc.stdout.splitlines():
         hunk = _HUNK_RE.match(line)
         if hunk:
             new_lineno = int(hunk.group(1))
+            in_hunk = True
             continue
-        if line.startswith("+++") or line.startswith("---"):
-            continue  # file headers, not content
+        if not in_hunk:
+            # Pre-hunk header block (`diff --git`, `index`, `--- a/…`, `+++ b/…`,
+            # `new file mode`, …). Skipping only here avoids mis-reading a body
+            # addition whose content starts with `++`/`--` — inside a hunk it
+            # appears as `+++…`/`---…` but IS content, not a header.
+            continue
         if line.startswith("+"):
             added.append((new_lineno, line[1:]))
             new_lineno += 1
@@ -96,7 +102,10 @@ def is_metadata_only(base_ref: str, path: Path) -> bool:
     if added is None:
         return False  # cannot determine → scan in full
     if not added:
-        return True  # only deletions (or no additions) → nothing new to gate
+        # Only deletions (no added lines). A body deletion can still introduce a
+        # structural FAIL (e.g. making two `##` headings adjacent), so we cannot
+        # prove it safe from the new side alone — fail toward a full scan.
+        return False
 
     try:
         text = path.read_text(encoding="utf-8")

--- a/scripts/quality/filter_content_changed.py
+++ b/scripts/quality/filter_content_changed.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Filter a list of changed Ukrainian markdown files down to those whose diff
+touches real *content* — dropping metadata-only changes (e.g. a provenance
+`en_commit:` frontmatter line) so the CI russicism / calque gates do not
+re-scan an untouched translation and surface its PRE-EXISTING findings.
+
+The UK quality gates (`check_uk_changed.py`, `uk_calque_v2.py`) each scan the
+WHOLE file they are handed, not just the changed lines. A pure-metadata touch
+(the `en_commit` provenance backfill, #2237) therefore triggers a full re-scan
+that fails on russicisms/structural issues the touch did not introduce. This
+filter runs ONCE in the workflow and feeds the reduced list to both gates.
+
+"Metadata-only" is defined conservatively: a file is metadata-only iff EVERY
+line its diff adds/modifies on the new side is (a) within the YAML frontmatter
+block AND (b) contains no Cyrillic. Rule (b) means any edit to translated
+frontmatter prose (`title:`, `description:`) — or any body edit — routes the
+file back to a full scan, so the gate's intent is preserved. Only fully-ASCII
+metadata additions (a git SHA, `sidebar.order`, an ASCII slug) are skipped.
+
+Usage:
+    python3 scripts/quality/filter_content_changed.py --base-ref origin/main \
+        <file1.md> <file2.md> ...
+
+Prints the content-changed subset (one path per line) to stdout. With no
+`--base-ref`, every input path is printed unchanged (fail-safe: scan all).
+
+Pure stdlib.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Any Cyrillic code point (U+0400–U+04FF). An added frontmatter line containing
+# Cyrillic is treated as translated content (e.g. an edited title), NOT skipped.
+CYRILLIC_RE = re.compile("[\u0400-\u04FF]")
+
+# Unified-diff hunk header: capture the new-side start line (and optional count).
+_HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+def frontmatter_end_line(text: str) -> int:
+    """1-based line number of the closing `---` of the YAML frontmatter block.
+
+    Returns 0 when the file has no leading frontmatter (so every line is body).
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return 0
+    for idx in range(1, len(lines)):
+        if lines[idx].strip() == "---":
+            return idx + 1  # 1-based line number of the closing fence
+    return 0
+
+
+def added_new_side_lines(base_ref: str, path: Path) -> list[tuple[int, str]] | None:
+    """Lines added/modified on the NEW side of `git diff base_ref...HEAD -- path`.
+
+    Returns a list of (new_line_number, line_text). Returns None when the diff
+    cannot be computed (git error / not a repo) so the caller can fail safe and
+    scan the file in full.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "diff", "--unified=0", f"{base_ref}...HEAD", "--", str(path)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return None
+
+    added: list[tuple[int, str]] = []
+    new_lineno = 0
+    for line in proc.stdout.splitlines():
+        hunk = _HUNK_RE.match(line)
+        if hunk:
+            new_lineno = int(hunk.group(1))
+            continue
+        if line.startswith("+++") or line.startswith("---"):
+            continue  # file headers, not content
+        if line.startswith("+"):
+            added.append((new_lineno, line[1:]))
+            new_lineno += 1
+        # `-` (deletion) lines and everything else do not advance the new-side
+        # counter; with --unified=0 there are no context lines.
+    return added
+
+
+def is_metadata_only(base_ref: str, path: Path) -> bool:
+    """True iff the file's diff vs base_ref touches only frontmatter metadata."""
+    added = added_new_side_lines(base_ref, path)
+    if added is None:
+        return False  # cannot determine → scan in full
+    if not added:
+        return True  # only deletions (or no additions) → nothing new to gate
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return False  # cannot read head file → scan in full
+
+    fm_end = frontmatter_end_line(text)
+    if fm_end == 0:
+        return False  # no frontmatter → any addition is body content
+
+    for lineno, content in added:
+        if lineno > fm_end:
+            return False  # a body line changed
+        if CYRILLIC_RE.search(content):
+            return False  # translated prose added inside frontmatter
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-ref",
+        default=None,
+        help="Base git ref to diff against (e.g. origin/main). "
+        "When omitted, every input path is emitted unchanged.",
+    )
+    parser.add_argument("paths", nargs="*", help="Changed Ukrainian markdown files")
+    args = parser.parse_args(argv)
+
+    for path_str in args.paths:
+        if args.base_ref and is_metadata_only(args.base_ref, Path(path_str)):
+            continue  # drop metadata-only file from the downstream scan
+        print(path_str)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/quality/test_filter_content_changed.py
+++ b/scripts/quality/test_filter_content_changed.py
@@ -1,5 +1,9 @@
 """Regression tests for scripts/quality/filter_content_changed.py.
 
+Guards the UK-quality-gate collision surfaced by the #2237 en_commit provenance
+backfill: a metadata-only frontmatter touch must not re-scan an untouched
+translation (fixed in PR #2238), while real content changes must still be gated.
+
 Drives a throwaway git repo so the git-diff plumbing is exercised end-to-end.
 """
 from __future__ import annotations

--- a/scripts/quality/test_filter_content_changed.py
+++ b/scripts/quality/test_filter_content_changed.py
@@ -140,6 +140,34 @@ def test_new_file_is_kept(repo, tmp_path, capsys):
     assert capsys.readouterr().out.strip() == str(new)
 
 
+# --- bypass regressions (codex R1 findings) ----------------------------------
+
+
+def test_plus_prefixed_body_line_is_kept(repo, tmp_path):
+    """A body addition whose content starts with `++` shows as `+++…` in the
+    diff and must NOT be mistaken for a file header and skipped (bypass)."""
+    base_sha, f = repo
+    f.write_text(
+        f.read_text(encoding="utf-8") + "\n++ самий ы тест\n", encoding="utf-8"
+    )
+    _commit(tmp_path, "body line starting with ++")
+    added = fc.added_new_side_lines(base_sha, f)
+    assert any("++ самий" in text for _, text in (added or [])), added
+    assert fc.is_metadata_only(base_sha, f) is False
+
+
+def test_pure_deletion_is_kept(repo, tmp_path):
+    """A body-only deletion (no added lines) can create a structural FAIL
+    (e.g. adjacent `##` headings); fail toward scan, not skip."""
+    base_sha, f = repo
+    lines = f.read_text(encoding="utf-8").splitlines(keepends=True)
+    # drop the last body line (a deletion, zero additions)
+    f.write_text("".join(lines[:-1]), encoding="utf-8")
+    _commit(tmp_path, "delete a body line")
+    assert fc.added_new_side_lines(base_sha, f) == []
+    assert fc.is_metadata_only(base_sha, f) is False
+
+
 # --- fail-safe: no base ref → emit everything unchanged ----------------------
 
 

--- a/scripts/quality/test_filter_content_changed.py
+++ b/scripts/quality/test_filter_content_changed.py
@@ -1,0 +1,150 @@
+"""Regression tests for scripts/quality/filter_content_changed.py.
+
+Drives a throwaway git repo so the git-diff plumbing is exercised end-to-end.
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load():
+    p = Path(__file__).resolve().parent / "filter_content_changed.py"
+    spec = importlib.util.spec_from_file_location("filter_content_changed", p)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+fc = _load()
+
+BASE = """---
+title: "Модуль 7.1: Архітектура AKS"
+slug: uk/cloud/aks-deep-dive/module-7.1
+sidebar:
+  order: 2
+---
+**Складність**: [MEDIUM]
+
+Це тіло містить пре-існуючий русизм самий тут, який гейт має ігнорувати
+доки його рядок не змінюється у цьому PR.
+"""
+
+
+def _git(args: list[str], cwd: Path) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True
+    ).stdout
+
+
+@pytest.fixture
+def repo(tmp_path: Path, monkeypatch):
+    """A repo with one committed UK file. Yields (base_sha, file_path)."""
+    _git(["init", "-q", "-b", "main"], tmp_path)
+    _git(["config", "user.email", "t@example.com"], tmp_path)
+    _git(["config", "user.name", "Test"], tmp_path)
+    d = tmp_path / "src" / "content" / "docs" / "uk" / "cloud" / "aks-deep-dive"
+    d.mkdir(parents=True)
+    f = d / "module-7.1.md"
+    f.write_text(BASE, encoding="utf-8")
+    _git(["add", "-A"], tmp_path)
+    _git(["commit", "-qm", "base"], tmp_path)
+    base_sha = _git(["rev-parse", "HEAD"], tmp_path).strip()
+    monkeypatch.chdir(tmp_path)
+    return base_sha, f
+
+
+def _commit(tmp_path: Path, msg: str) -> None:
+    _git(["add", "-A"], tmp_path)
+    _git(["commit", "-qm", msg], tmp_path)
+
+
+# --- pure-function: frontmatter boundary -------------------------------------
+
+
+def test_frontmatter_end_line():
+    # closing `---` is the 6th line of BASE
+    assert fc.frontmatter_end_line(BASE) == 6
+
+
+def test_frontmatter_end_line_no_frontmatter():
+    assert fc.frontmatter_end_line("no frontmatter here\njust body\n") == 0
+
+
+# --- metadata-only additions are dropped -------------------------------------
+
+
+def test_ascii_frontmatter_addition_is_metadata_only(repo, tmp_path):
+    base_sha, f = repo
+    text = f.read_text(encoding="utf-8")
+    # insert an en_commit provenance line just before the closing fence
+    text = text.replace(
+        "  order: 2\n---",
+        "  order: 2\nen_commit: a4a4935b266ce46eefb0682ff97beb7279f2f869\n---",
+    )
+    f.write_text(text, encoding="utf-8")
+    _commit(tmp_path, "backfill en_commit")
+    assert fc.is_metadata_only(base_sha, f) is True
+
+
+def test_main_drops_metadata_only(repo, tmp_path, capsys):
+    base_sha, f = repo
+    text = f.read_text(encoding="utf-8").replace(
+        "  order: 2\n---", "  order: 2\nen_commit: deadbeef\n---"
+    )
+    f.write_text(text, encoding="utf-8")
+    _commit(tmp_path, "backfill")
+    rc = fc.main(["--base-ref", base_sha, str(f)])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == ""  # dropped → nothing to scan
+
+
+# --- real content changes are kept -------------------------------------------
+
+
+def test_body_change_is_kept(repo, tmp_path, capsys):
+    base_sha, f = repo
+    f.write_text(f.read_text(encoding="utf-8") + "\nНовий рядок тіла.\n", encoding="utf-8")
+    _commit(tmp_path, "body edit")
+    assert fc.is_metadata_only(base_sha, f) is False
+    rc = fc.main(["--base-ref", base_sha, str(f)])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == str(f)  # kept
+
+
+def test_cyrillic_frontmatter_edit_is_kept(repo, tmp_path):
+    """Editing translated frontmatter prose (title) must NOT be skipped."""
+    base_sha, f = repo
+    text = f.read_text(encoding="utf-8").replace(
+        'title: "Модуль 7.1: Архітектура AKS"',
+        'title: "Модуль 7.1: Архітектура та мережі AKS"',
+    )
+    f.write_text(text, encoding="utf-8")
+    _commit(tmp_path, "retitle")
+    assert fc.is_metadata_only(base_sha, f) is False
+
+
+def test_new_file_is_kept(repo, tmp_path, capsys):
+    base_sha, _ = repo
+    new = tmp_path / "src" / "content" / "docs" / "uk" / "cloud" / "new.md"
+    new.write_text(BASE, encoding="utf-8")
+    _commit(tmp_path, "new translation")
+    assert fc.is_metadata_only(base_sha, new) is False
+    rc = fc.main(["--base-ref", base_sha, str(new)])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == str(new)
+
+
+# --- fail-safe: no base ref → emit everything unchanged ----------------------
+
+
+def test_no_base_ref_emits_all(repo, capsys):
+    _, f = repo
+    rc = fc.main([str(f)])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == str(f)


### PR DESCRIPTION
## Problem

The UK quality gates (`check_uk_changed.py`, `uk_calque_v2.py`) **full-scan every file they receive**, not just the changed lines. A pure-frontmatter touch — e.g. the `en_commit` provenance backfill (#2237) — therefore re-scans an untouched translation and fails the "Ukrainian Russicism check" on that translation's **pre-existing** russicisms / structural issues, which the PR never introduced. #2237 (204 metadata-only files) is blocked by exactly this.

## Fix

New `scripts/quality/filter_content_changed.py` drops files whose diff touches **only frontmatter metadata**: every added new-side line is inside the YAML block **and** contains no Cyrillic. So an edited translated `title:`/`description:` — or any body edit — still routes to a full scan, preserving the gate's intent; only fully-ASCII metadata additions (a git SHA, `sidebar.order`) are skipped.

The workflow computes the filtered content-file list **once** and feeds **both** gates (russicism + calque), so neither re-scans metadata-only files.

## Verification

- Ran against the **real 204-file #2237 backfill branch**: filter drops all 204 → content-changed = 0 → both gates skip → green. The old behavior fails with exactly the CI findings (`самий`, `ы`).
- **Positive control**: a body edit adding «самий» + `ы` is **kept** by the filter and correctly **fails** the gate.
- Regression test `scripts/quality/test_filter_content_changed.py` — 8 cases (metadata-only dropped; body/title/new-file kept; no-base-ref fail-safe). `ruff` clean; `zizmor --offline --strict-collection` clean.

Required-check job name (`Ukrainian Russicism check`) is unchanged — only a step was renamed.

Unblocks #2237.



Regression test: scripts/quality/test_filter_content_changed.py (10 cases; guards the #2237 gate collision)
