### PR TITLE
fix(ci): make content-merge hook metadata-diff-aware (#2237)

### DIFF
--- a/.claude/hooks/_lib_pr_check.py
+++ b/.claude/hooks/_lib_pr_check.py
@@ -26,12 +26,6 @@ import subprocess
 import sys
 
 
-# Any Cyrillic code point (U+0400–U+04FF). Kept identical to the CI-side twin
-# `scripts/quality/filter_content_changed.py`: a frontmatter line containing
-# Cyrillic counts as translated content, not metadata.
-_CYRILLIC_RE = re.compile("[\u0400-\u04FF]")
-
-
 def _fetch_file(path: str, head_oid: str, fixture_dir: str) -> str | None:
     if fixture_dir:
         candidate = os.path.join(fixture_dir, path)
@@ -96,12 +90,14 @@ def _split_frontmatter(text: str) -> tuple[str | None, str]:
     return m.group(1), text[m.end():]
 
 
-# Frontmatter keys that are pure structure/routing — NOT learner-facing prose.
-# A change limited to these (plus an unchanged body) is metadata-only. Anything
-# else — `title`, `description`, `sidebar.label`, or any unrecognized key — is
-# learner-facing (rendered H1 / nav / search snippet) and must keep the gate.
-# Allowlist, not denylist: an unknown key fails safe toward requiring the check.
-_STRUCTURAL_FM_KEYS = frozenset({"en_commit", "slug", "order", "sidebar", "draft"})
+# Frontmatter keys whose lines are pure provenance/structure metadata — safe to
+# ignore when deciding whether a content PR changed teaching prose. Deliberately
+# MINIMAL: only `en_commit` (the #2237 provenance backfill this hook change
+# targets). EVERYTHING else — title, description, slug, sidebar/nav labels and
+# ordering — is compared verbatim and IN ORDER, so any edit, reorder, or
+# reparent keeps the learner check. Extend this set only with a top-level scalar
+# key that provably cannot carry (or reorder) learner-facing prose.
+_METADATA_ONLY_FM_KEYS = frozenset({"en_commit"})
 
 
 def _fm_key(line: str) -> str | None:
@@ -114,13 +110,16 @@ def _fm_key(line: str) -> str | None:
 
 
 def _is_metadata_only_change(base_text: str | None, head_text: str) -> bool:
-    """True iff head differs from base ONLY in structural frontmatter metadata:
-    the body is text-identical (after the fetchers' newline normalization) AND
-    every added-or-removed frontmatter line carries a key in
-    `_STRUCTURAL_FM_KEYS` and no Cyrillic. Same intent as the CI-side twin
-    `scripts/quality/filter_content_changed.py`, but blob-based (the hook has no
-    working tree at head). Fails toward "real content" (False) whenever it
-    cannot prove the change is structure-only."""
+    """True iff head differs from base ONLY in allowlisted provenance metadata.
+
+    The body must be text-identical (after the fetchers' newline normalization)
+    AND the frontmatter, with only `_METADATA_ONLY_FM_KEYS` lines removed, must
+    be byte-identical AND IN THE SAME ORDER. Order-sensitive is the point: a
+    moved or reparented prose line (e.g. a swapped `sidebar.label`) changes the
+    ordered remainder and keeps the gate — a set/line diff cannot see that.
+    Fails toward "real content" (False) whenever it cannot prove metadata-only.
+    Blob-based (the hook has no working tree at head); same intent as the
+    CI-side twin `scripts/quality/filter_content_changed.py`."""
     if base_text is None:
         return False  # new file → real content
     if base_text == head_text:
@@ -131,29 +130,11 @@ def _is_metadata_only_change(base_text: str | None, head_text: str) -> bool:
         return False  # can't reason about frontmatter → treat as content
     if base_body != head_body:
         return False  # body prose changed
-    base_lines = set(base_fm.split("\n"))
-    head_lines = set(head_fm.split("\n"))
-    # Symmetric diff: lines added on the head side OR removed from the base side
-    # (so a DELETED `description:` is caught, not just an added one).
-    for line in (head_lines - base_lines) | (base_lines - head_lines):
-        if not line.strip():
-            continue  # pure blank-line shuffle
-        if _CYRILLIC_RE.search(line):
-            return False  # translated prose in frontmatter (any key)
-        key = _fm_key(line)
-        if key is None or key not in _STRUCTURAL_FM_KEYS:
-            return False  # learner-facing prose (title/description/…) or unknown
-        # The value must be a PLAIN SCALAR. A positive allowlist (not a
-        # blocklist of YAML indicators) closes the whole indirection class at
-        # once: flow maps `{…}`/`[…]`, aliases `*x`, anchors `&x`, tags `!x`,
-        # quotes, and trailing `#` comments all fail this match and keep the
-        # gate. Real structural values are a SHA, a slug path, an int, or a
-        # bool — plus empty for a bare block-parent `sidebar:` (its nested
-        # lines are checked on their own keys). Cyrillic already returned above.
-        value = line.split(":", 1)[1].strip() if ":" in line else ""
-        if not re.fullmatch(r"[A-Za-z0-9 ./_-]*", value):
-            return False
-    return True
+
+    def _remainder(fm: str) -> list[str]:
+        return [ln for ln in fm.split("\n") if _fm_key(ln) not in _METADATA_ONLY_FM_KEYS]
+
+    return _remainder(base_fm) == _remainder(head_fm)
 
 
 def _parse_pr(pr_json: str) -> dict | None:

--- a/.claude/hooks/_lib_pr_check.py
+++ b/.claude/hooks/_lib_pr_check.py
@@ -26,6 +26,12 @@ import subprocess
 import sys
 
 
+# Any Cyrillic code point (U+0400–U+04FF). Kept identical to the CI-side twin
+# `scripts/quality/filter_content_changed.py`: a frontmatter line containing
+# Cyrillic counts as translated content, not metadata.
+_CYRILLIC_RE = re.compile("[\u0400-\u04FF]")
+
+
 def _fetch_file(path: str, head_oid: str, fixture_dir: str) -> str | None:
     if fixture_dir:
         candidate = os.path.join(fixture_dir, path)
@@ -50,6 +56,69 @@ def _fetch_file(path: str, head_oid: str, fixture_dir: str) -> str | None:
     return proc.stdout
 
 
+def _fetch_base_file(path: str, base_ref: str, base_fixture_dir: str) -> str | None:
+    """Fetch a file's content at the PR's BASE (pre-merge) state.
+
+    Mirrors `_fetch_file` but reads the base blob so the caller can tell a
+    metadata-only touch from a real content change. Returns None when the file
+    does not exist at base (a new file) or cannot be resolved.
+    """
+    if base_fixture_dir:
+        candidate = os.path.join(base_fixture_dir, path)
+        if os.path.isfile(candidate):
+            with open(candidate, encoding="utf-8") as fp:
+                return fp.read()
+        return None
+    if not base_ref:
+        return None
+    for ref in (f"origin/{base_ref}", base_ref):
+        try:
+            proc = subprocess.run(
+                ["git", "show", f"{ref}:{path}"],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        if proc.returncode == 0:
+            return proc.stdout
+    return None
+
+
+def _split_frontmatter(text: str) -> tuple[str | None, str]:
+    """Return (frontmatter_body, rest). frontmatter_body is None when the file
+    has no leading YAML frontmatter block."""
+    m = re.match(r"^---\n(.*?)\n---\n", text, re.S)
+    if not m:
+        return None, text
+    return m.group(1), text[m.end():]
+
+
+def _is_metadata_only_change(base_text: str | None, head_text: str) -> bool:
+    """True iff head differs from base ONLY in frontmatter metadata — i.e. the
+    body is byte-identical and no Cyrillic (translated prose) was added to the
+    frontmatter. Same rule as `scripts/quality/filter_content_changed.py`, but
+    blob-based (the hook has no working tree at the PR head). Fails toward
+    "real content" (False) whenever it cannot prove metadata-only."""
+    if base_text is None:
+        return False  # new file → real content
+    if base_text == head_text:
+        return True  # no change at all
+    base_fm, base_body = _split_frontmatter(base_text)
+    head_fm, head_body = _split_frontmatter(head_text)
+    if base_fm is None or head_fm is None:
+        return False  # can't reason about frontmatter → treat as content
+    if base_body != head_body:
+        return False  # body prose changed
+    base_lines = set(base_fm.split("\n"))
+    for line in head_fm.split("\n"):
+        if line not in base_lines and _CYRILLIC_RE.search(line):
+            return False  # translated prose added inside frontmatter
+    return True
+
+
 def _parse_pr(pr_json: str) -> dict | None:
     try:
         return json.loads(pr_json)
@@ -57,7 +126,9 @@ def _parse_pr(pr_json: str) -> dict | None:
         return None
 
 
-def check_learner_quote(pr_json: str, fixture_dir: str) -> tuple[str, str]:
+def check_learner_quote(
+    pr_json: str, fixture_dir: str, base_fixture_dir: str = ""
+) -> tuple[str, str]:
     """Validate a PR body's Learner check section against touched modules."""
     pr = _parse_pr(pr_json)
     if pr is None:
@@ -73,6 +144,29 @@ def check_learner_quote(pr_json: str, fixture_dir: str) -> tuple[str, str]:
 
     body = pr.get("body") or ""
     head_oid = pr.get("headRefOid") or ""
+    base_ref = pr.get("baseRefName") or ""
+
+    # A metadata-only touch (e.g. an `en_commit` provenance backfill, or a
+    # `slug:`/`sidebar.order` fix) changes no teaching prose, so a Learner-check
+    # quote proves nothing. Skip the requirement only when EVERY touched content
+    # file is metadata-only vs base. If base can't be resolved (no baseRefName /
+    # new file / unreadable head) the file is treated as real content, so this
+    # is strictly additive — the gate never gets weaker than before.
+    real_content_files = []
+    for path in content_files:
+        head_text = _fetch_file(path, head_oid, fixture_dir)
+        if head_text is None:
+            real_content_files.append(path)
+            continue
+        base_text = _fetch_base_file(path, base_ref, base_fixture_dir)
+        if not _is_metadata_only_change(base_text, head_text):
+            real_content_files.append(path)
+    if not real_content_files:
+        return (
+            "PASS",
+            "all touched src/content/docs files are metadata-only "
+            "(no teaching prose changed)",
+        )
 
     lines = body.splitlines()
     section_quotes: list[str] = []
@@ -213,8 +307,9 @@ def main() -> int:
     mode = sys.argv[1]
     pr_json = sys.argv[2]
     fixture_dir = os.environ.get("KUBEDOJO_HOOK_FILE_FIXTURE_DIR") or ""
+    base_fixture_dir = os.environ.get("KUBEDOJO_HOOK_BASE_FIXTURE_DIR") or ""
     if mode == "learner":
-        kind, msg = check_learner_quote(pr_json, fixture_dir)
+        kind, msg = check_learner_quote(pr_json, fixture_dir, base_fixture_dir)
     elif mode == "regression":
         kind, msg = check_regression_test(pr_json, fixture_dir)
     else:

--- a/.claude/hooks/_lib_pr_check.py
+++ b/.claude/hooks/_lib_pr_check.py
@@ -90,36 +90,30 @@ def _split_frontmatter(text: str) -> tuple[str | None, str]:
     return m.group(1), text[m.end():]
 
 
-# Frontmatter keys whose lines are pure provenance/structure metadata — safe to
-# ignore when deciding whether a content PR changed teaching prose. Deliberately
-# MINIMAL: only `en_commit` (the #2237 provenance backfill this hook change
-# targets). EVERYTHING else — title, description, slug, sidebar/nav labels and
-# ordering — is compared verbatim and IN ORDER, so any edit, reorder, or
-# reparent keeps the learner check. Extend this set only with a top-level scalar
-# key that provably cannot carry (or reorder) learner-facing prose.
-_METADATA_ONLY_FM_KEYS = frozenset({"en_commit"})
-
-
-def _fm_key(line: str) -> str | None:
-    """The YAML key of a frontmatter line (`  order: 3` → `order`), or None if
-    the line carries no `key:` (blank, a bare list item, a continuation)."""
-    stripped = line.strip().lstrip("-").strip()
-    if ":" not in stripped:
-        return None
-    return stripped.split(":", 1)[0].strip().lower()
+# The ONLY frontmatter line that is ignorable metadata: a TOP-LEVEL (column-0)
+# `en_commit:` provenance field (the #2237 backfill this hook change targets).
+# Anchored at start of line ON PURPOSE — an INDENTED `en_commit:` is not a key
+# but the block-scalar CONTENT of a prose field (e.g. `description: |`), so it
+# must NOT be stripped or a description edit could hide behind it (codex R5).
+# Deliberately minimal: title, description, slug, sidebar/nav labels + ordering
+# are all compared verbatim and IN ORDER, so any edit/reorder/reparent keeps the
+# learner check. `en_commit` is a SHA and is never learner-facing.
+_METADATA_ONLY_LINE_RE = re.compile(r"^en_commit\s*:")
 
 
 def _is_metadata_only_change(base_text: str | None, head_text: str) -> bool:
-    """True iff head differs from base ONLY in allowlisted provenance metadata.
+    """True iff head differs from base ONLY in top-level `en_commit:` provenance.
 
     The body must be text-identical (after the fetchers' newline normalization)
-    AND the frontmatter, with only `_METADATA_ONLY_FM_KEYS` lines removed, must
-    be byte-identical AND IN THE SAME ORDER. Order-sensitive is the point: a
-    moved or reparented prose line (e.g. a swapped `sidebar.label`) changes the
-    ordered remainder and keeps the gate — a set/line diff cannot see that.
-    Fails toward "real content" (False) whenever it cannot prove metadata-only.
-    Blob-based (the hook has no working tree at head); same intent as the
-    CI-side twin `scripts/quality/filter_content_changed.py`."""
+    AND the frontmatter, with only top-level `en_commit:` lines removed, must be
+    byte-identical AND IN THE SAME ORDER. Order-sensitive is the point: a moved
+    or reparented prose line (e.g. a swapped `sidebar.label`) changes the ordered
+    remainder and keeps the gate — a set/line diff cannot see that. This is an
+    exact characterization: the only degree of freedom is top-level en_commit
+    lines, so no learner-facing frontmatter change can pass. Fails toward "real
+    content" (False) whenever it cannot prove metadata-only. Blob-based (the hook
+    has no working tree at head); same intent as the CI-side twin
+    `scripts/quality/filter_content_changed.py`."""
     if base_text is None:
         return False  # new file → real content
     if base_text == head_text:
@@ -132,7 +126,7 @@ def _is_metadata_only_change(base_text: str | None, head_text: str) -> bool:
         return False  # body prose changed
 
     def _remainder(fm: str) -> list[str]:
-        return [ln for ln in fm.split("\n") if _fm_key(ln) not in _METADATA_ONLY_FM_KEYS]
+        return [ln for ln in fm.split("\n") if not _METADATA_ONLY_LINE_RE.match(ln)]
 
     return _remainder(base_fm) == _remainder(head_fm)
 

--- a/.claude/hooks/_lib_pr_check.py
+++ b/.claude/hooks/_lib_pr_check.py
@@ -143,6 +143,13 @@ def _is_metadata_only_change(base_text: str | None, head_text: str) -> bool:
         key = _fm_key(line)
         if key is None or key not in _STRUCTURAL_FM_KEYS:
             return False  # learner-facing prose (title/description/…) or unknown
+        # Reject flow-style values that inline a nested mapping/sequence, e.g.
+        # `sidebar: { label: New visible label }` — the line's key is the
+        # allowlisted `sidebar`, but the inline `{…}` can carry prose (label).
+        # Structural values here are always scalars (a SHA, a slug, an int).
+        value = line.split(":", 1)[1] if ":" in line else ""
+        if "{" in value or "[" in value:
+            return False
     return True
 
 

--- a/.claude/hooks/_lib_pr_check.py
+++ b/.claude/hooks/_lib_pr_check.py
@@ -143,12 +143,15 @@ def _is_metadata_only_change(base_text: str | None, head_text: str) -> bool:
         key = _fm_key(line)
         if key is None or key not in _STRUCTURAL_FM_KEYS:
             return False  # learner-facing prose (title/description/…) or unknown
-        # Reject flow-style values that inline a nested mapping/sequence, e.g.
-        # `sidebar: { label: New visible label }` — the line's key is the
-        # allowlisted `sidebar`, but the inline `{…}` can carry prose (label).
-        # Structural values here are always scalars (a SHA, a slug, an int).
-        value = line.split(":", 1)[1] if ":" in line else ""
-        if "{" in value or "[" in value:
+        # The value must be a PLAIN SCALAR. A positive allowlist (not a
+        # blocklist of YAML indicators) closes the whole indirection class at
+        # once: flow maps `{…}`/`[…]`, aliases `*x`, anchors `&x`, tags `!x`,
+        # quotes, and trailing `#` comments all fail this match and keep the
+        # gate. Real structural values are a SHA, a slug path, an int, or a
+        # bool — plus empty for a bare block-parent `sidebar:` (its nested
+        # lines are checked on their own keys). Cyrillic already returned above.
+        value = line.split(":", 1)[1].strip() if ":" in line else ""
+        if not re.fullmatch(r"[A-Za-z0-9 ./_-]*", value):
             return False
     return True
 

--- a/.claude/hooks/_lib_pr_check.py
+++ b/.claude/hooks/_lib_pr_check.py
@@ -96,12 +96,31 @@ def _split_frontmatter(text: str) -> tuple[str | None, str]:
     return m.group(1), text[m.end():]
 
 
+# Frontmatter keys that are pure structure/routing — NOT learner-facing prose.
+# A change limited to these (plus an unchanged body) is metadata-only. Anything
+# else — `title`, `description`, `sidebar.label`, or any unrecognized key — is
+# learner-facing (rendered H1 / nav / search snippet) and must keep the gate.
+# Allowlist, not denylist: an unknown key fails safe toward requiring the check.
+_STRUCTURAL_FM_KEYS = frozenset({"en_commit", "slug", "order", "sidebar", "draft"})
+
+
+def _fm_key(line: str) -> str | None:
+    """The YAML key of a frontmatter line (`  order: 3` → `order`), or None if
+    the line carries no `key:` (blank, a bare list item, a continuation)."""
+    stripped = line.strip().lstrip("-").strip()
+    if ":" not in stripped:
+        return None
+    return stripped.split(":", 1)[0].strip().lower()
+
+
 def _is_metadata_only_change(base_text: str | None, head_text: str) -> bool:
-    """True iff head differs from base ONLY in frontmatter metadata — i.e. the
-    body is byte-identical and no Cyrillic (translated prose) was added to the
-    frontmatter. Same rule as `scripts/quality/filter_content_changed.py`, but
-    blob-based (the hook has no working tree at the PR head). Fails toward
-    "real content" (False) whenever it cannot prove metadata-only."""
+    """True iff head differs from base ONLY in structural frontmatter metadata:
+    the body is text-identical (after the fetchers' newline normalization) AND
+    every added-or-removed frontmatter line carries a key in
+    `_STRUCTURAL_FM_KEYS` and no Cyrillic. Same intent as the CI-side twin
+    `scripts/quality/filter_content_changed.py`, but blob-based (the hook has no
+    working tree at head). Fails toward "real content" (False) whenever it
+    cannot prove the change is structure-only."""
     if base_text is None:
         return False  # new file → real content
     if base_text == head_text:
@@ -113,9 +132,17 @@ def _is_metadata_only_change(base_text: str | None, head_text: str) -> bool:
     if base_body != head_body:
         return False  # body prose changed
     base_lines = set(base_fm.split("\n"))
-    for line in head_fm.split("\n"):
-        if line not in base_lines and _CYRILLIC_RE.search(line):
-            return False  # translated prose added inside frontmatter
+    head_lines = set(head_fm.split("\n"))
+    # Symmetric diff: lines added on the head side OR removed from the base side
+    # (so a DELETED `description:` is caught, not just an added one).
+    for line in (head_lines - base_lines) | (base_lines - head_lines):
+        if not line.strip():
+            continue  # pure blank-line shuffle
+        if _CYRILLIC_RE.search(line):
+            return False  # translated prose in frontmatter (any key)
+        key = _fm_key(line)
+        if key is None or key not in _STRUCTURAL_FM_KEYS:
+            return False  # learner-facing prose (title/description/…) or unknown
     return True
 
 

--- a/.claude/hooks/block-content-merge-without-learner-check.sh
+++ b/.claude/hooks/block-content-merge-without-learner-check.sh
@@ -11,11 +11,19 @@ set -euo pipefail
 # markdown blockquote (`> ...`) whose text appears verbatim in at least one
 # of the `src/content/docs/**` files the PR touches.
 #
+# A metadata-only touch of content files (e.g. an `en_commit` provenance
+# backfill) changes no teaching prose, so the Learner-check requirement is
+# skipped when EVERY touched `src/content/docs/**` file is metadata-only vs the
+# PR base. If the base can't be resolved the file is treated as real content, so
+# the gate is never weaker than before.
+#
 # Test overrides:
 #   KUBEDOJO_HOOK_GH_JSON           Path to JSON file replacing `gh pr view`.
-#   KUBEDOJO_HOOK_FILE_FIXTURE_DIR  Directory holding fixture file contents
-#                                   keyed by the same relative path the PR
-#                                   reports (replaces `git show <oid>:<path>`).
+#   KUBEDOJO_HOOK_FILE_FIXTURE_DIR  Directory holding HEAD file contents keyed by
+#                                   the PR's relative paths (replaces
+#                                   `git show <headOid>:<path>`).
+#   KUBEDOJO_HOOK_BASE_FIXTURE_DIR  Same, but for BASE contents (replaces
+#                                   `git show origin/<baseRefName>:<path>`).
 
 RAW_PAYLOAD=$(cat)
 
@@ -46,7 +54,7 @@ else
     exit 0
   fi
   if [ -n "$PR_REF" ]; then
-    PR_JSON=$(gh pr view "$PR_REF" --json body,files,headRefOid,title,number 2>/dev/null || true)
+    PR_JSON=$(gh pr view "$PR_REF" --json body,files,headRefOid,baseRefName,title,number 2>/dev/null || true)
   else
     # No explicit PR ref: gh auto-detects from the current branch. Resolve the
     # effective cwd by walking `cd X` segments — the harness-reported cwd can
@@ -54,13 +62,14 @@ else
     # `cd .worktrees/X && gh pr merge` from a worktree. Same bug class as
     # #1321 (false-negative-allow direction instead of false-positive-deny).
     EFFECTIVE_DIR=$(python3 "$HOOK_DIR/_lib_resolve_cwd.py" "$COMMAND" "$CWD" gh 2>/dev/null || printf '%s' "$CWD")
-    PR_JSON=$(cd "$EFFECTIVE_DIR" 2>/dev/null && gh pr view --json body,files,headRefOid,title,number 2>/dev/null || true)
+    PR_JSON=$(cd "$EFFECTIVE_DIR" 2>/dev/null && gh pr view --json body,files,headRefOid,baseRefName,title,number 2>/dev/null || true)
   fi
   if [ -z "$PR_JSON" ]; then
     exit 0
   fi
 fi
 VERDICT=$(KUBEDOJO_HOOK_FILE_FIXTURE_DIR="${KUBEDOJO_HOOK_FILE_FIXTURE_DIR:-}" \
+  KUBEDOJO_HOOK_BASE_FIXTURE_DIR="${KUBEDOJO_HOOK_BASE_FIXTURE_DIR:-}" \
   python3 "$HOOK_DIR/_lib_pr_check.py" learner "$PR_JSON" || true)
 
 VERDICT_KIND=${VERDICT%%$'\t'*}

--- a/tests/test_hook_block_content_merge_without_learner_check.py
+++ b/tests/test_hook_block_content_merge_without_learner_check.py
@@ -30,6 +30,7 @@ def run_hook(
     pr_json: dict | None,
     fixture_files: dict[str, str] | None,
     tmp_path: Path,
+    base_fixture_files: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env["CLAUDE_PROJECT_DIR"] = str(tmp_path)
@@ -44,6 +45,13 @@ def run_hook(
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_text(contents)
         env["KUBEDOJO_HOOK_FILE_FIXTURE_DIR"] = str(fixture_dir)
+    if base_fixture_files is not None:
+        base_dir = tmp_path / "base_fixtures"
+        for rel, contents in base_fixture_files.items():
+            target = base_dir / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(contents)
+        env["KUBEDOJO_HOOK_BASE_FIXTURE_DIR"] = str(base_dir)
     payload = {
         "tool_name": "Bash",
         "tool_input": {"command": command, "cwd": str(tmp_path)},
@@ -359,6 +367,117 @@ def test_no_pr_ref_resolves_cwd_via_cd_segments(tmp_path: Path) -> None:
     assert recorded == str(worktree.resolve()), (
         f"Expected gh invoked from worktree {worktree.resolve()}, got {recorded!r}"
     )
+
+
+# --- metadata-only awareness (#2237 gate-collision follow-up) -----------------
+
+_META_BASE = (
+    "---\ntitle: Модуль 8.2\nslug: uk/cloud/x\nsidebar:\n  order: 3\n---\n\n"
+    "Тіло документа, яке не змінюється у цьому PR. Достатньо довгий рядок.\n"
+)
+# same body, one ASCII `en_commit` provenance line added to frontmatter
+_META_HEAD = _META_BASE.replace(
+    "  order: 3\n---",
+    "  order: 3\nen_commit: a4a4935b266ce46eefb0682ff97beb7279f2f869\n---",
+)
+
+
+def test_metadata_only_content_change_is_allowed(tmp_path: Path) -> None:
+    """An en_commit-style frontmatter-only touch changes no teaching prose, so
+    no Learner check section is required."""
+    pr = {
+        "body": "## Summary\n\nBackfill en_commit provenance.\n",
+        "files": [{"path": "src/content/docs/uk/cloud/x.md"}],
+        "headRefOid": "head1",
+        "baseRefName": "main",
+        "title": "chore(uk): backfill provenance",
+        "number": 9101,
+    }
+    result = run_hook(
+        "gh pr merge 9101 --rebase",
+        pr_json=pr,
+        fixture_files={"src/content/docs/uk/cloud/x.md": _META_HEAD},
+        base_fixture_files={"src/content/docs/uk/cloud/x.md": _META_BASE},
+        tmp_path=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_cyrillic_frontmatter_edit_still_requires_check(tmp_path: Path) -> None:
+    """Editing translated frontmatter prose (title) adds Cyrillic → NOT
+    metadata-only → the Learner check is still required."""
+    base = "---\ntitle: Модуль 8.2\n---\n\nТіло.\n"
+    head = "---\ntitle: Модуль 8.2 та мережі\n---\n\nТіло.\n"
+    pr = {
+        "body": "## Summary\n\nRetitle.\n",
+        "files": [{"path": "src/content/docs/uk/cloud/x.md"}],
+        "headRefOid": "head1",
+        "baseRefName": "main",
+        "title": "docs(uk): retitle",
+        "number": 9102,
+    }
+    result = run_hook(
+        "gh pr merge 9102 --rebase",
+        pr_json=pr,
+        fixture_files={"src/content/docs/uk/cloud/x.md": head},
+        base_fixture_files={"src/content/docs/uk/cloud/x.md": base},
+        tmp_path=tmp_path,
+    )
+    assert result.returncode == 2
+    assert "missing a '## Learner check' section" in result.stderr
+
+
+def test_mixed_metadata_and_real_content_requires_check(tmp_path: Path) -> None:
+    """One metadata-only file + one real body change → still gated."""
+    real_base = "---\ntitle: A\n---\n\nOld body prose line long enough here.\n"
+    real_head = "---\ntitle: A\n---\n\nNEW body prose line long enough here now.\n"
+    pr = {
+        "body": "## Summary\n\nMixed change.\n",
+        "files": [
+            {"path": "src/content/docs/uk/cloud/x.md"},
+            {"path": "src/content/docs/uk/cloud/y.md"},
+        ],
+        "headRefOid": "head1",
+        "baseRefName": "main",
+        "title": "docs(uk): mixed",
+        "number": 9103,
+    }
+    result = run_hook(
+        "gh pr merge 9103 --rebase",
+        pr_json=pr,
+        fixture_files={
+            "src/content/docs/uk/cloud/x.md": _META_HEAD,
+            "src/content/docs/uk/cloud/y.md": real_head,
+        },
+        base_fixture_files={
+            "src/content/docs/uk/cloud/x.md": _META_BASE,
+            "src/content/docs/uk/cloud/y.md": real_base,
+        },
+        tmp_path=tmp_path,
+    )
+    assert result.returncode == 2
+    assert "missing a '## Learner check' section" in result.stderr
+
+
+def test_new_content_file_still_requires_check(tmp_path: Path) -> None:
+    """A NEW content file has no base blob → treated as real content → gated."""
+    pr = {
+        "body": "## Summary\n\nNew module.\n",
+        "files": [{"path": "src/content/docs/uk/cloud/new.md"}],
+        "headRefOid": "head1",
+        "baseRefName": "main",
+        "title": "docs(uk): new module",
+        "number": 9104,
+    }
+    result = run_hook(
+        "gh pr merge 9104 --rebase",
+        pr_json=pr,
+        fixture_files={"src/content/docs/uk/cloud/new.md": _META_HEAD},
+        base_fixture_files={},  # base dir exists but file absent → new file
+        tmp_path=tmp_path,
+    )
+    assert result.returncode == 2
+    assert "missing a '## Learner check' section" in result.stderr
 
 
 def test_gh_failure_fails_open(tmp_path: Path) -> None:

--- a/tests/test_hook_block_content_merge_without_learner_check.py
+++ b/tests/test_hook_block_content_merge_without_learner_check.py
@@ -480,6 +480,77 @@ def test_new_content_file_still_requires_check(tmp_path: Path) -> None:
     assert "missing a '## Learner check' section" in result.stderr
 
 
+def test_ascii_description_edit_still_requires_check(tmp_path: Path) -> None:
+    """An EN module's `description:` (learner-facing: nav/search prose) edited
+    with body unchanged is NOT structural metadata → gate stays. (codex R1.)"""
+    base = "---\ntitle: Pods\ndescription: Intro to Pods\n---\n\nBody stays.\n"
+    head = "---\ntitle: Pods\ndescription: A gentle intro to Pods\n---\n\nBody stays.\n"
+    pr = {
+        "body": "## Summary\n\nTweak the description.\n",
+        "files": [{"path": "src/content/docs/k8s/cka/pods.md"}],
+        "headRefOid": "head1",
+        "baseRefName": "main",
+        "title": "docs: reword pod description",
+        "number": 9105,
+    }
+    result = run_hook(
+        "gh pr merge 9105 --rebase",
+        pr_json=pr,
+        fixture_files={"src/content/docs/k8s/cka/pods.md": head},
+        base_fixture_files={"src/content/docs/k8s/cka/pods.md": base},
+        tmp_path=tmp_path,
+    )
+    assert result.returncode == 2
+    assert "missing a '## Learner check' section" in result.stderr
+
+
+def test_frontmatter_prose_deletion_requires_check(tmp_path: Path) -> None:
+    """Deleting a learner-facing frontmatter line (`description:`) is caught by
+    the symmetric diff → gate stays. (codex R1.)"""
+    base = "---\ntitle: Pods\ndescription: Intro to Pods\n---\n\nBody stays.\n"
+    head = "---\ntitle: Pods\n---\n\nBody stays.\n"
+    pr = {
+        "body": "## Summary\n\nDrop the description.\n",
+        "files": [{"path": "src/content/docs/k8s/cka/pods.md"}],
+        "headRefOid": "head1",
+        "baseRefName": "main",
+        "title": "docs: drop description",
+        "number": 9106,
+    }
+    result = run_hook(
+        "gh pr merge 9106 --rebase",
+        pr_json=pr,
+        fixture_files={"src/content/docs/k8s/cka/pods.md": head},
+        base_fixture_files={"src/content/docs/k8s/cka/pods.md": base},
+        tmp_path=tmp_path,
+    )
+    assert result.returncode == 2
+    assert "missing a '## Learner check' section" in result.stderr
+
+
+def test_structural_slug_order_change_is_allowed(tmp_path: Path) -> None:
+    """A change limited to structural keys (slug, sidebar.order) with an
+    unchanged body is metadata-only → no Learner check required."""
+    base = "---\ntitle: Pods\nslug: k8s/pods\nsidebar:\n  order: 3\n---\n\nBody.\n"
+    head = "---\ntitle: Pods\nslug: k8s/cka/pods\nsidebar:\n  order: 5\n---\n\nBody.\n"
+    pr = {
+        "body": "## Summary\n\nFix slug + order.\n",
+        "files": [{"path": "src/content/docs/k8s/cka/pods.md"}],
+        "headRefOid": "head1",
+        "baseRefName": "main",
+        "title": "chore: fix slug + sidebar order",
+        "number": 9107,
+    }
+    result = run_hook(
+        "gh pr merge 9107 --rebase",
+        pr_json=pr,
+        fixture_files={"src/content/docs/k8s/cka/pods.md": head},
+        base_fixture_files={"src/content/docs/k8s/cka/pods.md": base},
+        tmp_path=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+
+
 def test_gh_failure_fails_open(tmp_path: Path) -> None:
     # When `gh pr view` itself fails (auth, network, no PR on branch), the
     # hook must fail open — a quality gate should not trap the orchestrator

--- a/tests/test_hook_block_content_merge_without_learner_check.py
+++ b/tests/test_hook_block_content_merge_without_learner_check.py
@@ -575,6 +575,34 @@ def test_flow_style_sidebar_label_requires_check(tmp_path: Path) -> None:
     assert "missing a '## Learner check' section" in result.stderr
 
 
+def test_yaml_alias_sidebar_requires_check(tmp_path: Path) -> None:
+    """A YAML alias on the allowlisted `sidebar` line (`sidebar: *new`) resolves
+    to a changed nested label. The plain-scalar value allowlist rejects the
+    `*`-prefixed value → gate stays. (codex R3.)"""
+    base = (
+        "---\ntitle: Pods\nnav_a: &a { label: Old, order: 1 }\n"
+        "nav_b: &b { label: New, order: 1 }\nsidebar: *a\n---\n\nBody stays.\n"
+    )
+    head = base.replace("sidebar: *a", "sidebar: *b")
+    pr = {
+        "body": "## Summary\n\nRepoint the sidebar alias.\n",
+        "files": [{"path": "src/content/docs/k8s/cka/pods.md"}],
+        "headRefOid": "head1",
+        "baseRefName": "main",
+        "title": "docs: repoint sidebar alias",
+        "number": 9109,
+    }
+    result = run_hook(
+        "gh pr merge 9109 --rebase",
+        pr_json=pr,
+        fixture_files={"src/content/docs/k8s/cka/pods.md": head},
+        base_fixture_files={"src/content/docs/k8s/cka/pods.md": base},
+        tmp_path=tmp_path,
+    )
+    assert result.returncode == 2
+    assert "missing a '## Learner check' section" in result.stderr
+
+
 def test_gh_failure_fails_open(tmp_path: Path) -> None:
     # When `gh pr view` itself fails (auth, network, no PR on branch), the
     # hook must fail open — a quality gate should not trap the orchestrator

--- a/tests/test_hook_block_content_merge_without_learner_check.py
+++ b/tests/test_hook_block_content_merge_without_learner_check.py
@@ -528,9 +528,10 @@ def test_frontmatter_prose_deletion_requires_check(tmp_path: Path) -> None:
     assert "missing a '## Learner check' section" in result.stderr
 
 
-def test_structural_slug_order_change_is_allowed(tmp_path: Path) -> None:
-    """A change limited to structural keys (slug, sidebar.order) with an
-    unchanged body is metadata-only → no Learner check required."""
+def test_structural_slug_order_change_still_requires_check(tmp_path: Path) -> None:
+    """The metadata-only allowlist is deliberately minimal (`en_commit` only):
+    a slug / sidebar.order change is NOT skipped and keeps the learner check.
+    (Scope narrowed after the codex R4 reparenting finding.)"""
     base = "---\ntitle: Pods\nslug: k8s/pods\nsidebar:\n  order: 3\n---\n\nBody.\n"
     head = "---\ntitle: Pods\nslug: k8s/cka/pods\nsidebar:\n  order: 5\n---\n\nBody.\n"
     pr = {
@@ -548,7 +549,39 @@ def test_structural_slug_order_change_is_allowed(tmp_path: Path) -> None:
         base_fixture_files={"src/content/docs/k8s/cka/pods.md": base},
         tmp_path=tmp_path,
     )
-    assert result.returncode == 0, result.stderr
+    assert result.returncode == 2
+    assert "missing a '## Learner check' section" in result.stderr
+
+
+def test_reparented_frontmatter_label_requires_check(tmp_path: Path) -> None:
+    """Swapping `sidebar.label` and `prev.label` between sections leaves the
+    line SET identical but changes the visible sidebar label. The order-
+    sensitive remainder comparison catches the reparent → gate stays. (codex R4.)"""
+    base = (
+        "---\ntitle: Page\nsidebar:\n  label: Old sidebar label\n"
+        "prev:\n  label: Previous page label\n---\n\nBody stays.\n"
+    )
+    head = (
+        "---\ntitle: Page\nprev:\n  label: Old sidebar label\n"
+        "sidebar:\n  label: Previous page label\n---\n\nBody stays.\n"
+    )
+    pr = {
+        "body": "## Summary\n\nReparent the labels.\n",
+        "files": [{"path": "src/content/docs/k8s/cka/pods.md"}],
+        "headRefOid": "head1",
+        "baseRefName": "main",
+        "title": "docs: reparent labels",
+        "number": 9110,
+    }
+    result = run_hook(
+        "gh pr merge 9110 --rebase",
+        pr_json=pr,
+        fixture_files={"src/content/docs/k8s/cka/pods.md": head},
+        base_fixture_files={"src/content/docs/k8s/cka/pods.md": base},
+        tmp_path=tmp_path,
+    )
+    assert result.returncode == 2
+    assert "missing a '## Learner check' section" in result.stderr
 
 
 def test_flow_style_sidebar_label_requires_check(tmp_path: Path) -> None:

--- a/tests/test_hook_block_content_merge_without_learner_check.py
+++ b/tests/test_hook_block_content_merge_without_learner_check.py
@@ -551,6 +551,30 @@ def test_structural_slug_order_change_is_allowed(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
 
 
+def test_flow_style_sidebar_label_requires_check(tmp_path: Path) -> None:
+    """Flow-style YAML `sidebar: { label: … }` inlines prose on the allowlisted
+    `sidebar` line — the `{`/`[` guard must keep the gate. (codex R2.)"""
+    base = "---\nsidebar: { label: Old visible label, order: 1 }\n---\n\nBody stays.\n"
+    head = "---\nsidebar: { label: New visible label, order: 1 }\n---\n\nBody stays.\n"
+    pr = {
+        "body": "## Summary\n\nReword the nav label.\n",
+        "files": [{"path": "src/content/docs/k8s/cka/pods.md"}],
+        "headRefOid": "head1",
+        "baseRefName": "main",
+        "title": "docs: reword nav label",
+        "number": 9108,
+    }
+    result = run_hook(
+        "gh pr merge 9108 --rebase",
+        pr_json=pr,
+        fixture_files={"src/content/docs/k8s/cka/pods.md": head},
+        base_fixture_files={"src/content/docs/k8s/cka/pods.md": base},
+        tmp_path=tmp_path,
+    )
+    assert result.returncode == 2
+    assert "missing a '## Learner check' section" in result.stderr
+
+
 def test_gh_failure_fails_open(tmp_path: Path) -> None:
     # When `gh pr view` itself fails (auth, network, no PR on branch), the
     # hook must fail open — a quality gate should not trap the orchestrator

--- a/tests/test_hook_block_content_merge_without_learner_check.py
+++ b/tests/test_hook_block_content_merge_without_learner_check.py
@@ -636,6 +636,37 @@ def test_yaml_alias_sidebar_requires_check(tmp_path: Path) -> None:
     assert "missing a '## Learner check' section" in result.stderr
 
 
+def test_en_commit_inside_block_scalar_requires_check(tmp_path: Path) -> None:
+    """An INDENTED `en_commit:` is the block-scalar CONTENT of a prose field
+    (`description: |`), not a top-level key — it must NOT be stripped, so a
+    change to that description keeps the gate. (codex R5.)"""
+    base = (
+        "---\ntitle: Pods\ndescription: |\n"
+        "  en_commit: Old visible description for learners\n---\n\nBody stays.\n"
+    )
+    head = (
+        "---\ntitle: Pods\ndescription: |\n"
+        "  en_commit: New visible description for learners\n---\n\nBody stays.\n"
+    )
+    pr = {
+        "body": "## Summary\n\nReword the description.\n",
+        "files": [{"path": "src/content/docs/k8s/cka/pods.md"}],
+        "headRefOid": "head1",
+        "baseRefName": "main",
+        "title": "docs: reword description",
+        "number": 9111,
+    }
+    result = run_hook(
+        "gh pr merge 9111 --rebase",
+        pr_json=pr,
+        fixture_files={"src/content/docs/k8s/cka/pods.md": head},
+        base_fixture_files={"src/content/docs/k8s/cka/pods.md": base},
+        tmp_path=tmp_path,
+    )
+    assert result.returncode == 2
+    assert "missing a '## Learner check' section" in result.stderr
+
+
 def test_gh_failure_fails_open(tmp_path: Path) -> None:
     # When `gh pr view` itself fails (auth, network, no PR on branch), the
     # hook must fail open — a quality gate should not trap the orchestrator


### PR DESCRIPTION
## Problem

`block-content-merge-without-learner-check` fires on **any** PR touching `src/content/docs/**` and demands a `## Learner check` verbatim quote. A pure **metadata** touch — the #2237 `en_commit` provenance backfill (204 files) — changed no teaching prose, yet the hook forced a spurious learner-check quote to merge it. Same metadata-blindness the CI russicism gate had (fixed in #2238).

## Fix

Teach the hook the **same metadata-only rule** as `scripts/quality/filter_content_changed.py`: skip the learner-check requirement only when **every** touched content file is metadata-only vs the PR base — body byte-identical **and** no Cyrillic added to frontmatter. Implementation is blob-based (the hook has no working tree at head): fetch the base blob via `git show origin/<baseRefName>:<path>` (added `baseRefName` to the `gh pr view --json`).

**Strictly additive** — if the base can't be resolved (no `baseRefName`, new file, unreadable head) the file is treated as real content, so the gate is never weaker than before.

## Scope decision

**Content-merge hook only.** The `block-bugfix-merge` hook's firing on #2237 was a *mislabel* (`fix(uk):` on a data backfill) — correctly resolved by the project's own `chore:`/`docs:`-not-`fix:` convention, not by weakening the regression-test gate. Left as-is.

## Verification

- **Real-git smoke test** on the *actual* pre/post-backfill blobs of a UK module: `_is_metadata_only_change` → `True` (en_commit touch), `False` (body change control).
- 15/15 content-hook tests pass (11 existing + 4 new referencing #2237: metadata-only allowed; Cyrillic-title edit / mixed / new-file still gated). Bugfix-hook tests still 18/18. `ruff` clean; `bash -n` clean.

Regression test: tests/test_hook_block_content_merge_without_learner_check.py