### PR TITLE
feat(dispatch): opt-in OpenRouter provider lane for deepseek

### DIFF
--- a/scripts/agent_runtime/adapters/deepseek.py
+++ b/scripts/agent_runtime/adapters/deepseek.py
@@ -6,7 +6,10 @@ peer to codex / claude / gemini for code review, deliberation, and fix lanes.
 Key design points:
 
 - **Transport:** ``hermes`` CLI in oneshot mode (``--oneshot=<prompt>``
-  argv binding). Hermes proxies to DeepSeek via the ``deepseek`` provider.
+  argv binding). Two provider lanes: ``deepseek`` (DEFAULT — first-party
+  API, China-hosted, cheapest, local-only) and ``openrouter`` (opt-in —
+  US-hosted proxy for residency / failover / CI-eligibility). Provider is
+  resolved by ``_resolve_provider`` (tool_config > env > model slug).
 - **Modes:** All three (read-only / workspace-write / danger) supported.
   Mode → hermes toolset mapping is conservative for read-only (no
   terminal/file tools), permissive for workspace-write and danger.
@@ -114,6 +117,41 @@ def translate_mcp_prefix_for_hermes(prompt: str) -> str:
     return prompt.replace("mcp__sources__", "mcp_sources_")
 
 
+def _resolve_provider(tool_config: dict[str, Any], model: str) -> str:
+    """Pick the Hermes provider for a DeepSeek dispatch.
+
+    Two lanes share this adapter:
+
+    1. ``deepseek`` (**default**) — DeepSeek's first-party API
+       (``api.deepseek.com``, China-hosted). Cheapest path; local-only —
+       never dispatched from CI (``feedback_no_china_apis_from_gh_actions``).
+    2. ``openrouter`` — OpenRouter's US-hosted proxy. Opt-in, for residency /
+       failover / CI-eligibility. NOTE: OpenRouter's default DeepSeek pool can
+       still route to DeepSeek's own China API — pin non-China hosts on the
+       OpenRouter side (``provider.only``/``ignore`` + ``data_collection: deny``)
+       or you keep China residency plus an extra hop.
+
+    Precedence (first match wins), mirroring
+    ``dispatch_smart._hermes_provider_for_model``:
+
+    1. explicit ``tool_config["provider"]`` — caller intent.
+    2. ``KUBEDOJO_HERMES_PROVIDER`` env — operator override.
+    3. model-slug inference — an OpenRouter-style slug (``openrouter/…`` or any
+       ``vendor/model`` form such as ``deepseek/deepseek-v3.2``) routes via
+       ``openrouter``; a bare first-party slug (``deepseek-v4-pro``) via
+       ``deepseek``.
+    """
+    explicit = tool_config.get("provider")
+    if explicit:
+        return str(explicit)
+    env_override = os.environ.get("KUBEDOJO_HERMES_PROVIDER")
+    if env_override:
+        return env_override
+    if model.startswith("openrouter/") or "/" in model:
+        return "openrouter"
+    return "deepseek"
+
+
 class DeepSeekAdapter:
     """Adapter for ``hermes -z`` with the deepseek provider."""
 
@@ -146,7 +184,10 @@ class DeepSeekAdapter:
             - ``toolsets: str`` — comma-separated override for ``-t``.
               Wins over the mode-default mapping.
             - ``provider: str`` — override hermes provider. Default
-              ``deepseek``.
+              ``deepseek`` (first-party, China-hosted); pass ``openrouter``
+              (US-hosted proxy) for residency / failover / CI-eligibility.
+              Also selectable via ``KUBEDOJO_HERMES_PROVIDER`` or an
+              OpenRouter model slug — see ``_resolve_provider``.
             - ``effort: str`` — reasoning effort label. Hermes does not
               expose this as a flag today; we forward it via prompt
               prefix when ``"xhigh"`` is requested. Tracking issue: see
@@ -182,10 +223,14 @@ class DeepSeekAdapter:
             final_prompt = translate_mcp_prefix_for_hermes(final_prompt)
 
         # Model
-        cmd.extend(["-m", model or self.default_model])
+        effective_model = model or self.default_model
+        cmd.extend(["-m", effective_model])
 
-        # Provider — deepseek is the canonical KubeDojo path (Hermes API key).
-        provider = tc.get("provider", "deepseek")
+        # Provider — first-party ``deepseek`` (China-hosted) is the default;
+        # opt into OpenRouter's US-hosted proxy via tool_config, the
+        # KUBEDOJO_HERMES_PROVIDER env, or an OpenRouter model slug. See
+        # ``_resolve_provider``.
+        provider = _resolve_provider(tc, effective_model)
         cmd.extend(["--provider", provider])
 
         # Toolset selection — caller override wins, else mode default.

--- a/tests/test_deepseek_adapter.py
+++ b/tests/test_deepseek_adapter.py
@@ -87,6 +87,61 @@ def test_model_override(monkeypatch) -> None:
     assert plan.cmd[plan.cmd.index("-m") + 1] == "deepseek-v4-flash"
 
 
+def _provider_of(plan) -> str:
+    return plan.cmd[plan.cmd.index("--provider") + 1]
+
+
+def _build(monkeypatch, *, model=None, tool_config=None):
+    monkeypatch.setattr("agent_runtime.adapters.deepseek.shutil.which", lambda _: "hermes")
+    return DeepSeekAdapter().build_invocation(
+        prompt="p",
+        mode="read-only",
+        cwd=Path("/tmp"),
+        model=model,
+        task_id=None,
+        session_id=None,
+        tool_config=tool_config,
+    )
+
+
+def test_provider_default_is_first_party_deepseek(monkeypatch) -> None:
+    """No override + bare first-party slug → China-hosted ``deepseek`` provider."""
+    monkeypatch.delenv("KUBEDOJO_HERMES_PROVIDER", raising=False)
+    plan = _build(monkeypatch)
+    assert _provider_of(plan) == "deepseek"
+    assert plan.cmd[plan.cmd.index("-m") + 1] == "deepseek-v4-pro"
+
+
+def test_provider_openrouter_inferred_from_slug(monkeypatch) -> None:
+    """An OpenRouter-style ``vendor/model`` slug routes via ``openrouter``."""
+    monkeypatch.delenv("KUBEDOJO_HERMES_PROVIDER", raising=False)
+    plan = _build(monkeypatch, model="deepseek/deepseek-v3.2-exp")
+    assert _provider_of(plan) == "openrouter"
+    # The slug is forwarded verbatim to hermes -m.
+    assert plan.cmd[plan.cmd.index("-m") + 1] == "deepseek/deepseek-v3.2-exp"
+
+
+def test_provider_explicit_tool_config_wins(monkeypatch) -> None:
+    """Explicit tool_config provider is honored even with a first-party slug."""
+    monkeypatch.delenv("KUBEDOJO_HERMES_PROVIDER", raising=False)
+    plan = _build(monkeypatch, tool_config={"provider": "openrouter"})
+    assert _provider_of(plan) == "openrouter"
+
+
+def test_provider_env_override(monkeypatch) -> None:
+    """KUBEDOJO_HERMES_PROVIDER selects the provider for a default dispatch."""
+    monkeypatch.setenv("KUBEDOJO_HERMES_PROVIDER", "openrouter")
+    plan = _build(monkeypatch)
+    assert _provider_of(plan) == "openrouter"
+
+
+def test_provider_explicit_beats_env(monkeypatch) -> None:
+    """Explicit tool_config provider takes precedence over the env override."""
+    monkeypatch.setenv("KUBEDOJO_HERMES_PROVIDER", "openrouter")
+    plan = _build(monkeypatch, tool_config={"provider": "deepseek"})
+    assert _provider_of(plan) == "deepseek"
+
+
 def test_parse_response_strips_hermes_banner() -> None:
     adapter = DeepSeekAdapter()
     result = adapter.parse_response(

--- a/tests/test_dispatch_smart.py
+++ b/tests/test_dispatch_smart.py
@@ -193,3 +193,38 @@ def test_dispatch_smart_codex_review_no_worktree_required() -> None:
     assert "worktree=(none — danger)" in result.stdout
     merged_output = (result.stdout or "") + (result.stderr or "")
     assert "requires --worktree" not in merged_output
+
+
+def test_ci_guard_blocks_glm_but_allows_openrouter_deepseek(monkeypatch) -> None:
+    """The China-provider CI guard refuses GLM/z.ai but allows deepseek.
+
+    OpenRouter is a US-hosted proxy, so an OpenRouter-routed deepseek slug is
+    intentionally NOT China-blocked. The first-party ``deepseek`` slug is also
+    absent from the marker list (it is governed by the broader no-LLM-in-CI
+    policy, not this marker guard). Regression guard for #2240.
+    """
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    import pytest
+    from dispatch_smart import guard_no_china_provider_in_ci
+
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+
+    # GLM / z.ai local-only lane must be refused in CI.
+    with pytest.raises(SystemExit):
+        guard_no_china_provider_in_ci("opencode", "zai-coding-plan/glm-5.2")
+
+    # OpenRouter-routed deepseek is US-hosted → must NOT be refused.
+    guard_no_china_provider_in_ci("deepseek", "deepseek/deepseek-v3.2-exp")
+    # First-party deepseek slug also isn't in the marker list.
+    guard_no_china_provider_in_ci("deepseek", "deepseek-v4-pro")
+
+
+def test_ci_guard_noop_outside_ci(monkeypatch) -> None:
+    """Outside CI the guard never fires, even for a China-hosted marker."""
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    from dispatch_smart import guard_no_china_provider_in_ci
+
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    # No raise even for the GLM marker when not running in CI.
+    guard_no_china_provider_in_ci("opencode", "zai-coding-plan/glm-5.2")

--- a/tests/test_dispatch_smart.py
+++ b/tests/test_dispatch_smart.py
@@ -195,13 +195,21 @@ def test_dispatch_smart_codex_review_no_worktree_required() -> None:
     assert "requires --worktree" not in merged_output
 
 
-def test_ci_guard_blocks_glm_but_allows_openrouter_deepseek(monkeypatch) -> None:
-    """The China-provider CI guard refuses GLM/z.ai but allows deepseek.
+def test_ci_marker_guard_matches_glm_markers_only_not_deepseek_slugs(monkeypatch) -> None:
+    """The marker guard fires on the GLM/z.ai markers and on nothing else here.
 
-    OpenRouter is a US-hosted proxy, so an OpenRouter-routed deepseek slug is
-    intentionally NOT China-blocked. The first-party ``deepseek`` slug is also
-    absent from the marker list (it is governed by the broader no-LLM-in-CI
-    policy, not this marker guard). Regression guard for #2240.
+    This asserts ONLY the mechanical behavior of ``_CI_BLOCKED_PROVIDER_MARKERS``
+    (GLM/z.ai/Zhipu direct-endpoint markers). It is NOT a residency claim:
+
+    - The ``deepseek/…`` (OpenRouter-slug) case merely shows the marker guard
+      does not match it. That is NOT an assertion that OpenRouter DeepSeek is
+      residency-safe — OpenRouter can still route to DeepSeek's China API unless
+      providers are pinned (see ``_resolve_provider`` in the deepseek adapter).
+    - The first-party ``deepseek-v4-pro`` case is China-hosted; it is absent from
+      the marker list and is governed by the broader no-LLM-in-CI policy, not by
+      this marker guard.
+
+    Regression guard for #2240.
     """
     sys.path.insert(0, str(SCRIPTS_DIR))
     import pytest
@@ -209,13 +217,13 @@ def test_ci_guard_blocks_glm_but_allows_openrouter_deepseek(monkeypatch) -> None
 
     monkeypatch.setenv("GITHUB_ACTIONS", "true")
 
-    # GLM / z.ai local-only lane must be refused in CI.
+    # GLM / z.ai local-only lane carries a marker → refused in CI.
     with pytest.raises(SystemExit):
         guard_no_china_provider_in_ci("opencode", "zai-coding-plan/glm-5.2")
 
-    # OpenRouter-routed deepseek is US-hosted → must NOT be refused.
+    # Neither deepseek slug carries a China marker → guard does not fire.
+    # (Mechanical only; NOT a residency guarantee — see docstring.)
     guard_no_china_provider_in_ci("deepseek", "deepseek/deepseek-v3.2-exp")
-    # First-party deepseek slug also isn't in the marker list.
     guard_no_china_provider_in_ci("deepseek", "deepseek-v4-pro")
 
 


### PR DESCRIPTION
## What

Adds an **opt-in** OpenRouter provider lane to `DeepSeekAdapter`, alongside the existing **default** first-party `deepseek` (China-hosted) path. Enables routing DeepSeek models through OpenRouter's **US-hosted proxy** for data-residency / failover / CI-eligibility. **Default behavior is unchanged.**

## Why

`--agent deepseek` currently hits DeepSeek's first-party API (`api.deepseek.com`, China-hosted) — cheapest, but local-only. OpenRouter (US proxy) is already wired in our Hermes stack for `qwen`; this makes the same escape hatch available for deepseek. The dispatch code already anticipated this (`dispatch_smart.py:311-312`: openrouter-routed deepseek ids are intentionally not China-blocked). Refs #2240.

## How

`_resolve_provider(tool_config, model)` — precedence (mirrors `dispatch_smart._hermes_provider_for_model`):
1. explicit `tool_config["provider"]`
2. `KUBEDOJO_HERMES_PROVIDER` env
3. model-slug inference — `openrouter/…` or any `vendor/model` slug (e.g. `deepseek/deepseek-v3.2-exp`) → `openrouter`; bare `deepseek-v4-pro` → `deepseek`.

## Residency caveat (documented in code)
OpenRouter's default DeepSeek pool can still route to DeepSeek's own China API. Real residency requires pinning non-China providers on the OpenRouter side (`provider.only`/`ignore` + `data_collection: deny`) — the hop alone does not change residency.

## Tests
- 5 provider-selection cases: default first-party / slug-inference / explicit tool_config / env override / explicit-beats-env.
- 2 CI-guard regressions: openrouter deepseek slug (US-hosted) is **not** refused in CI; GLM/z.ai still refused; guard is a no-op outside CI.
- `ruff` clean; 30/30 affected tests pass (`PYTHONPATH=scripts pytest`).

## Scope
Pure Python adapter + tests. No content/astro changes → astro build unaffected. Default dispatch path byte-identical.

Refs #2240