### PR TITLE
feat(agents): route dispatches on CodexBar live quota when running

### DIFF
--- a/.claude/skills/curriculum-orchestrator/SKILL.md
+++ b/.claude/skills/curriculum-orchestrator/SKILL.md
@@ -55,6 +55,8 @@ Full ritual: [`scripts/prompts/cold-start.md`](../../../scripts/prompts/cold-sta
 
 ### Before any dispatch
 1. Verify the agent's auth is alive (codex 403 = `codex login` needed; agy panel quota).
+   Before a WAVE: check live caps via `codexbar usage --provider both --no-color` when
+   CodexBar is running — session (5h) window governs; full rules in [[dispatch-router]].
 2. WARN the user before 3+ parallel or 5+ sequential to any single agent in 10 min ([[feedback_warn_before_gemini_quota_burn]]).
 3. Pick the lowest-tier model that can do the job ([[feedback_codex_model_routing]], [[feedback_dispatch_smart_for_sweeps]]).
 4. **Make fix briefs literal-complete.** Opus-4.8-class authors follow instructions literally and do not generalize from one listed item to its siblings. Every fix brief MUST say: *"Find and fix ALL occurrences of this pattern in the file, not just the listed line(s) — issue listings are sampled, not exhaustive. Apply the change to every instance, not just the first one."* ([[feedback_class_a_fix_includes_sibling_grep]]).

--- a/.claude/skills/dispatch-router/SKILL.md
+++ b/.claude/skills/dispatch-router/SKILL.md
@@ -111,8 +111,10 @@ Routing rules on top of the numbers (verified output shape 2026-07-07):
    START a new multi-dispatch wave on that lane.
 4. **agy has TWO pools** — `Gemini Models` vs `Claude and GPT` reset independently.
    Check the pool for the MODEL you're dispatching, not just the first line.
-5. **deepseek and grok are not CodexBar-enabled here** → keep the manual checks for
-   those lanes (deepseek is ≈free anyway; grok via its CLI auth state).
+5. **deepseek and grok report credits/balance, NOT Session/Weekly windows**
+   (`--provider deepseek` → API balance; `--provider grok` → credits) — useful as a
+   spend check, but the window rules 2–3 don't apply; keep the manual auth checks for
+   these lanes (deepseek is ≈free anyway; grok via its CLI auth state).
 6. **Fallback, never a blocker**: if `codexbar` is missing or errors (app not running,
    cookies stale), fall back to the manual pre-flight below and proceed.
 

--- a/.claude/skills/dispatch-router/SKILL.md
+++ b/.claude/skills/dispatch-router/SKILL.md
@@ -83,12 +83,46 @@ T0 author primary is **codex-or-cursor** depending on codex weekly-cap state —
 2. For high-leverage decisions: `scripts/ab discuss --with claude,codex,agy` ([[.claude/rules/decision-card]]).
 3. Consult codex on non-trivial scope decisions ([[feedback_consult_codex_on_decisions]]).
 
+## Live cap state — route on CodexBar when it's up (user directive 2026-07-07)
+
+`codexbar` (Homebrew CLI + menu-bar app, `/opt/homebrew/bin/codexbar`) reports LIVE
+per-lane quota windows. **When it's installed and running, base routing on ITS numbers**
+instead of panel-checking rituals or guesses:
+
+```bash
+codexbar usage --provider both --no-color          # codex + claude in one call
+codexbar usage --provider cursor --no-color        # Total / Auto / API pools
+codexbar usage --provider antigravity --no-color   # agy — TWO pools (see rule 4)
+codexbar usage --provider zai --no-color           # GLM (opencode zai-coding-plan)
+# --format json for scripting; --provider all honors the in-app toggles
+```
+
+Routing rules on top of the numbers (verified output shape 2026-07-07):
+
+1. **When to check**: before a wave (3+ dispatches), before any burst to a single lane,
+   and at the start of a heavy orchestration session. Skip it for a one-off routine
+   dispatch — each call takes seconds (web-dashboard fetch); don't tax every small call.
+2. **Session window beats weekly.** `Session:` (the 5-hour rolling window) with its
+   `Pace: … Projected empty in …` line is what heavy headless bursts actually exhaust
+   (s195). If a lane's session window is projected empty before your batch would finish,
+   route the batch to another family NOW — don't ride it into the throttle.
+3. **Thresholds**: <20% left in the governing window → treat the lane as THROTTLED
+   (route per the throttle section below). 20–40% → finish in-flight work but don't
+   START a new multi-dispatch wave on that lane.
+4. **agy has TWO pools** — `Gemini Models` vs `Claude and GPT` reset independently.
+   Check the pool for the MODEL you're dispatching, not just the first line.
+5. **deepseek and grok are not CodexBar-enabled here** → keep the manual checks for
+   those lanes (deepseek is ≈free anyway; grok via its CLI auth state).
+6. **Fallback, never a blocker**: if `codexbar` is missing or errors (app not running,
+   cookies stale), fall back to the manual pre-flight below and proceed.
+
 ## Pre-flight checklist (before EVERY dispatch)
 
 1. **Is the agent's auth alive?**
    - Codex: `codex exec --help` should not 403. If it does, `codex login`.
    - Agy: open agy panel, verify Claude tier selected.
-2. **Are caps healthy?** Check the panel/dashboard before firing 3+ in parallel.
+2. **Are caps healthy?** `codexbar usage` (section above) when available; else the
+   panel/dashboard — before firing 3+ in parallel.
 3. **Will this burn the cheap-tier first?** If the cheap tier (mini/spark/flash-lite) can do it, use it. Don't reflex-bump to gpt-5.5 ([[feedback_codex_model_routing]]).
 4. **Will this fan out beyond the parallel cap?** Hard cap 3 parallel rewrites ([[feedback_parallel_rewrite_cap_three]]).
 5. **Will this trip the OAuth burst limit?** Mix agents for 3+ parallel reviews ([[feedback_parallel_review_oauth_burst]]).

--- a/agents_extensions/claude/skills/curriculum-orchestrator/SKILL.md
+++ b/agents_extensions/claude/skills/curriculum-orchestrator/SKILL.md
@@ -55,6 +55,8 @@ Full ritual: [`scripts/prompts/cold-start.md`](../../../scripts/prompts/cold-sta
 
 ### Before any dispatch
 1. Verify the agent's auth is alive (codex 403 = `codex login` needed; agy panel quota).
+   Before a WAVE: check live caps via `codexbar usage --provider both --no-color` when
+   CodexBar is running — session (5h) window governs; full rules in [[dispatch-router]].
 2. WARN the user before 3+ parallel or 5+ sequential to any single agent in 10 min ([[feedback_warn_before_gemini_quota_burn]]).
 3. Pick the lowest-tier model that can do the job ([[feedback_codex_model_routing]], [[feedback_dispatch_smart_for_sweeps]]).
 4. **Make fix briefs literal-complete.** Opus-4.8-class authors follow instructions literally and do not generalize from one listed item to its siblings. Every fix brief MUST say: *"Find and fix ALL occurrences of this pattern in the file, not just the listed line(s) — issue listings are sampled, not exhaustive. Apply the change to every instance, not just the first one."* ([[feedback_class_a_fix_includes_sibling_grep]]).

--- a/agents_extensions/claude/skills/dispatch-router/SKILL.md
+++ b/agents_extensions/claude/skills/dispatch-router/SKILL.md
@@ -111,8 +111,10 @@ Routing rules on top of the numbers (verified output shape 2026-07-07):
    START a new multi-dispatch wave on that lane.
 4. **agy has TWO pools** — `Gemini Models` vs `Claude and GPT` reset independently.
    Check the pool for the MODEL you're dispatching, not just the first line.
-5. **deepseek and grok are not CodexBar-enabled here** → keep the manual checks for
-   those lanes (deepseek is ≈free anyway; grok via its CLI auth state).
+5. **deepseek and grok report credits/balance, NOT Session/Weekly windows**
+   (`--provider deepseek` → API balance; `--provider grok` → credits) — useful as a
+   spend check, but the window rules 2–3 don't apply; keep the manual auth checks for
+   these lanes (deepseek is ≈free anyway; grok via its CLI auth state).
 6. **Fallback, never a blocker**: if `codexbar` is missing or errors (app not running,
    cookies stale), fall back to the manual pre-flight below and proceed.
 

--- a/agents_extensions/claude/skills/dispatch-router/SKILL.md
+++ b/agents_extensions/claude/skills/dispatch-router/SKILL.md
@@ -83,12 +83,46 @@ T0 author primary is **codex-or-cursor** depending on codex weekly-cap state —
 2. For high-leverage decisions: `scripts/ab discuss --with claude,codex,agy` ([[.claude/rules/decision-card]]).
 3. Consult codex on non-trivial scope decisions ([[feedback_consult_codex_on_decisions]]).
 
+## Live cap state — route on CodexBar when it's up (user directive 2026-07-07)
+
+`codexbar` (Homebrew CLI + menu-bar app, `/opt/homebrew/bin/codexbar`) reports LIVE
+per-lane quota windows. **When it's installed and running, base routing on ITS numbers**
+instead of panel-checking rituals or guesses:
+
+```bash
+codexbar usage --provider both --no-color          # codex + claude in one call
+codexbar usage --provider cursor --no-color        # Total / Auto / API pools
+codexbar usage --provider antigravity --no-color   # agy — TWO pools (see rule 4)
+codexbar usage --provider zai --no-color           # GLM (opencode zai-coding-plan)
+# --format json for scripting; --provider all honors the in-app toggles
+```
+
+Routing rules on top of the numbers (verified output shape 2026-07-07):
+
+1. **When to check**: before a wave (3+ dispatches), before any burst to a single lane,
+   and at the start of a heavy orchestration session. Skip it for a one-off routine
+   dispatch — each call takes seconds (web-dashboard fetch); don't tax every small call.
+2. **Session window beats weekly.** `Session:` (the 5-hour rolling window) with its
+   `Pace: … Projected empty in …` line is what heavy headless bursts actually exhaust
+   (s195). If a lane's session window is projected empty before your batch would finish,
+   route the batch to another family NOW — don't ride it into the throttle.
+3. **Thresholds**: <20% left in the governing window → treat the lane as THROTTLED
+   (route per the throttle section below). 20–40% → finish in-flight work but don't
+   START a new multi-dispatch wave on that lane.
+4. **agy has TWO pools** — `Gemini Models` vs `Claude and GPT` reset independently.
+   Check the pool for the MODEL you're dispatching, not just the first line.
+5. **deepseek and grok are not CodexBar-enabled here** → keep the manual checks for
+   those lanes (deepseek is ≈free anyway; grok via its CLI auth state).
+6. **Fallback, never a blocker**: if `codexbar` is missing or errors (app not running,
+   cookies stale), fall back to the manual pre-flight below and proceed.
+
 ## Pre-flight checklist (before EVERY dispatch)
 
 1. **Is the agent's auth alive?**
    - Codex: `codex exec --help` should not 403. If it does, `codex login`.
    - Agy: open agy panel, verify Claude tier selected.
-2. **Are caps healthy?** Check the panel/dashboard before firing 3+ in parallel.
+2. **Are caps healthy?** `codexbar usage` (section above) when available; else the
+   panel/dashboard — before firing 3+ in parallel.
 3. **Will this burn the cheap-tier first?** If the cheap tier (mini/spark/flash-lite) can do it, use it. Don't reflex-bump to gpt-5.5 ([[feedback_codex_model_routing]]).
 4. **Will this fan out beyond the parallel cap?** Hard cap 3 parallel rewrites ([[feedback_parallel_rewrite_cap_three]]).
 5. **Will this trip the OAuth burst limit?** Mix agents for 3+ parallel reviews ([[feedback_parallel_review_oauth_burst]]).


### PR DESCRIPTION
## Summary

User directive (2026-07-07): **routing should be based on CodexBar if it is up and running.**

Adds a **"Live cap state — route on CodexBar when it's up"** section to the `dispatch-router` skill, placed above the pre-flight checklist, and rewires pre-flight item 2 to consult it. `curriculum-orchestrator`'s pre-dispatch list gets a one-line pointer (single source of truth stays in dispatch-router).

Grounded by live probe on the target machine (2026-07-07):
- `/opt/homebrew/bin/codexbar` installed, CodexBar.app running.
- **Live lanes**: codex (Session 5h + Weekly + pace + credits), claude (Session 5h + Weekly + pace), cursor (Total/Auto/API pools), antigravity/agy (**two independent pools**: Gemini Models vs Claude and GPT), zai/GLM.
- **Not enabled**: deepseek, grok → skill says keep manual checks for those.

Rules encoded:
1. Check before a wave (3+ dispatches) / single-lane burst — not per routine dispatch.
2. **Session (5h) window governs over weekly** — the s195 lesson (heavy headless bursts exhaust the 5h window first).
3. <20% left = treat lane as throttled; 20–40% = no NEW waves on that lane.
4. agy: check the pool for the model being dispatched.
5. Fallback to manual pre-flight when codexbar is missing/erroring — never a blocker.

## Verification
- Count-asserted exact-string edits; deployed copies regenerated (`deploy.sh --target claude`), `diff -q` clean → satisfies the "Extensions in sync" required check.
- CLI output shapes quoted from real `codexbar usage` runs, not assumed.

Companion (non-git): memory `reference_codexbar_live_quota_routing.md` + MEMORY.md index hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)