### PR TITLE
chore(agents): final conflict sweep — context-monitor hook + curriculum agent/skill off the pre-s196 handoff convention

### DIFF
--- a/.claude/agents/curriculum-orchestrator.md
+++ b/.claude/agents/curriculum-orchestrator.md
@@ -34,7 +34,7 @@ queue ownership). Then orient via `bash scripts/cold-start.sh` and drive the que
 - Module quality review, calque/translation review, and the module queue itself.
 - Author/reviewer dispatch (`scripts/dispatch_smart.py`, `scripts/ab`), PR
   creation + cross-family review + merge.
-- Curriculum session handoffs to `docs/session-state/**` + the `STATUS.md` index.
+- Curriculum session handoffs to `.agent/session-state/**` + the `.agent/STATUS.md` live index (pre-s196 history: `docs/session-state/**`).
 
 ## Out of scope (hand to the infra lane)
 
@@ -58,8 +58,8 @@ queue ownership). Then orient via `bash scripts/cold-start.sh` and drive the que
 - **Orient** via `bash scripts/cold-start.sh` / the briefing API
   (`curl 127.0.0.1:8768/api/briefing/session?compact=1`). The SessionStart hook
   has already run cold-start for you.
-- **At session end**, write the handoff to
-  `docs/session-state/YYYY-MM-DD-<topic>.html` (HTML-first per the artifact
-  policy) and update the `STATUS.md` index — promote the new file to "Latest
-  handoff", refresh `## TODO` / `## Blockers`. See the `session-handoff-writer`
-  skill for the exact protocol.
+- **At session end**, write a lean MD handoff brief to
+  `.agent/session-state/YYYY-MM-DD-session-NN-<topic>.md` and update the
+  `.agent/STATUS.md` live index — promote the new file to "Latest handoff",
+  refresh `## TODO` / `## Blockers`. Never through git/PRs (local agent state,
+  s196). See the `session-handoff-writer` skill for the exact protocol.

--- a/.claude/hooks/context-monitor.sh
+++ b/.claude/hooks/context-monitor.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Hook: PostToolUse — monitors context size and warns Claude before auto-compact
-# triggers, demanding a session handoff to docs/session-state/YYYY-MM-DD-<topic>.html
-# by default, with .md still accepted for brief handoffs (per CLAUDE.md session workflow).
+# triggers, demanding a lean MD session-handoff brief to
+# .agent/session-state/YYYY-MM-DD-session-NN-<topic>.md + a .agent/STATUS.md index
+# update (s196 convention — local agent state, never through git/PRs).
 #
 # Tiers (% of autoCompactWindow):
 #   75% -> heads-up: prepare handoff soon
@@ -54,21 +55,21 @@ if [ "$PCT" -ge 95 ]; then
     "EMERGENCY: Context at ${PCT}% of auto-compact window [~${TOKENS}/${WINDOW} tokens]. AUTO-COMPACT IS IMMINENT." \
     "" \
     "STOP all current work THIS TURN. Do not start any new tool calls beyond what is needed to:" \
-    "1. Write or update docs/session-state/YYYY-MM-DD-<topic>.html NOW with: latest commit hash on main, any background tasks still running [PIDs + log paths], what was just completed, what is left to do, and the EXACT next-step commands the new session should run. Prefer .html per the HTML-first artifact policy; existing .md handoffs remain valid for lookup/back-compat. Then update STATUS.md (the index) per CLAUDE.md workflow." \
-    "2. Tell the user to /exit immediately and start a fresh session that reads the new docs/session-state/ handoff first. Auto-compaction is a billed model call that summarizes your entire conversation: much more expensive than a 3KB handoff file the next session reads cheaply.")
+    "1. Write or update the lean MD handoff brief .agent/session-state/YYYY-MM-DD-session-NN-<topic>.md NOW with: latest commit hash on main, any background tasks still running [PIDs + log paths], what was just completed, what is left to do, and the EXACT next-step commands the new session should run. Then update .agent/STATUS.md (the live index) per the session-handoff-writer skill. NO git add/commit/PR — handoffs are local agent state." \
+    "2. Tell the user to /exit immediately and start a fresh session that reads the new .agent/session-state/ brief first. Auto-compaction is a billed model call that summarizes your entire conversation: much more expensive than a ~3KB brief the next session reads cheaply.")
 elif [ "$PCT" -ge 85 ]; then
   MSG=$(printf '%s\n%s\n%s\n%s\n%s\n%s\n' \
     "CRITICAL: Context at ${PCT}% of auto-compact window [~${TOKENS}/${WINDOW} tokens]." \
     "" \
     "Finish your current task ASAP, then:" \
-    "1. Write or update docs/session-state/YYYY-MM-DD-<topic>.html with commit hashes, in-flight tasks, next steps, restart commands. Prefer .html per the HTML-first artifact policy; existing .md handoffs remain valid for lookup/back-compat. Then update STATUS.md (the index) per CLAUDE.md workflow." \
+    "1. Write or update the lean MD handoff brief .agent/session-state/YYYY-MM-DD-session-NN-<topic>.md with commit hashes, in-flight tasks, next steps, restart commands. Then update .agent/STATUS.md (the live index). NO git add/commit/PR — handoffs are local agent state." \
     "2. Tell the user to /exit and start fresh." \
     "Do NOT start any new multi-step work or large operations. Handoff is much cheaper than the auto-compact that is about to trigger.")
 elif [ "$PCT" -ge 75 ]; then
   MSG=$(printf '%s\n%s\n%s\n' \
     "HEADS UP: Context at ${PCT}% of auto-compact window [~${TOKENS}/${WINDOW} tokens]." \
     "" \
-    "Wrap up your current logical unit of work soon. Once it lands, prepare docs/session-state/YYYY-MM-DD-<topic>.html by default, or .md for a brief handoff (and update STATUS.md as the index), so we can hand off to a fresh session before auto-compact triggers. Handoff costs ~3KB; compaction costs a full model summarization call.")
+    "Wrap up your current logical unit of work soon. Once it lands, prepare the lean MD handoff brief .agent/session-state/YYYY-MM-DD-session-NN-<topic>.md (and update .agent/STATUS.md as the live index), so we can hand off to a fresh session before auto-compact triggers. The brief costs ~3KB; compaction costs a full model summarization call.")
 else
   exit 0
 fi

--- a/.claude/hooks/context-monitor.sh
+++ b/.claude/hooks/context-monitor.sh
@@ -69,7 +69,7 @@ elif [ "$PCT" -ge 75 ]; then
   MSG=$(printf '%s\n%s\n%s\n' \
     "HEADS UP: Context at ${PCT}% of auto-compact window [~${TOKENS}/${WINDOW} tokens]." \
     "" \
-    "Wrap up your current logical unit of work soon. Once it lands, prepare the lean MD handoff brief .agent/session-state/YYYY-MM-DD-session-NN-<topic>.md (and update .agent/STATUS.md as the live index), so we can hand off to a fresh session before auto-compact triggers. The brief costs ~3KB; compaction costs a full model summarization call.")
+    "Wrap up your current logical unit of work soon. Once it lands, prepare the lean MD handoff brief .agent/session-state/YYYY-MM-DD-session-NN-<topic>.md (and update .agent/STATUS.md as the live index) — NO git add/commit/PR, handoffs are local agent state — so we can hand off to a fresh session before auto-compact triggers. The brief costs ~3KB; compaction costs a full model summarization call.")
 else
   exit 0
 fi

--- a/.claude/rules/headroom.md
+++ b/.claude/rules/headroom.md
@@ -40,11 +40,12 @@ user explicitly asks — it can rewrite `CLAUDE.md` / `AGENTS.md` / `GEMINI.md`.
 
 ## Handoffs — on-disk files stay SSOT
 
-KubeDojo session handoffs (`docs/session-state/YYYY-MM-DD-<topic>.html`, indexed in
-the live `.agent/STATUS.md`, parsed by the briefing API at cold-start) **remain the
-durable cross-session source of truth — as ON-DISK files.** (Since s196 new handoffs
-are gitignored local agent state — user directive s190b; git holds only the
-pre-s190b history.) The proxy's memory store is local-only with no MCP
+KubeDojo session handoffs (lean MD briefs at
+`.agent/session-state/YYYY-MM-DD-session-NN-<topic>.md`, indexed in the live
+`.agent/STATUS.md`, parsed by the briefing API at cold-start) **remain the durable
+cross-session source of truth — as ON-DISK files.** (s196 convention: handoffs are
+gitignored local agent state, never through git/PRs — user directives s190b + s196;
+`docs/session-state/` holds only the tracked pre-s196 history.) The proxy's memory store is local-only with no MCP
 write tool yet (`native_tool`/`bridge` off) — it auto-injects context but cannot
 carry the handoff across sessions. So keep the on-disk files as the backstop and push bulky
 evidence behind Headroom hashes rather than pasting it. **Migrate the handoff body

--- a/.claude/skills/cold-start/SKILL.md
+++ b/.claude/skills/cold-start/SKILL.md
@@ -21,7 +21,7 @@ Full ritual: [`scripts/prompts/cold-start.md`](../../../scripts/prompts/cold-sta
 2. **Run cold-start** — `KUBEDOJO_ISSUE=N bash scripts/cold-start.sh`
 3. **Claim if assigned** — `gh issue comment N --body "Claiming — worktree .worktrees/<name>"`
 4. **Worktree only** — never commit on primary `main`
-5. **Handoff on demand** — read `docs/session-state/*` only when orient/briefing leave a narrative gap
+5. **Handoff on demand** — read the latest `.agent/session-state/*` brief (pre-s196 history: `docs/session-state/*`) only when orient/briefing leave a narrative gap
 
 ## Script output sections
 

--- a/.claude/skills/cold-start/SKILL.md
+++ b/.claude/skills/cold-start/SKILL.md
@@ -29,7 +29,7 @@ Parse the labeled blocks from stdout:
 
 - `kubedojo:orient` — **start here** for "what to do now" (primary + up to 3 alternatives)
 - `kubedojo:briefing` — full compact snapshot (`actions`, `top_modules`, blockers)
-- `kubedojo:session` — latest handoff path (do not read the HTML file unless needed)
+- `kubedojo:session` — latest handoff path (do not read the handoff file unless needed)
 - `kubedojo:pending-decisions` — blocking Decision Cards in `docs/decisions/pending/`
 
 Optional: `bash scripts/cold-start.sh --manifest` for route discovery via `/api/state/manifest`.

--- a/.claude/skills/curriculum-orchestrator/SKILL.md
+++ b/.claude/skills/curriculum-orchestrator/SKILL.md
@@ -18,7 +18,7 @@ This skill is intentionally concrete: it names the agents on the roster as of `l
    - `kubedojo:briefing` — actions/top_modules/blockers
    - `kubedojo:session` — latest handoff path
    - `kubedojo:pending-decisions` — blocking Decision Cards in `docs/decisions/pending/`
-3. Read the latest handoff (`docs/session-state/...`) only if briefing/orient leave a real narrative-why gap.
+3. Read the latest handoff (`.agent/session-state/...`; pre-s196 history in `docs/session-state/`) only if briefing/orient leave a real narrative-why gap.
 4. Check `docs/decisions/pending/` — pending Decision Cards block only their declared Scope; surface them before starting other work.
 5. If the local API is down, `cold-start.sh` exits 0 with a STATUS.md fallback. Don't treat API failure as a hard stop.
 
@@ -120,7 +120,7 @@ Per user policy refinement: every shipped module must carry a composer-2.5 cross
 ## Operational rules
 
 - Quality-gate numbers live in `scripts/quality/verify_module.py` and `scripts/config.py`. Change the test fixture in the same commit as the gate ([[feedback_three_way_rule_agreement]]).
-- `STATUS.md` is an INDEX, not a log. Full handoffs go in `docs/session-state/YYYY-MM-DD-<topic>.html` per HTML-first artifact policy ([[feedback_html_over_markdown_for_artifacts]]).
+- `.agent/STATUS.md` (live, gitignored) is an INDEX, not a log. Handoffs = lean MD briefs in `.agent/session-state/` — never through git/PRs ([[session-handoff-writer]]). The tracked `STATUS.md` holds durable sections, PR-only.
 - HTML artifacts MUST be served via `http://127.0.0.1:8768/`, never `open <file>` or `file://` ([[feedback_html_artifacts_via_local_api]]).
 - Briefing API parses `## TODO` (unchecked `- [ ]`) and `## Blockers` (`- `) from STATUS.md. Keep those headings populated.
 - Pending Decision Cards live in `docs/decisions/pending/`. On user decision, move to `docs/decisions/{date}-{slug}.md`.
@@ -140,8 +140,8 @@ Context discipline in the meantime:
 - **Large content** (`npm run build` output, review verdicts, dispatch responses,
   search/grep bundles): pipe to a file and grep/tail the file — never Read raw
   ([[feedback_never_read_build_logs]]).
-- **Handoffs:** `docs/session-state/YYYY-MM-DD-<topic>.html` (indexed in `STATUS.md`,
-  parsed by the briefing API) is the durable cross-session SSOT (#2024).
+- **Handoffs:** `.agent/session-state/YYYY-MM-DD-session-NN-<topic>.md` (indexed in
+  `.agent/STATUS.md`, parsed by the briefing API) is the durable cross-session SSOT (#2024).
 - Full rule + re-enable procedure: [[.claude/rules/headroom]]. Never run
   `headroom learn --apply`.
 

--- a/.claude/skills/session-handoff-writer/SKILL.md
+++ b/.claude/skills/session-handoff-writer/SKILL.md
@@ -176,6 +176,6 @@ The handoff cites/links to these; it does not duplicate them.
 - [[feedback_html_over_markdown_for_artifacts]] — format-choice rule.
 - [[feedback_html_artifacts_via_local_api]] — serving rule.
 - [`STATUS.md`](../../../STATUS.md) — the tracked seed/fallback (durable sections; PR-only). The LIVE index this skill updates is `.agent/STATUS.md`.
-- [`docs/session-state/`](../../../docs/session-state/) — all prior handoffs (49+ files).
+- [`docs/session-state/`](../../../docs/session-state/) — tracked pre-s196 handoff history; live briefs in `.agent/session-state/`.
 - [`docs/migrations/html-first/plan.html`](../../../docs/migrations/html-first/plan.html) — HTML-first artifact policy spec.
 - [`scripts/local_api.py`](../../../scripts/local_api.py) `_parse_status_md` — the briefing parser.

--- a/agents_extensions/claude/agents/curriculum-orchestrator.md
+++ b/agents_extensions/claude/agents/curriculum-orchestrator.md
@@ -34,7 +34,7 @@ queue ownership). Then orient via `bash scripts/cold-start.sh` and drive the que
 - Module quality review, calque/translation review, and the module queue itself.
 - Author/reviewer dispatch (`scripts/dispatch_smart.py`, `scripts/ab`), PR
   creation + cross-family review + merge.
-- Curriculum session handoffs to `docs/session-state/**` + the `STATUS.md` index.
+- Curriculum session handoffs to `.agent/session-state/**` + the `.agent/STATUS.md` live index (pre-s196 history: `docs/session-state/**`).
 
 ## Out of scope (hand to the infra lane)
 
@@ -58,8 +58,8 @@ queue ownership). Then orient via `bash scripts/cold-start.sh` and drive the que
 - **Orient** via `bash scripts/cold-start.sh` / the briefing API
   (`curl 127.0.0.1:8768/api/briefing/session?compact=1`). The SessionStart hook
   has already run cold-start for you.
-- **At session end**, write the handoff to
-  `docs/session-state/YYYY-MM-DD-<topic>.html` (HTML-first per the artifact
-  policy) and update the `STATUS.md` index — promote the new file to "Latest
-  handoff", refresh `## TODO` / `## Blockers`. See the `session-handoff-writer`
-  skill for the exact protocol.
+- **At session end**, write a lean MD handoff brief to
+  `.agent/session-state/YYYY-MM-DD-session-NN-<topic>.md` and update the
+  `.agent/STATUS.md` live index — promote the new file to "Latest handoff",
+  refresh `## TODO` / `## Blockers`. Never through git/PRs (local agent state,
+  s196). See the `session-handoff-writer` skill for the exact protocol.

--- a/agents_extensions/claude/hooks/context-monitor.sh
+++ b/agents_extensions/claude/hooks/context-monitor.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Hook: PostToolUse — monitors context size and warns Claude before auto-compact
-# triggers, demanding a session handoff to docs/session-state/YYYY-MM-DD-<topic>.html
-# by default, with .md still accepted for brief handoffs (per CLAUDE.md session workflow).
+# triggers, demanding a lean MD session-handoff brief to
+# .agent/session-state/YYYY-MM-DD-session-NN-<topic>.md + a .agent/STATUS.md index
+# update (s196 convention — local agent state, never through git/PRs).
 #
 # Tiers (% of autoCompactWindow):
 #   75% -> heads-up: prepare handoff soon
@@ -54,21 +55,21 @@ if [ "$PCT" -ge 95 ]; then
     "EMERGENCY: Context at ${PCT}% of auto-compact window [~${TOKENS}/${WINDOW} tokens]. AUTO-COMPACT IS IMMINENT." \
     "" \
     "STOP all current work THIS TURN. Do not start any new tool calls beyond what is needed to:" \
-    "1. Write or update docs/session-state/YYYY-MM-DD-<topic>.html NOW with: latest commit hash on main, any background tasks still running [PIDs + log paths], what was just completed, what is left to do, and the EXACT next-step commands the new session should run. Prefer .html per the HTML-first artifact policy; existing .md handoffs remain valid for lookup/back-compat. Then update STATUS.md (the index) per CLAUDE.md workflow." \
-    "2. Tell the user to /exit immediately and start a fresh session that reads the new docs/session-state/ handoff first. Auto-compaction is a billed model call that summarizes your entire conversation: much more expensive than a 3KB handoff file the next session reads cheaply.")
+    "1. Write or update the lean MD handoff brief .agent/session-state/YYYY-MM-DD-session-NN-<topic>.md NOW with: latest commit hash on main, any background tasks still running [PIDs + log paths], what was just completed, what is left to do, and the EXACT next-step commands the new session should run. Then update .agent/STATUS.md (the live index) per the session-handoff-writer skill. NO git add/commit/PR — handoffs are local agent state." \
+    "2. Tell the user to /exit immediately and start a fresh session that reads the new .agent/session-state/ brief first. Auto-compaction is a billed model call that summarizes your entire conversation: much more expensive than a ~3KB brief the next session reads cheaply.")
 elif [ "$PCT" -ge 85 ]; then
   MSG=$(printf '%s\n%s\n%s\n%s\n%s\n%s\n' \
     "CRITICAL: Context at ${PCT}% of auto-compact window [~${TOKENS}/${WINDOW} tokens]." \
     "" \
     "Finish your current task ASAP, then:" \
-    "1. Write or update docs/session-state/YYYY-MM-DD-<topic>.html with commit hashes, in-flight tasks, next steps, restart commands. Prefer .html per the HTML-first artifact policy; existing .md handoffs remain valid for lookup/back-compat. Then update STATUS.md (the index) per CLAUDE.md workflow." \
+    "1. Write or update the lean MD handoff brief .agent/session-state/YYYY-MM-DD-session-NN-<topic>.md with commit hashes, in-flight tasks, next steps, restart commands. Then update .agent/STATUS.md (the live index). NO git add/commit/PR — handoffs are local agent state." \
     "2. Tell the user to /exit and start fresh." \
     "Do NOT start any new multi-step work or large operations. Handoff is much cheaper than the auto-compact that is about to trigger.")
 elif [ "$PCT" -ge 75 ]; then
   MSG=$(printf '%s\n%s\n%s\n' \
     "HEADS UP: Context at ${PCT}% of auto-compact window [~${TOKENS}/${WINDOW} tokens]." \
     "" \
-    "Wrap up your current logical unit of work soon. Once it lands, prepare docs/session-state/YYYY-MM-DD-<topic>.html by default, or .md for a brief handoff (and update STATUS.md as the index), so we can hand off to a fresh session before auto-compact triggers. Handoff costs ~3KB; compaction costs a full model summarization call.")
+    "Wrap up your current logical unit of work soon. Once it lands, prepare the lean MD handoff brief .agent/session-state/YYYY-MM-DD-session-NN-<topic>.md (and update .agent/STATUS.md as the live index), so we can hand off to a fresh session before auto-compact triggers. The brief costs ~3KB; compaction costs a full model summarization call.")
 else
   exit 0
 fi

--- a/agents_extensions/claude/hooks/context-monitor.sh
+++ b/agents_extensions/claude/hooks/context-monitor.sh
@@ -69,7 +69,7 @@ elif [ "$PCT" -ge 75 ]; then
   MSG=$(printf '%s\n%s\n%s\n' \
     "HEADS UP: Context at ${PCT}% of auto-compact window [~${TOKENS}/${WINDOW} tokens]." \
     "" \
-    "Wrap up your current logical unit of work soon. Once it lands, prepare the lean MD handoff brief .agent/session-state/YYYY-MM-DD-session-NN-<topic>.md (and update .agent/STATUS.md as the live index), so we can hand off to a fresh session before auto-compact triggers. The brief costs ~3KB; compaction costs a full model summarization call.")
+    "Wrap up your current logical unit of work soon. Once it lands, prepare the lean MD handoff brief .agent/session-state/YYYY-MM-DD-session-NN-<topic>.md (and update .agent/STATUS.md as the live index) — NO git add/commit/PR, handoffs are local agent state — so we can hand off to a fresh session before auto-compact triggers. The brief costs ~3KB; compaction costs a full model summarization call.")
 else
   exit 0
 fi

--- a/agents_extensions/claude/skills/cold-start/SKILL.md
+++ b/agents_extensions/claude/skills/cold-start/SKILL.md
@@ -21,7 +21,7 @@ Full ritual: [`scripts/prompts/cold-start.md`](../../../scripts/prompts/cold-sta
 2. **Run cold-start** — `KUBEDOJO_ISSUE=N bash scripts/cold-start.sh`
 3. **Claim if assigned** — `gh issue comment N --body "Claiming — worktree .worktrees/<name>"`
 4. **Worktree only** — never commit on primary `main`
-5. **Handoff on demand** — read `docs/session-state/*` only when orient/briefing leave a narrative gap
+5. **Handoff on demand** — read the latest `.agent/session-state/*` brief (pre-s196 history: `docs/session-state/*`) only when orient/briefing leave a narrative gap
 
 ## Script output sections
 

--- a/agents_extensions/claude/skills/cold-start/SKILL.md
+++ b/agents_extensions/claude/skills/cold-start/SKILL.md
@@ -29,7 +29,7 @@ Parse the labeled blocks from stdout:
 
 - `kubedojo:orient` — **start here** for "what to do now" (primary + up to 3 alternatives)
 - `kubedojo:briefing` — full compact snapshot (`actions`, `top_modules`, blockers)
-- `kubedojo:session` — latest handoff path (do not read the HTML file unless needed)
+- `kubedojo:session` — latest handoff path (do not read the handoff file unless needed)
 - `kubedojo:pending-decisions` — blocking Decision Cards in `docs/decisions/pending/`
 
 Optional: `bash scripts/cold-start.sh --manifest` for route discovery via `/api/state/manifest`.

--- a/agents_extensions/claude/skills/curriculum-orchestrator/SKILL.md
+++ b/agents_extensions/claude/skills/curriculum-orchestrator/SKILL.md
@@ -18,7 +18,7 @@ This skill is intentionally concrete: it names the agents on the roster as of `l
    - `kubedojo:briefing` — actions/top_modules/blockers
    - `kubedojo:session` — latest handoff path
    - `kubedojo:pending-decisions` — blocking Decision Cards in `docs/decisions/pending/`
-3. Read the latest handoff (`docs/session-state/...`) only if briefing/orient leave a real narrative-why gap.
+3. Read the latest handoff (`.agent/session-state/...`; pre-s196 history in `docs/session-state/`) only if briefing/orient leave a real narrative-why gap.
 4. Check `docs/decisions/pending/` — pending Decision Cards block only their declared Scope; surface them before starting other work.
 5. If the local API is down, `cold-start.sh` exits 0 with a STATUS.md fallback. Don't treat API failure as a hard stop.
 
@@ -120,7 +120,7 @@ Per user policy refinement: every shipped module must carry a composer-2.5 cross
 ## Operational rules
 
 - Quality-gate numbers live in `scripts/quality/verify_module.py` and `scripts/config.py`. Change the test fixture in the same commit as the gate ([[feedback_three_way_rule_agreement]]).
-- `STATUS.md` is an INDEX, not a log. Full handoffs go in `docs/session-state/YYYY-MM-DD-<topic>.html` per HTML-first artifact policy ([[feedback_html_over_markdown_for_artifacts]]).
+- `.agent/STATUS.md` (live, gitignored) is an INDEX, not a log. Handoffs = lean MD briefs in `.agent/session-state/` — never through git/PRs ([[session-handoff-writer]]). The tracked `STATUS.md` holds durable sections, PR-only.
 - HTML artifacts MUST be served via `http://127.0.0.1:8768/`, never `open <file>` or `file://` ([[feedback_html_artifacts_via_local_api]]).
 - Briefing API parses `## TODO` (unchecked `- [ ]`) and `## Blockers` (`- `) from STATUS.md. Keep those headings populated.
 - Pending Decision Cards live in `docs/decisions/pending/`. On user decision, move to `docs/decisions/{date}-{slug}.md`.
@@ -140,8 +140,8 @@ Context discipline in the meantime:
 - **Large content** (`npm run build` output, review verdicts, dispatch responses,
   search/grep bundles): pipe to a file and grep/tail the file — never Read raw
   ([[feedback_never_read_build_logs]]).
-- **Handoffs:** `docs/session-state/YYYY-MM-DD-<topic>.html` (indexed in `STATUS.md`,
-  parsed by the briefing API) is the durable cross-session SSOT (#2024).
+- **Handoffs:** `.agent/session-state/YYYY-MM-DD-session-NN-<topic>.md` (indexed in
+  `.agent/STATUS.md`, parsed by the briefing API) is the durable cross-session SSOT (#2024).
 - Full rule + re-enable procedure: [[.claude/rules/headroom]]. Never run
   `headroom learn --apply`.
 

--- a/agents_extensions/shared/skills/session-handoff-writer/SKILL.md
+++ b/agents_extensions/shared/skills/session-handoff-writer/SKILL.md
@@ -176,6 +176,6 @@ The handoff cites/links to these; it does not duplicate them.
 - [[feedback_html_over_markdown_for_artifacts]] — format-choice rule.
 - [[feedback_html_artifacts_via_local_api]] — serving rule.
 - [`STATUS.md`](../../../STATUS.md) — the tracked seed/fallback (durable sections; PR-only). The LIVE index this skill updates is `.agent/STATUS.md`.
-- [`docs/session-state/`](../../../docs/session-state/) — all prior handoffs (49+ files).
+- [`docs/session-state/`](../../../docs/session-state/) — tracked pre-s196 handoff history; live briefs in `.agent/session-state/`.
 - [`docs/migrations/html-first/plan.html`](../../../docs/migrations/html-first/plan.html) — HTML-first artifact policy spec.
 - [`scripts/local_api.py`](../../../scripts/local_api.py) `_parse_status_md` — the briefing parser.

--- a/scripts/agent_onboarding.md
+++ b/scripts/agent_onboarding.md
@@ -30,7 +30,7 @@ curl -s --max-time 2 http://127.0.0.1:8768/api/briefing/session?compact=1
 # Punch-line orientation — primary action + up to 3 alternatives (~1.3 KB).
 curl -s --max-time 2 http://127.0.0.1:8768/api/orient
 
-# Latest handoff pointer (path + title/tldr, not full HTML body).
+# Latest handoff pointer (path + title/tldr, not the full handoff body).
 curl -s --max-time 2 http://127.0.0.1:8768/api/session/current
 
 # Full briefing (~1.5K) when you also want next_reads + the worktree list.


### PR DESCRIPTION
## Summary

User check: *"what about the context improvement we did, got rid of all the conflicts etc"* — a verification sweep found the s196 handoff convention (PRs #2247/#2248) had NOT reached every always-loaded surface. Residual conflicts fixed:

1. **`context-monitor.sh` (highest stakes)** — at the 75/85/95% context tiers it instructed agents to write an **HTML handoff to `docs/session-state/` + update tracked `STATUS.md`** — the exact opposite of the new convention, delivered at the worst possible moment (context pressure). All three tiers now demand the lean MD brief → `.agent/session-state/` + `.agent/STATUS.md`, explicitly "NO git add/commit/PR".
2. **curriculum-orchestrator agent def** — lane-scope line + session-end protocol repointed.
3. **curriculum-orchestrator SKILL** — cold-start read path, the "STATUS.md is an INDEX" operational rule, and the headroom section's handoff-SSOT line.
4. **cold-start SKILL** — "HTML file" wording.

Re-sweep after the fix: zero remaining active instructions referencing the pre-s196 convention (historical/pre-s196-labeled mentions excluded by design).

## Verification
- Count-asserted exact edits; `bash -n` clean on the hook; deploy `--check` in sync.
- No code/read-path changes — prompt surfaces only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)