### PR TITLE
fix(deps): pin transitive CVE patches via npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3843,16 +3843,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-image-size": {
@@ -6172,9 +6172,9 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -7848,9 +7848,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -8245,9 +8245,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -8264,7 +8264,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -9145,9 +9145,9 @@
       "license": "MIT"
     },
     "node_modules/svgo": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
-      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,12 @@
     "uuid": "^14.0.0",
     "esbuild": "^0.28.1",
     "vite": "^8.1.3",
-    "dompurify": "^3.4.13"
+    "dompurify": "^3.4.13",
+    "nanoid": "^3.3.18",
+    "js-yaml": "^4.3.1",
+    "postcss": "^8.5.25",
+    "svgo": "^4.0.2",
+    "brace-expansion": "^5.0.9"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.66.0",


### PR DESCRIPTION
## Summary
- Pin patched transitives in `package.json` `overrides` (same pattern as `dompurify`) so the lockfile bump is accompanied by a manifest change and the supply-chain `detect` tripwire stays green.
- Versions: `nanoid` 3.3.18, `js-yaml` 4.3.1, `postcss` 8.5.26, `svgo` 4.0.2, `brace-expansion` 5.0.9.
- Closes Dependabot alerts GHSA-2v37-7h3g-55p8 / GHSA-28wg-ghj8-5hjv (nanoid), GHSA-5p4m-2wfm-xmqj (js-yaml), GHSA-r28c-9q8g-f849 / CVE-2026-69153 (postcss), GHSA-2p49-hgcm-8545 (svgo), GHSA-mh99-v99m-4gvg / GHSA-rgw5-rvv9-x895 (brace-expansion).
- Supersedes lockfile-only PRs #2265, #2263, #2259, #2254 (those fail `detect` because they do not touch `package.json`).
- `npm audit` is clean (0 vulnerabilities) on this branch.

## Test plan
- [x] `python3 scripts/security/check_lockfile_integrity.py --base origin/main --head HEAD --three-dot` → OK (manifest changed)
- [x] `npm audit` → 0 vulnerabilities
- [ ] CI: Astro build, vitest, detect, link check
- [ ] Cross-family review (codex; author is cursor/grok)


Made with [Cursor](https://cursor.com)