### PR TITLE
fix(site): stop home header overflow at mid-desktop widths (#2266)

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -44,7 +44,7 @@ const nav = isUk
     ];
 ---
 
-<div class="kd-header-shell">
+<div class:list={['kd-header-shell', { 'kd-header-standalone': standalone }]}>
   <div class="kd-topbar">
     <a class="kd-logo" href={`${p}/` || '/'}><span class="kd-logo-icon">K</span><span>KubeDojo</span></a>
     <nav class="kd-nav" aria-label="Primary">
@@ -116,8 +116,11 @@ const nav = isUk
       root.querySelectorAll('.kd-mobile-nav a').forEach((anchor) => {
         anchor.addEventListener('click', closeMenu);
       });
+      const navCollapseQuery = root.classList.contains('kd-header-standalone')
+        ? '(max-width: 80rem)'
+        : '(max-width: 50rem)';
       window.addEventListener('resize', () => {
-        if (window.innerWidth > 800) closeMenu();
+        if (!window.matchMedia(navCollapseQuery).matches) closeMenu();
       });
     } else {
       closeMenu();
@@ -146,6 +149,13 @@ const nav = isUk
   .kd-right { margin-left: auto; display: flex; align-items: center; gap: 0.5rem; }
   .kd-search { min-width: 10rem; }
   .kd-search :global(button) { border-radius: 0.5rem !important; height: 2rem !important; font-size: 0.8125rem !important; }
+  /* #2266: standalone home header intrinsic width was ~1268px (search clipped).
+     Keep Starlight pages on the 50rem collapse; home collapses earlier and lets
+     the search button size to its label so "Search" stays fully visible. */
+  .kd-header-standalone .kd-topbar { max-width: 100%; min-width: 0; }
+  .kd-header-standalone .kd-right { flex-shrink: 0; }
+  .kd-header-standalone .kd-search { min-width: 0; }
+  .kd-header-standalone .kd-search :global(button) { max-width: none; width: auto; }
   .kd-theme :global(select), .kd-lang :global(select) { font-size: 0.75rem; }
   .kd-social :global(a) { color: #9CA3AF; } .kd-social :global(a:hover) { color: #0F172A; }
   :global([data-theme='dark']) .kd-social :global(a:hover) { color: white; }
@@ -168,5 +178,15 @@ const nav = isUk
     .kd-search { min-width: 0; }
     .kd-search :global(button) { max-width: none; width: auto; }
     .kd-menu-toggle { display: inline-flex; align-items: center; justify-content: center; }
+  }
+
+  /* #2266: mid-desktop home viewports (e.g. 1027px) still show the 9-item nav. */
+  @media (max-width: 80rem) {
+    .kd-header-standalone .kd-topbar { padding: 0 1rem; }
+    .kd-header-standalone .kd-nav,
+    .kd-header-standalone .kd-social,
+    .kd-header-standalone .kd-lang,
+    .kd-header-standalone .kd-lang-link { display: none; }
+    .kd-header-standalone .kd-menu-toggle { display: inline-flex; align-items: center; justify-content: center; }
   }
 </style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -155,7 +155,8 @@ const nav = isUk
   .kd-header-standalone .kd-topbar { max-width: 100%; min-width: 0; }
   .kd-header-standalone .kd-right { flex-shrink: 0; }
   .kd-header-standalone .kd-search { min-width: 0; }
-  .kd-header-standalone .kd-search :global(button) { max-width: none; width: auto; }
+  .kd-header-standalone .kd-search :global(button) { max-width: none; width: auto; white-space: nowrap; }
+  .kd-header-standalone .kd-search :global(kbd) { display: none; }
   .kd-theme :global(select), .kd-lang :global(select) { font-size: 0.75rem; }
   .kd-social :global(a) { color: #9CA3AF; } .kd-social :global(a:hover) { color: #0F172A; }
   :global([data-theme='dark']) .kd-social :global(a:hover) { color: white; }

--- a/tests/header-overflow.test.ts
+++ b/tests/header-overflow.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Regression test for issue #2266: custom home header overflow at ~1027px.
+// Production QA measured document.scrollWidth 1268 vs clientWidth 1027, with
+// `.kd-right` / `.kd-search` past the viewport and the search label clipped.
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const header = readFileSync(resolve(repoRoot, 'src/components/Header.astro'), 'utf8');
+
+function mediaBlock(source: string, query: string): string {
+  const needle = `@media (${query})`;
+  const start = source.indexOf(needle);
+  expect(start, `missing ${needle}`).toBeGreaterThan(-1);
+  const open = source.indexOf('{', start);
+  let depth = 0;
+  for (let i = open; i < source.length; i += 1) {
+    if (source[i] === '{') depth += 1;
+    if (source[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(open, i + 1);
+    }
+  }
+  throw new Error(`unclosed ${needle}`);
+}
+
+describe('home header overflow (#2266)', () => {
+  it('marks the standalone homepage header so collapse can be scoped', () => {
+    expect(header).toContain("'kd-header-standalone': standalone");
+  });
+
+  it('collapses the standalone home nav at 80rem (covers 1027px / 1268px)', () => {
+    const rem = 80;
+    expect(rem * 16).toBeGreaterThan(1027);
+    expect(rem * 16).toBeGreaterThanOrEqual(1268);
+
+    const block = mediaBlock(header, 'max-width: 80rem');
+    expect(block).toContain('.kd-header-standalone .kd-nav');
+    expect(block).toMatch(/\.kd-header-standalone \.kd-nav[\s\S]*display:\s*none/);
+    expect(block).toContain('.kd-header-standalone .kd-menu-toggle');
+  });
+
+  it('keeps Starlight content pages on the 50rem collapse', () => {
+    const block = mediaBlock(header, 'max-width: 50rem');
+    expect(block).toMatch(/\.kd-nav[^{]*\{|display:\s*none/);
+    expect(block).toContain('.kd-nav');
+    expect(block).not.toContain('.kd-header-standalone');
+  });
+
+  it('lets standalone search size to its label instead of clipping to Sear…', () => {
+    expect(header).toMatch(
+      /\.kd-header-standalone \.kd-search :global\(button\)\s*\{[^}]*max-width:\s*none[^}]*width:\s*auto/,
+    );
+    expect(header).toMatch(/\.kd-header-standalone \.kd-search\s*\{[^}]*min-width:\s*0/);
+  });
+
+  it('keeps the JS menu closer in sync with the CSS collapse queries', () => {
+    expect(header).toContain("'(max-width: 80rem)'");
+    expect(header).toContain("'(max-width: 50rem)'");
+    expect(header).toMatch(/classList\.contains\('kd-header-standalone'\)/);
+    expect(header).not.toMatch(/innerWidth\s*>\s*800/);
+  });
+});

--- a/tests/header-overflow.test.ts
+++ b/tests/header-overflow.test.ts
@@ -54,6 +54,7 @@ describe('home header overflow (#2266)', () => {
       /\.kd-header-standalone \.kd-search :global\(button\)\s*\{[^}]*max-width:\s*none[^}]*width:\s*auto/,
     );
     expect(header).toMatch(/\.kd-header-standalone \.kd-search\s*\{[^}]*min-width:\s*0/);
+    expect(header).toMatch(/\.kd-header-standalone \.kd-search :global\(kbd\)\s*\{[^}]*display:\s*none/);
   });
 
   it('keeps the JS menu closer in sync with the CSS collapse queries', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the custom homepage header overflowing at mid-desktop widths (~1027px). Production QA measured `document.scrollWidth` 1268 vs `clientWidth` 1027, with `.kd-right` / `.kd-search` past the viewport and the search label clipped to `Sear…`.

**Cause:** `.kd-topbar` is a nowrap flex row. The 9-item desktop nav, logo, `min-width: 10rem` search, theme, social, and language controls stay visible until `50rem` (800px). Intrinsic width is ~1268px, so 801–1267px grows a horizontal scrollbar.

**Fix (home only):**
- Mark the standalone homepage header with `.kd-header-standalone`
- Collapse that header at `80rem` (1280px) — hamburger + unclipped search
- Let the home search button size to its label (`width: auto; max-width: none`)
- Hide the Ctrl-K chip on the home header so unclipping "Search" does not overflow just above 80rem
- Keep Starlight content pages (`/k8s/kcna/`, `/progress/`, `/status/`) on the existing `50rem` collapse
- Sync the JS menu-close listener with `matchMedia` instead of a hardcoded `800`px

## Test plan

- [x] `tests/header-overflow.test.ts` locks the 80rem home collapse, 50rem Starlight collapse, search `width: auto`, kbd hide, and JS/CSS query sync (`#2266`)
- [x] `npm test` — 5 files / 56 tests passed (CI vitest green)
- [x] Headless Chrome fixture of the header CSS at 1027px: home `scrollWidth === clientWidth` (1027), search label `Search` (not clipped), nav collapsed
- [x] Same fixture at 1366/1440: home desktop nav visible, `scrollWidth === clientWidth`
- [x] Same fixture at 1027px for the non-standalone (Starlight) header: still uses the 50rem collapse (nav visible) — unchanged
- [x] CI Astro build green (11/11 checks passed)

Fixes #2266

Regression test: tests/header-overflow.test.ts

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4055b0af-a688-4372-b8f0-22fead0513ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4055b0af-a688-4372-b8f0-22fead0513ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

