### PR TITLE
feat(quality): add an evidence-aware content inventory (#2273)

### DIFF
--- a/docs/content-upgrade/inventory.md
+++ b/docs/content-upgrade/inventory.md
@@ -1,0 +1,37 @@
+# Content inventory ledger
+
+`content_inventory.py` is a deterministic, read-only inventory CLI. From the
+repository root it defaults to `src/content/docs`; tests and isolated audits may
+pass `--docs-root PATH`. It accepts an optional evidence receipt with
+`--evidence PATH` and always writes one JSON report to stdout:
+
+```bash
+.venv/bin/python scripts/quality/content_inventory.py --evidence evidence.json
+```
+
+Each `pages[]` record contains the docs-relative `path`, `locale` (`en` or
+`uk`), `type` (`hub`, `module`, `chapter`, `lab`, or `page`), normalized
+`section`, `source_digest` (`sha256:<hex>`), counterpart fields, and the
+frontmatter `slug` as `source_route`. `route_validation` is always
+`not_checked`: this tool does not claim that a route rendered or resolved in
+Astro. A missing `slug` is reported as a null source route rather than inferred.
+
+An evidence file has a `pages` list or path-keyed object. Each receipt needs
+`path`, `page_digest`, `disposition` (`retain`, `revise`, or `expand`),
+`reviewer_refs`, `evidence_refs`, and `independent_statuses`. Status values are
+`pending`, `pass`, `fail`, `unknown`, or `not_applicable`. The CLI fills omitted
+layers with `unknown`; it never derives a pass from a file,
+heading, frontmatter flag, or inventory presence. A pass must include an
+evidence reference. Both reference lists must be nonempty for every disposition,
+including pending or unknown layers. A `current` receipt means only that its
+digest and schema were checked; its reviewer and evidence references/statuses
+remain supplied assertions, not independently verified source or reviewer
+evidence.
+
+`new_pages` are current paths absent from a valid supplied receipt set;
+`missing_pages` are receipt paths absent from disk; `stale_receipts` have a
+digest mismatch; `invalid_receipts` fail receipt validation. Missing, invalid,
+and stale receipts are emitted as unreviewed with unknown statuses. Without a
+usable evidence input, the inventory remains deterministic but does not label
+pages as new or missing. The command does not write ledgers, caches, state, or
+content files.

--- a/scripts/quality/content_inventory.py
+++ b/scripts/quality/content_inventory.py
@@ -1,0 +1,263 @@
+"""Build a deterministic, read-only inventory of KubeDojo content pages."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DOCS_ROOT = REPO_ROOT / "src" / "content" / "docs"
+DISPOSITIONS = {"retain", "revise", "expand"}
+STATUS_VALUES = {"pending", "pass", "fail", "unknown", "not_applicable"}
+EVIDENCE_LAYERS = (
+    "page_presence",
+    "structural_checks",
+    "technical_source",
+    "editorial_review",
+    "lab_execution",
+    "translation_fidelity",
+    "deployed_smoke",
+    "learner_data",
+)
+
+
+def _frontmatter(text: str) -> tuple[dict[str, Any], list[str]]:
+    """Parse leading YAML without inferring a route from the file path."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}, ["missing frontmatter"]
+    try:
+        end = lines.index("---", 1)
+    except ValueError:
+        return {}, ["unterminated frontmatter"]
+    try:
+        value = yaml.safe_load("\n".join(lines[1:end])) or {}
+    except yaml.YAMLError as exc:
+        return {}, [f"invalid frontmatter: {exc.__class__.__name__}"]
+    if not isinstance(value, dict):
+        return {}, ["frontmatter is not a mapping"]
+    return value, []
+
+
+def _locale(rel: Path) -> str:
+    return "uk" if rel.parts and rel.parts[0] == "uk" else "en"
+
+
+def _source_section(rel: Path, locale: str) -> str:
+    parts = rel.parts[1:] if locale == "uk" else rel.parts
+    return Path(*parts[:-1]).as_posix() if len(parts) > 1 else ""
+
+
+def _page_type(rel: Path) -> str:
+    if rel.name in {"index.md", "index.mdx"}:
+        return "hub"
+    if rel.stem.startswith("module-"):
+        return "module"
+    if rel.stem.startswith("ch-") and "ai-history" in rel.parts:
+        return "chapter"
+    if "lab" in rel.parts or rel.stem.startswith("lab-"):
+        return "lab"
+    return "page"
+
+
+def _expected_counterpart(rel: Path, locale: str) -> str:
+    if locale == "uk":
+        return Path(*rel.parts[1:]).as_posix()
+    return Path("uk", rel).as_posix()
+
+
+def _digest(data: bytes) -> str:
+    return f"sha256:{hashlib.sha256(data).hexdigest()}"
+
+
+def _unknown_evidence(receipt_status: str) -> dict[str, Any]:
+    return {
+        "receipt_status": receipt_status,
+        "status_source": "unknown",
+        "disposition": None,
+        "reviewer_refs": [],
+        "evidence_refs": [],
+        "independent_statuses": {layer: "unknown" for layer in EVIDENCE_LAYERS},
+    }
+
+
+def _normalise_digest(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip().lower()
+    if len(value) == 64:
+        value = f"sha256:{value}"
+    if len(value) != 71 or not value.startswith("sha256:"):
+        return None
+    return value if all(char in "0123456789abcdef" for char in value[7:]) else None
+
+
+def _receipt_evidence(receipt: Any, page_digest: str) -> tuple[dict[str, Any], str]:
+    """Validate one receipt; invalid input can never retain a passing status."""
+    if not isinstance(receipt, dict):
+        return _unknown_evidence("invalid"), "receipt is not an object"
+    supplied_value = receipt.get("page_digest", receipt.get("source_digest", receipt.get("digest")))
+    if _normalise_digest(supplied_value) != page_digest:
+        supplied = _normalise_digest(supplied_value)
+        if supplied is None:
+            return _unknown_evidence("invalid"), "missing or invalid page_digest"
+        return _unknown_evidence("stale"), "page_digest does not match source"
+
+    disposition = receipt.get("disposition")
+    if not isinstance(disposition, str) or disposition not in DISPOSITIONS:
+        return _unknown_evidence("invalid"), "disposition must be retain, revise, or expand"
+    statuses = receipt.get("independent_statuses", receipt.get("statuses"))
+    if not isinstance(statuses, dict):
+        return _unknown_evidence("invalid"), "independent_statuses must be an object"
+    if any(not isinstance(key, str) or key not in EVIDENCE_LAYERS for key in statuses):
+        return _unknown_evidence("invalid"), "independent statuses contain an unknown layer"
+    if any(not isinstance(value, str) or value not in STATUS_VALUES for value in statuses.values()):
+        return _unknown_evidence("invalid"), "independent statuses contain an invalid value"
+    refs = {}
+    for key in ("reviewer_refs", "evidence_refs"):
+        value = receipt.get(key, [])
+        if not isinstance(value, list) or not value or any(
+            not isinstance(item, str) or not item.strip() for item in value
+        ):
+            return _unknown_evidence("invalid"), f"{key} must be a list of non-empty strings"
+        refs[key] = value
+    merged_statuses = {layer: "unknown" for layer in EVIDENCE_LAYERS}
+    merged_statuses.update(statuses)
+    return {
+        "receipt_status": "current",
+        "status_source": "supplied_receipt",
+        "disposition": disposition,
+        "reviewer_refs": refs["reviewer_refs"],
+        "evidence_refs": refs["evidence_refs"],
+        "independent_statuses": merged_statuses,
+    }, ""
+
+
+def _load_receipts(path: Path | None) -> tuple[dict[str, Any], list[str], bool]:
+    if path is None:
+        return {}, [], False
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        return {}, [f"evidence input unavailable or invalid: {exc.__class__.__name__}"], True
+    records = payload.get("pages") if isinstance(payload, dict) else None
+    if isinstance(records, list):
+        entries = records
+    elif isinstance(records, dict):
+        entries = [dict(value, path=key) if isinstance(value, dict) else value for key, value in records.items()]
+    else:
+        return {}, ["evidence input must contain pages as a list or object"], True
+    receipts: dict[str, Any] = {}
+    errors: list[str] = []
+    for entry in entries:
+        key = entry.get("path") if isinstance(entry, dict) else None
+        if not isinstance(key, str) or not key or Path(key).is_absolute() or ".." in Path(key).parts:
+            errors.append("evidence input contains an invalid page path")
+            continue
+        if key in receipts:
+            errors.append(f"duplicate evidence receipt: {key}")
+            receipts[key] = None
+        else:
+            receipts[key] = entry
+    return receipts, errors, False
+
+
+def build_inventory(docs_root: Path, evidence_path: Path | None = None) -> dict[str, Any]:
+    """Return inventory JSON data without writing files or changing runtime state."""
+    docs_root = docs_root.resolve()
+    if not docs_root.is_dir():
+        return {
+            "schema": "kubedojo.content_inventory.v1",
+            "docs_root": str(docs_root),
+            "page_count": 0,
+            "pages": [],
+            "new_pages": [],
+            "missing_pages": [],
+            "stale_receipts": [],
+            "invalid_receipts": [],
+            "receipt_errors": [],
+            "errors": ["docs_root does not exist or is not a directory"],
+        }
+    source_paths = sorted(
+        (path for path in docs_root.rglob("*") if path.is_file() and path.suffix in {".md", ".mdx"}),
+        key=lambda path: path.relative_to(docs_root).as_posix(),
+    )
+    rel_paths = {path.relative_to(docs_root).as_posix() for path in source_paths}
+    receipts, receipt_errors, invalid_input = _load_receipts(evidence_path)
+    pages: list[dict[str, Any]] = []
+
+    for path in source_paths:
+        rel = path.relative_to(docs_root)
+        locale = _locale(rel)
+        expected = _expected_counterpart(rel, locale)
+        raw = path.read_bytes()
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            text = ""
+        frontmatter, source_warnings = _frontmatter(text)
+        route = frontmatter.get("slug")
+        route = route.strip() if isinstance(route, str) and route.strip() else None
+        page = {
+            "path": rel.as_posix(),
+            "locale": locale,
+            "type": _page_type(rel),
+            "section": _source_section(rel, locale),
+            "source_digest": _digest(raw),
+            "counterpart": expected if expected in rel_paths else None,
+            "counterpart_expected": expected,
+            "counterpart_present": expected in rel_paths,
+            "source_route": route,
+            "route_source": "frontmatter.slug" if route is not None else None,
+            "route_validation": "not_checked",
+            "source_warnings": source_warnings,
+        }
+        if invalid_input:
+            page["evidence"] = _unknown_evidence("invalid")
+        elif evidence_path is None or rel.as_posix() not in receipts:
+            page["evidence"] = _unknown_evidence("missing")
+        elif receipts[rel.as_posix()] is None:
+            page["evidence"] = _unknown_evidence("invalid")
+        else:
+            evidence, error = _receipt_evidence(receipts[rel.as_posix()], page["source_digest"])
+            page["evidence"] = evidence
+            if error:
+                receipt_errors.append(f"{rel.as_posix()}: {error}")
+        pages.append(page)
+
+    receipt_paths = set(receipts)
+    return {
+        "schema": "kubedojo.content_inventory.v1",
+        "docs_root": str(docs_root),
+        "page_count": len(pages),
+        "pages": pages,
+        "new_pages": sorted(rel_paths - receipt_paths) if evidence_path is not None and not invalid_input else [],
+        "missing_pages": sorted(receipt_paths - rel_paths) if evidence_path is not None and not invalid_input else [],
+        "stale_receipts": sorted(
+            page["path"] for page in pages if page["evidence"]["receipt_status"] == "stale"
+        ),
+        "invalid_receipts": sorted(
+            page["path"] for page in pages if page["evidence"]["receipt_status"] == "invalid"
+        ),
+        "receipt_errors": sorted(receipt_errors),
+        "errors": [],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--docs-root", type=Path, default=DEFAULT_DOCS_ROOT)
+    parser.add_argument("--evidence", "--evidence-json", type=Path)
+    args = parser.parse_args(argv)
+    report = build_inventory(args.docs_root, args.evidence)
+    print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    return 2 if report["errors"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_content_inventory.py
+++ b/tests/test_content_inventory.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_module():
+    path = Path(__file__).resolve().parent.parent / "scripts" / "quality" / "content_inventory.py"
+    spec = importlib.util.spec_from_file_location("content_inventory", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+inventory = _load_module()
+
+
+def _write(path: Path, *, slug: str | None = None, body: str = "body") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    route = f'\nslug: "{slug}"' if slug else ""
+    path.write_text(f'---\ntitle: "Example"{route}\n---\n\n{body}\n', encoding="utf-8")
+
+
+def _receipt(docs: Path, rel: str, **changes: object) -> dict[str, object]:
+    path = docs / rel
+    receipt: dict[str, object] = {
+        "path": rel,
+        "page_digest": inventory._digest(path.read_bytes()),
+        "disposition": "retain",
+        "reviewer_refs": ["review:one"],
+        "evidence_refs": ["evidence:one"],
+        "independent_statuses": {"technical_source": "pass"},
+    }
+    receipt.update(changes)
+    return receipt
+
+
+def _pages(report: dict[str, object]) -> dict[str, dict[str, object]]:
+    return {page["path"]: page for page in report["pages"]}  # type: ignore[index]
+
+
+def test_en_uk_mapping_and_source_fields(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    _write(docs / "track/module-1.1-example.md", slug="track/module-1.1-example")
+    _write(docs / "uk/track/module-1.1-example.md", slug="uk/track/module-1.1-example")
+    _write(docs / "track/index.md")
+
+    pages = _pages(inventory.build_inventory(docs))
+    en = pages["track/module-1.1-example.md"]
+    uk = pages["uk/track/module-1.1-example.md"]
+    hub = pages["track/index.md"]
+    assert en["locale"] == "en" and en["type"] == "module"
+    assert en["section"] == "track"
+    assert en["counterpart"] == "uk/track/module-1.1-example.md"
+    assert uk["locale"] == "uk" and uk["counterpart"] == "track/module-1.1-example.md"
+    assert en["source_route"] == "track/module-1.1-example"
+    assert hub["source_route"] is None
+    assert hub["route_validation"] == "not_checked"
+
+
+def test_new_and_missing_pages_are_reported(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    _write(docs / "old.md")
+    _write(docs / "new.md")
+    evidence = tmp_path / "evidence.json"
+    evidence.write_text(
+        json.dumps({"pages": [_receipt(docs, "old.md"), {
+            "path": "removed.md",
+            "page_digest": "0" * 64,
+            "disposition": "revise",
+        }]}),
+        encoding="utf-8",
+    )
+
+    report = inventory.build_inventory(docs, evidence)
+    assert report["new_pages"] == ["new.md"]
+    assert report["missing_pages"] == ["removed.md"]
+    assert _pages(report)["old.md"]["evidence"]["receipt_status"] == "current"
+    assert _pages(report)["old.md"]["evidence"]["status_source"] == "supplied_receipt"
+    assert _pages(report)["new.md"]["evidence"]["status_source"] == "unknown"
+
+
+def test_changed_content_invalidates_receipt(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    page = docs / "module.md"
+    _write(page)
+    evidence = tmp_path / "evidence.json"
+    evidence.write_text(json.dumps({"pages": [_receipt(docs, "module.md")]}), encoding="utf-8")
+    page.write_text(page.read_text(encoding="utf-8") + "changed\n", encoding="utf-8")
+
+    record = _pages(inventory.build_inventory(docs, evidence))["module.md"]
+    assert record["evidence"]["receipt_status"] == "stale"
+    assert record["evidence"]["status_source"] == "unknown"
+    assert set(record["evidence"]["independent_statuses"].values()) == {"unknown"}
+
+
+def test_headings_and_presence_never_imply_pass(tmp_path: Path, capsys) -> None:
+    docs = tmp_path / "docs"
+    page = docs / "module.md"
+    _write(page, body="## Learning Outcomes\n## Quiz\n## Lab")
+    before = page.read_bytes()
+
+    assert inventory.main(["--docs-root", str(docs)]) == 0
+    report = json.loads(capsys.readouterr().out)
+    record = _pages(report)["module.md"]
+    assert record["evidence"]["receipt_status"] == "missing"
+    assert set(record["evidence"]["independent_statuses"].values()) == {"unknown"}
+    assert page.read_bytes() == before
+
+
+def test_invalid_receipt_cannot_pass(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    _write(docs / "module.md")
+    evidence = tmp_path / "evidence.json"
+    evidence.write_text(json.dumps({"pages": [_receipt(docs, "module.md", evidence_refs=[], independent_statuses={"technical_source": "pass"})]}), encoding="utf-8")
+
+    record = _pages(inventory.build_inventory(docs, evidence))["module.md"]
+    assert record["evidence"]["receipt_status"] == "invalid"
+    assert set(record["evidence"]["independent_statuses"].values()) == {"unknown"}
+
+
+def test_duplicate_and_malformed_status_receipts_are_invalid(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    _write(docs / "module.md")
+    receipt = _receipt(docs, "module.md")
+    malformed = _receipt(docs, "module.md", independent_statuses={"made_up": "pass"})
+    malformed_value = _receipt(docs, "module.md", independent_statuses={"technical_source": []})
+    evidence = tmp_path / "evidence.json"
+    evidence.write_text(json.dumps({"pages": [receipt, receipt]}), encoding="utf-8")
+    duplicate_report = inventory.build_inventory(docs, evidence)
+    duplicate = _pages(duplicate_report)["module.md"]
+    assert duplicate["evidence"]["receipt_status"] == "invalid"
+    assert duplicate_report["receipt_errors"].count("duplicate evidence receipt: module.md") == 1
+
+    evidence.write_text(json.dumps({"pages": [malformed]}), encoding="utf-8")
+    unknown_layer = _pages(inventory.build_inventory(docs, evidence))["module.md"]
+    assert unknown_layer["evidence"]["receipt_status"] == "invalid"
+
+    evidence.write_text(json.dumps({"pages": [malformed_value]}), encoding="utf-8")
+    bad_value = _pages(inventory.build_inventory(docs, evidence))["module.md"]
+    assert bad_value["evidence"]["receipt_status"] == "invalid"
+
+    for bad_disposition in ([], {}):
+        evidence.write_text(
+            json.dumps({"pages": [_receipt(docs, "module.md", disposition=bad_disposition)]}),
+            encoding="utf-8",
+        )
+        bad_receipt = _pages(inventory.build_inventory(docs, evidence))["module.md"]
+        assert bad_receipt["evidence"]["receipt_status"] == "invalid"
+
+
+def test_missing_docs_root_is_an_explicit_cli_error(tmp_path: Path, capsys) -> None:
+    missing = tmp_path / "does-not-exist"
+    assert inventory.main(["--docs-root", str(missing)]) == 2
+    report = json.loads(capsys.readouterr().out)
+    assert report["errors"] == ["docs_root does not exist or is not a directory"]
+    assert report["pages"] == []


### PR DESCRIPTION
Adds a read-only inventory CLI for #2273 and the complete upgrade epic #2272. It enumerates every Markdown/MDX page with a content digest, EN/UK counterpart, type, section and explicit route declaration. Optional evidence receipts are schema/digest checked; missing, malformed, duplicate or stale receipts cannot carry passing statuses. Supplied receipt assertions are explicitly distinguished from independently verified truth.

The baseline run found 1,639 pages (1,083 EN, 556 UK), 527 missing UK counterparts and no orphan UK paths. With no receipts supplied, all 1,639 pages correctly remain unreviewed. The full generated JSON stays outside version control and can be reproduced with the documented command; route rendering and content truth are not evaluated by this tool.

Validation: seven targeted adversarial tests pass; project-venv Ruff passes; all 176 curriculum pipeline tests pass; staged diff check passes. Three files, 459 added lines, within this issue's explicit 500-line budget. No published content or Astro config changes, so a site build is not applicable. Gemini's second-round review approved after reference-validation semantics and duplicate diagnostics were corrected. Review output is posted separately.

This PR implements the inventory mechanism. It does not mark any content page accepted, certify receipt claims, or complete the overall upgrade.
