### PR TITLE
fix(quality): separate citation backfill from source acceptance (#2305)

### DIFF
--- a/scripts/quality/pipeline.py
+++ b/scripts/quality/pipeline.py
@@ -26,21 +26,23 @@ scripts can detect issues), 3 when aborted by dispatcher unavailability.
 from __future__ import annotations
 
 import argparse
+import logging
 import re
 import sys
 from collections import Counter
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
-from . import density, queue, state, stages
+from . import density, queue, stages, state
 from .dispatchers import DispatcherUnavailable
 from .prompts import assert_required_docs_exist
-from .worktree import has_uncommitted, primary_checkout_root
 from .queue import set_citations_verified_frontmatter
-
+from .worktree import has_uncommitted, primary_checkout_root
 
 _REPO_ROOT = primary_checkout_root(Path(__file__).resolve().parents[2])
 _CONTENT_ROOT = _REPO_ROOT / "src" / "content" / "docs"
+logger = logging.getLogger(__name__)
 
 WORKER_CAP = 3
 """Hard cap per project memory ``feedback_batch_worker_cap.md`` —
@@ -369,6 +371,7 @@ def _process_batch(
             aborted = True
             return ok, fail, aborted
         except Exception as exc:  # pragma: no cover — unexpected failures logged
+            logger.exception("quality batch item failed for %s", slug)
             print(f"[fail] {slug}: {exc}")
             fail += 1
     return ok, fail, aborted
@@ -433,8 +436,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         )
         return 2
 
-    if args.workers < 1:
-        args.workers = 1
+    args.workers = max(args.workers, 1)
     if args.workers > WORKER_CAP:
         print(f"[warn] --workers clamped from {args.workers} to {WORKER_CAP}")
         args.workers = WORKER_CAP
@@ -492,6 +494,7 @@ def _run_one_with_abort(slug: str) -> str:
         print(f"[abort] dispatcher unavailable at {slug}: {exc}")
         return "abort"
     except Exception as exc:
+        logger.exception("quality module run failed for %s", slug)
         print(f"[fail] {slug}: {exc}")
         _print_failure_diagnostics(slug)
         return "fail"
@@ -510,6 +513,7 @@ def _print_failure_diagnostics(slug: str) -> None:
     try:
         st = state.load_state(slug)
     except Exception as exc:  # pragma: no cover — display path
+        logger.exception("could not load failure state for %s", slug)
         print(f"        (could not read state: {exc})")
         return
     if st is None:
@@ -559,6 +563,14 @@ def cmd_run_module(args: argparse.Namespace) -> int:
 
 _CITATION_BACKFILL_SCRIPT = _REPO_ROOT / "scripts" / "citation_backfill.py"
 _VENV_PYTHON = str(_REPO_ROOT / ".venv" / "bin" / "python")
+
+# The v2 backfill seam records processing completion, but it does not have a
+# durable claim/source verification receipt.  Keep that readiness distinction
+# explicit: an injection (or no-op) never earns the frontmatter bit.
+_SOURCE_UNVERIFIED = {
+    "source_acceptance": "unverified",
+    "readiness_impact": "not_cleared_until_independent_source_evidence",
+}
 
 
 def _module_key_from_path(module_path: str) -> str:
@@ -618,8 +630,9 @@ def _backfill_one(st: dict[str, Any], *, agent: str | None) -> dict[str, Any]:
 
     Returns the outcome dict to be persisted to ``state.backfill``. On
     success, the working module file may have been edited and a new
-    commit added on ``main``; on failure, leaves the worktree clean
-    (``git restore`` rolls back any partial inject write).
+    commit added on ``main``; this does not establish source acceptance.
+    On failure, leaves the worktree clean (``git restore`` rolls back any
+    partial inject write).
     """
     slug = st["slug"]
     module_key = _module_key_from_path(st["module_path"])
@@ -656,11 +669,13 @@ def _backfill_one(st: dict[str, Any], *, agent: str | None) -> dict[str, Any]:
 
     inject = _run_citation_subcommand(module_key, "inject", agent=agent)
     if not inject["ok"]:
-        # `nothing_to_do` means verification ran but there were no
-        # actionable citation changes; for backfill, this is a success
-        # path (frontmatter can still be marked verified).
+        # `nothing_to_do` means injection found no actionable citation
+        # changes; for backfill, this remains a
+        # processing-complete path, but it is not source acceptance.
         if inject.get("error") == "nothing_to_do" or "nothing_to_do" in (inject.get("stdout") or ""):
-            set_citations_verified_frontmatter(_REPO_ROOT / st["module_path"], verified=True)
+            # A pre-existing true bit is not evidence this run can inherit.
+            # Remove it so readiness fails closed after this pipeline pass.
+            set_citations_verified_frontmatter(_REPO_ROOT / st["module_path"], verified=False)
             rc, status_all, _ = _git(repo, "status", "--porcelain", check=False)
             if rc != 0:
                 _git(repo, "restore", st["module_path"], check=False)
@@ -691,9 +706,10 @@ def _backfill_one(st: dict[str, Any], *, agent: str | None) -> dict[str, Any]:
                 return {
                     "done": True, "ok": True, "no_op": True,
                     "reason": "nothing_to_do", "module_key": module_key,
+                    **_SOURCE_UNVERIFIED,
                 }
             _git(repo, "add", *backfill_paths)
-            msg = f"chore(citations): mark {module_key} verified (no-op backfill)"
+            msg = f"chore(citations): record {module_key} backfill no-op"
             rc, _, stderr = _git(repo, "commit", "-m", msg, check=False)
             if rc != 0:
                 for p in backfill_paths:
@@ -709,6 +725,7 @@ def _backfill_one(st: dict[str, Any], *, agent: str | None) -> dict[str, Any]:
                 "done": True, "ok": True, "no_op": True,
                 "reason": "nothing_to_do", "sha": (sha.strip() if sha else None),
                 "module_key": module_key,
+                **_SOURCE_UNVERIFIED,
             }
         # Best-effort: discard any partial write so primary stays clean.
         _git(repo, "restore", st["module_path"], check=False)
@@ -718,10 +735,9 @@ def _backfill_one(st: dict[str, Any], *, agent: str | None) -> dict[str, Any]:
             "error": (inject["stderr"] or inject["stdout"])[-500:],
             "module_key": module_key,
         }
-    # A4 prereq #1: backfill success (including no-op inject) means
-    # citations were verified for readiness purposes, so mark as verified
-    # in frontmatter.
-    set_citations_verified_frontmatter(_REPO_ROOT / st["module_path"], verified=True)
+    # Injection completion is not claim/source verification.  Remove any
+    # inherited bit so this unsupported mutation cannot promote readiness.
+    set_citations_verified_frontmatter(_REPO_ROOT / st["module_path"], verified=False)
 
     # The research step writes (or refreshes) the seed JSON; both
     # artifacts (module + seed) must land in the same commit so the
@@ -759,7 +775,7 @@ def _backfill_one(st: dict[str, Any], *, agent: str | None) -> dict[str, Any]:
         # Mark as done — backfill considered complete for this module.
         return {
             "done": True, "ok": True, "no_op": True,
-            "module_key": module_key,
+            "module_key": module_key, **_SOURCE_UNVERIFIED,
         }
 
     _git(repo, "add", *backfill_paths)
@@ -782,7 +798,7 @@ def _backfill_one(st: dict[str, Any], *, agent: str | None) -> dict[str, Any]:
     _, sha, _ = _git(repo, "rev-parse", "HEAD")
     return {
         "done": True, "ok": True, "sha": sha.strip(),
-        "module_key": module_key,
+        "module_key": module_key, **_SOURCE_UNVERIFIED,
     }
 
 
@@ -830,7 +846,10 @@ def cmd_backfill_pending(args: argparse.Namespace) -> int:
                 "at": state.now_iso(),
                 "stage": current["stage"],
                 "note": (
-                    "backfill done" if outcome.get("ok") and not outcome.get("no_op")
+                    "backfill done; source acceptance unverified"
+                    if outcome.get("ok") and not outcome.get("no_op")
+                    else "backfill no-op; source acceptance unverified"
+                    if outcome.get("no_op") and outcome.get("source_acceptance") == "unverified"
                     else "backfill no-op" if outcome.get("no_op")
                     else f"backfill failed: {outcome.get('stage_failed') or 'unknown'}"
                 ),
@@ -1001,6 +1020,7 @@ def _cleanup_banner_for_module(
         )
         return True
     except Exception:
+        logger.exception("banner cleanup failed for %s", slug)
         return False
 
 

--- a/scripts/quality/queue.py
+++ b/scripts/quality/queue.py
@@ -424,12 +424,13 @@ def set_citations_verified_frontmatter(module_path: Path, verified: bool = True)
         verified: if True, sets ``citations_verified: true``.
             If False, removes the key entirely (absent = not verified).
 
-    Called from ``_backfill_one`` after inject. The contract is:
+    ``_backfill_one`` does not establish claim/source verification:
 
-    * inject success → verified=True (citations were written)
-    * inject nothing_to_do → verified=True (verification ran, nothing to
-      verify)
-    * inject failure → not called (key stays absent)
+    * inject success or nothing_to_do → verified=False (remove inherited key)
+    * inject failure → not called (the caller restores partial file changes)
+
+    Setting the key to True requires independent source evidence; this helper
+    only mutates frontmatter and does not validate that evidence.
     """
     text = module_path.read_text(encoding="utf-8")
     fm = _FRONTMATTER_RE.match(text)
@@ -494,23 +495,23 @@ def queue_summary() -> dict[str, Any]:
 
 
 __all__ = [
-    "PRIMARY_BEGINNER",
-    "PRIMARY_ADVANCED",
-    "TERTIARY",
-    "MAX_PRIMARY_ATTEMPTS",
     "BACKOFF_SECONDS",
+    "MAX_PRIMARY_ATTEMPTS",
+    "PRIMARY_ADVANCED",
+    "PRIMARY_BEGINNER",
+    "TERTIARY",
     "ClaimResult",
-    "route_writer",
-    "model_to_agent",
-    "ensure_queued",
     "claim",
+    "clear_qa_pending_frontmatter",
+    "clear_revision_pending_frontmatter",
+    "ensure_queued",
+    "model_to_agent",
+    "queue_summary",
     "record_attempt_start",
     "record_block",
     "record_completion",
-    "queue_summary",
-    "set_revision_pending_frontmatter",
-    "clear_revision_pending_frontmatter",
-    "set_qa_pending_frontmatter",
-    "clear_qa_pending_frontmatter",
+    "route_writer",
     "set_citations_verified_frontmatter",
+    "set_qa_pending_frontmatter",
+    "set_revision_pending_frontmatter",
 ]

--- a/tests/test_quality_stages.py
+++ b/tests/test_quality_stages.py
@@ -25,13 +25,12 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
-import citation_backfill  # noqa: E402
-
-from scripts.quality import dispatchers, pipeline, stages, state, worktree  # noqa: E402
-from scripts.quality.citations import CitationResult  # noqa: E402
-from scripts.quality.dispatchers import DispatchResult  # noqa: E402
+import citation_backfill
 from conftest import _read_frontmatter
 
+from scripts.quality import dispatchers, pipeline, stages, state, worktree
+from scripts.quality.citations import CitationResult
+from scripts.quality.dispatchers import DispatchResult
 
 # ---- fixtures ---------------------------------------------------------
 
@@ -970,7 +969,8 @@ def test_cleanup_only_no_changes_ends_at_skipped_without_merge(fake_repo, monkey
     import subprocess as _sp
     branch = worktree.branch_name(slug)
     rc = _sp.run(
-        ["git", "rev-parse", "--verify", branch], cwd=fake_repo, capture_output=True
+        ["git", "rev-parse", "--verify", branch], cwd=fake_repo, capture_output=True,
+        check=False,
     ).returncode
     assert rc != 0, "branch should be cleaned up"
 
@@ -1064,7 +1064,8 @@ def test_failed_modules_have_branches_cleaned_up(fake_repo, monkeypatch):
     import subprocess as _sp
     branch = worktree.branch_name(slug)
     rc = _sp.run(
-        ["git", "rev-parse", "--verify", branch], cwd=fake_repo, capture_output=True
+        ["git", "rev-parse", "--verify", branch], cwd=fake_repo, capture_output=True,
+        check=False,
     ).returncode
     assert rc != 0, "FAILED module must not leak its branch"
     # Worktree gone.
@@ -1254,7 +1255,7 @@ Better scenario question.
     assert not worktree.worktree_dir(fake_repo, slug).exists()
     rc = subprocess.run(
         ["git", "rev-parse", "--verify", worktree.branch_name(slug)],
-        cwd=fake_repo, capture_output=True,
+        cwd=fake_repo, capture_output=True, check=False,
     ).returncode
     assert rc != 0, "branch must be deleted after gate fail"
 
@@ -1306,7 +1307,7 @@ def test_cleanup_only_scrubs_worktree_when_state_file_disappears(fake_repo, monk
     import subprocess as _sp
     rc = _sp.run(
         ["git", "rev-parse", "--verify", worktree.branch_name(slug)],
-        cwd=fake_repo, capture_output=True,
+        cwd=fake_repo, capture_output=True, check=False,
     ).returncode
     assert rc != 0, "cleanup-only branch must not leak when state file vanishes"
 
@@ -1356,7 +1357,7 @@ def test_cleanup_only_removes_worktree_when_lease_raises_after_create(fake_repo,
     import subprocess as _sp
     rc = _sp.run(
         ["git", "rev-parse", "--verify", worktree.branch_name(slug)],
-        cwd=fake_repo, capture_output=True,
+        cwd=fake_repo, capture_output=True, check=False,
     ).returncode
     assert rc != 0, "cleanup-only branch must not leak on post-write lease failure"
 
@@ -1400,7 +1401,7 @@ def test_cleanup_only_scrubs_worktree_when_create_worktree_raises_after_creation
     )
     rc = subprocess.run(
         ["git", "rev-parse", "--verify", worktree.branch_name(slug)],
-        cwd=fake_repo, capture_output=True,
+        cwd=fake_repo, capture_output=True, check=False,
     ).returncode
     assert rc != 0, "round-5: throwaway branch must not leak"
 
@@ -1448,7 +1449,7 @@ def test_cleanup_only_removes_worktree_when_write_text_raises(fake_repo, monkeyp
     import subprocess as _sp
     rc = _sp.run(
         ["git", "rev-parse", "--verify", worktree.branch_name(slug)],
-        cwd=fake_repo, capture_output=True,
+        cwd=fake_repo, capture_output=True, check=False,
     ).returncode
     assert rc != 0, "cleanup-only branch must not leak on write_text failure"
 
@@ -1519,7 +1520,8 @@ def test_write_cleanup_even_when_commit_fails(fake_repo, monkeypatch):
     import subprocess as _sp
     branch = worktree.branch_name(slug)
     rc = _sp.run(
-        ["git", "rev-parse", "--verify", branch], cwd=fake_repo, capture_output=True
+        ["git", "rev-parse", "--verify", branch], cwd=fake_repo, capture_output=True,
+        check=False,
     ).returncode
     assert rc != 0
 
@@ -1542,6 +1544,21 @@ def _seed_committed_state(fake_repo: Path, monkeypatch) -> tuple[str, dict]:
     return slug, st
 
 
+def _seed_inherited_citation_bit(fake_repo: Path, module_rel: str) -> None:
+    """Give the backfill input a pre-existing bit with no attached receipt."""
+    module_path = fake_repo / module_rel
+    module_path.write_text(
+        module_path.read_text().replace("---\n", "---\ncitations_verified: true\n", 1)
+    )
+    subprocess.run(["git", "add", module_rel], cwd=fake_repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "seed inherited citation bit"],
+        cwd=fake_repo,
+        check=True,
+        capture_output=True,
+    )
+
+
 def test_backfill_pending_happy_path_records_done_and_commits(fake_repo, monkeypatch):
     """When research + inject both succeed and inject modifies the file,
     cmd_backfill_pending stamps state.backfill={done, ok, sha} and adds
@@ -1552,6 +1569,7 @@ def test_backfill_pending_happy_path_records_done_and_commits(fake_repo, monkeyp
     slug, st = _seed_committed_state(fake_repo, monkeypatch)
 
     module_rel = st["module_path"]
+    _seed_inherited_citation_bit(fake_repo, module_rel)
     sources_block = "\n## Sources\n\n- [Test](https://example.com) — example citation.\n"
 
     def fake_subcmd(module_key, sub, *, agent=None):
@@ -1573,9 +1591,12 @@ def test_backfill_pending_happy_path_records_done_and_commits(fake_repo, monkeyp
     bf = st2["backfill"]
     assert bf["done"] is True and bf["ok"] is True
     assert bf["sha"] and len(bf["sha"]) == 40
+    assert bf["source_acceptance"] == "unverified"
+    assert bf["readiness_impact"] == "not_cleared_until_independent_source_evidence"
     # Module file on disk has the Sources section.
     assert "## Sources" in (fake_repo / module_rel).read_text()
-    assert _read_frontmatter(fake_repo / module_rel)["citations_verified"] is True
+    assert _read_frontmatter(fake_repo / module_rel).get("citations_verified") is None
+    assert "source acceptance unverified" in st2["history"][-1]["note"]
     # Stage is still COMMITTED — backfill is a metadata layer, not a stage.
     assert st2["stage"] == "COMMITTED"
     # Re-running is a no-op (filtered out by backfill.done).
@@ -1603,7 +1624,7 @@ def test_backfill_pending_research_failure_records_error_no_commit(fake_repo, mo
     state.backfill.done=False, and NOT touch the working tree. Repeating
     the command will retry (because done=False), which is the desired
     behavior for transient LLM failures."""
-    slug, st = _seed_committed_state(fake_repo, monkeypatch)
+    slug, _st = _seed_committed_state(fake_repo, monkeypatch)
 
     head_before = subprocess.run(
         ["git", "rev-parse", "HEAD"], cwd=fake_repo, check=True, capture_output=True, text=True,
@@ -1638,7 +1659,7 @@ def test_backfill_pending_commits_seed_alongside_module(fake_repo, monkeypatch):
     in the same backfill commit so the provenance is traceable in git
     history (matches the prior pipeline_v3 convention from commit ec20ddef).
     """
-    slug, st = _seed_committed_state(fake_repo, monkeypatch)
+    _slug, st = _seed_committed_state(fake_repo, monkeypatch)
     module_rel = st["module_path"]
     module_key = pipeline._module_key_from_path(module_rel)
     seed_rel = f"docs/citation-seeds/{module_key.replace('/', '-')}.json"
@@ -1653,7 +1674,7 @@ def test_backfill_pending_commits_seed_alongside_module(fake_repo, monkeypatch):
 
     def fake_subcmd(mk, sub, *, agent=None):
         if sub == "research":
-            seed_path.write_text('{"module_key": "%s", "claims": []}\n' % mk)
+            seed_path.write_text(f'{{"module_key": "{mk}", "claims": []}}\n')
             return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
         target = fake_repo / module_rel
         target.write_text(target.read_text() + "\n## Sources\n\n- [Test](https://example.com).\n")
@@ -1706,9 +1727,9 @@ def test_backfill_pending_refuses_when_foreign_changes_appear(fake_repo, monkeyp
 
 
 def test_backfill_pending_inject_nothing_to_do_marks_done(fake_repo, monkeypatch):
-    """Inject returns production `nothing_to_do` → mark done=True, ok=True,
-    no_op=True, reason=nothing_to_do and write citations_verified=true."""
+    """A no-op completes processing but cannot promote source acceptance."""
     slug, st = _seed_committed_state(fake_repo, monkeypatch)
+    _seed_inherited_citation_bit(fake_repo, st["module_path"])
 
     def fake_subcmd(module_key, sub, *, agent=None):
         if sub == "research":
@@ -1733,14 +1754,17 @@ def test_backfill_pending_inject_nothing_to_do_marks_done(fake_repo, monkeypatch
     assert bf["done"] is True and bf["ok"] is True and bf.get("no_op") is True
     assert bf.get("reason") == "nothing_to_do"
     assert bf.get("sha") is None or len(bf["sha"]) == 40
-    assert _read_frontmatter(fake_repo / st["module_path"])["citations_verified"] is True
+    assert bf["source_acceptance"] == "unverified"
+    assert bf["readiness_impact"] == "not_cleared_until_independent_source_evidence"
+    assert _read_frontmatter(fake_repo / st["module_path"]).get("citations_verified") is None
 
 
 def test_backfill_pending_inject_nothing_to_do_includes_seed_in_commit(fake_repo, monkeypatch):
     """When inject is no-op after research changed the seed, both module and
     seed must be committed so the checkout stays clean."""
-    slug, st = _seed_committed_state(fake_repo, monkeypatch)
+    _slug, st = _seed_committed_state(fake_repo, monkeypatch)
     module_rel = st["module_path"]
+    _seed_inherited_citation_bit(fake_repo, module_rel)
     module_key = pipeline._module_key_from_path(module_rel)
     seed_rel = f"docs/citation-seeds/{module_key.replace('/', '-')}.json"
     seed_path = fake_repo / seed_rel


### PR DESCRIPTION
Citation backfill previously marked a page's citations verified after injection succeeded or reported nothing to do. For #2305, these outcomes now complete processing while explicitly recording source acceptance as unverified; they remove any inherited citations_verified flag instead of promoting readiness. Tests start with an inherited true flag and verify its removal while preserving commit, no-op and retry behavior.

This is the first fail-closed boundary fix under #2274. It does not establish a revision-bound source-verification receipt or claim that an aggregate verifier result is sufficient. No live backfill or provider call was run by the validation suite.

The helper documentation now states the same source-acceptance boundary. The mandatory full-file lint gate also required minimal baseline cleanup in the three affected files. Broad exception boundaries and existing return/console behavior remain, with exception logging added; imports, worker clamping, export ordering and explicit subprocess check=False probes were normalized without weakening assertions or rules.

Validation: full venv Ruff on all three changed Python files, 57 focused quality/backfill tests, all 176 pipeline tests, and git diff --check pass. Three files, +102/-57 (159 aggregate changed lines). No published content or Astro configuration changes, so a site build is not applicable. Generated test review state is excluded; local reviewer patch artifacts are not staged.

Independent-family review and final CI evidence are posted separately. This PR fixes an unsupported status promotion; it does not certify any module's factual claims.
