### PR TITLE
docs(quality): align narrative guidance and rubric (#2313)

### DIFF
--- a/.claude/rules/module-quality.md
+++ b/.claude/rules/module-quality.md
@@ -9,7 +9,7 @@ paths:
 ## Required Sections (in order)
 1. Title + metadata (complexity, time, prerequisites)
 2. Learning Outcomes — 3-5 measurable outcomes using Bloom's L3+ verbs (debug, design, evaluate, compare)
-3. Why This Module Matters — dramatic real-world opening (third person)
+3. Why This Module Matters — clear motivation and practical relevance; use a documented incident or explicitly labeled scenario only when it helps
 4. Core content (3-6 sections with code, ASCII diagrams, tables, inline active learning prompts)
 5. Did You Know? — exactly 4 facts
 6. Common Mistakes — table with 6-8 rows
@@ -59,3 +59,4 @@ paths:
 - Do NOT repeat the number 47 (known LLM pattern)
 - Do NOT use emojis
 - Do NOT write "list of facts" modules — if sections are just bullets, it's a reference doc, not a lesson
+- Stories and analogies are optional: real incidents require verifiable citations, hypothetical examples explicit labels, and analogies a clear mapping and limits. Do not manufacture mystery, clue hunts, or gamification to satisfy an engagement checklist.

--- a/.claude/skills/module-quality-reviewer/SKILL.md
+++ b/.claude/skills/module-quality-reviewer/SKILL.md
@@ -37,7 +37,7 @@ Every PR must be reviewed by a different model family than the author per [`docs
 | **Learning Outcomes** | Are they stated? Measurable? Bloom's L3+? |
 | **Scaffolding** | Does content build simple→complex? Narrative bridges between sections? |
 | **Active Learning** | Are there inline prompts? Or is all practice back-loaded to the end? |
-| **Real-World Connection** | War stories with specific details? Or generic "in production" handwaving? |
+| **Real-World Connection** | Concrete, evidence-backed context, consequences, tradeoffs, or diagnosis? Or generic "in production" handwaving? |
 | **Assessment Alignment** | Do quiz questions test understanding (scenarios) or recall (what is X?)? |
 | **Cognitive Load** | Well-chunked? Diagrams integrated? Or information dump? |
 | **Engagement** | Memorable tone? Would you recommend this to a colleague? Or dry/robotic? |
@@ -45,7 +45,7 @@ Every PR must be reviewed by a different model family than the author per [`docs
 ## Structure Checklist
 
 - [ ] Learning Outcomes (Bloom's L3+ verbs: debug, design, evaluate)
-- [ ] Why This Module Matters (war story with real impact)
+- [ ] Why This Module Matters (clear motivation and practical relevance; any incident or scenario is cited or explicitly labeled `Hypothetical scenario:`/`Exercise scenario:`/`Simulation:`)
 - [ ] Core content (3-6 sections with code, diagrams, tables)
 - [ ] Inline active learning (at least 2 prediction/try-it prompts in the body)
 - [ ] Did You Know? (4 facts with real numbers)
@@ -53,6 +53,8 @@ Every PR must be reviewed by a different model family than the author per [`docs
 - [ ] Quiz (6-8 scenario-based questions with `<details>` answers)
 - [ ] Hands-On Exercise (multi-step with success criteria)
 - [ ] Next Module link
+
+Do not penalize a module solely for omitting a story or analogy. When used, verify the incident's source, the hypothetical scenario's explicit label, and the analogy's mapping and limits. A labeled simulation illustrates a concept; it is not evidence that an incident occurred or a learner improved. Engagement scores are editorial judgments, not measured learner outcomes.
 
 > **Reviewer bar ≥ author template.** [[curriculum-writer]]'s minimal template lists 2-3 Did You Know? / 4 quiz questions; this reviewer checklist is the stricter shipping bar. Author for the reviewer bar, not the template floor.
 
@@ -110,6 +112,7 @@ Every PR must be reviewed by a different model family than the author per [`docs
 - "Refer to official documentation for details"
 - Sections that could be rearranged in any order without losing coherence
 - Unverified external citations (a hard-flag, not a soft-flag — see [[feedback_citation_verify_or_remove]])
+- Unsourced incidents presented as facts or anonymous “authentic” details treated as evidence
 - Personal-life framing (interview/job/role narrative — [[feedback_no_personal_framing]])
 - Listicle dumps without teaching arc ([[feedback_teaching_not_listicles]])
 

--- a/agents_extensions/shared/skills/module-quality-reviewer/SKILL.md
+++ b/agents_extensions/shared/skills/module-quality-reviewer/SKILL.md
@@ -37,7 +37,7 @@ Every PR must be reviewed by a different model family than the author per [`docs
 | **Learning Outcomes** | Are they stated? Measurable? Bloom's L3+? |
 | **Scaffolding** | Does content build simple→complex? Narrative bridges between sections? |
 | **Active Learning** | Are there inline prompts? Or is all practice back-loaded to the end? |
-| **Real-World Connection** | War stories with specific details? Or generic "in production" handwaving? |
+| **Real-World Connection** | Concrete, evidence-backed context, consequences, tradeoffs, or diagnosis? Or generic "in production" handwaving? |
 | **Assessment Alignment** | Do quiz questions test understanding (scenarios) or recall (what is X?)? |
 | **Cognitive Load** | Well-chunked? Diagrams integrated? Or information dump? |
 | **Engagement** | Memorable tone? Would you recommend this to a colleague? Or dry/robotic? |
@@ -45,7 +45,7 @@ Every PR must be reviewed by a different model family than the author per [`docs
 ## Structure Checklist
 
 - [ ] Learning Outcomes (Bloom's L3+ verbs: debug, design, evaluate)
-- [ ] Why This Module Matters (war story with real impact)
+- [ ] Why This Module Matters (clear motivation and practical relevance; any incident or scenario is cited or explicitly labeled `Hypothetical scenario:`/`Exercise scenario:`/`Simulation:`)
 - [ ] Core content (3-6 sections with code, diagrams, tables)
 - [ ] Inline active learning (at least 2 prediction/try-it prompts in the body)
 - [ ] Did You Know? (4 facts with real numbers)
@@ -53,6 +53,8 @@ Every PR must be reviewed by a different model family than the author per [`docs
 - [ ] Quiz (6-8 scenario-based questions with `<details>` answers)
 - [ ] Hands-On Exercise (multi-step with success criteria)
 - [ ] Next Module link
+
+Do not penalize a module solely for omitting a story or analogy. When used, verify the incident's source, the hypothetical scenario's explicit label, and the analogy's mapping and limits. A labeled simulation illustrates a concept; it is not evidence that an incident occurred or a learner improved. Engagement scores are editorial judgments, not measured learner outcomes.
 
 > **Reviewer bar ≥ author template.** [[curriculum-writer]]'s minimal template lists 2-3 Did You Know? / 4 quiz questions; this reviewer checklist is the stricter shipping bar. Author for the reviewer bar, not the template floor.
 
@@ -110,6 +112,7 @@ Every PR must be reviewed by a different model family than the author per [`docs
 - "Refer to official documentation for details"
 - Sections that could be rearranged in any order without losing coherence
 - Unverified external citations (a hard-flag, not a soft-flag — see [[feedback_citation_verify_or_remove]])
+- Unsourced incidents presented as facts or anonymous “authentic” details treated as evidence
 - Personal-life framing (interview/job/role narrative — [[feedback_no_personal_framing]])
 - Listicle dumps without teaching arc ([[feedback_teaching_not_listicles]])
 

--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -88,10 +88,10 @@ follow-up, not silently re-tiered. Locked via #2141 / #2146 / #2181 / #2187 / #2
 | Score | Description |
 |-------|-------------|
 | **1** | No real-world context. Pure theory or command reference. |
-| **2** | Mentions "in production" but no specific examples or stories. |
-| **3** | Has "Did You Know?" or equivalent. Some real numbers/dates. Generic examples. |
-| **4** | Has war stories with specific (anonymized) companies, financial impact, timeline. "Why This Matters" section opens with a real incident. Common Mistakes table with production-relevant pitfalls. |
-| **5** | Real-world context is integrated throughout, not just in designated sections. Examples use realistic scenarios. Trade-offs are discussed honestly. Reader feels why this matters viscerally. |
+| **2** | Mentions "in production" but gives no concrete context, consequence, or tradeoff. |
+| **3** | Connects the concept to a concrete use case, consequence, or decision; examples may remain generic. |
+| **4** | Explains practical relevance with specific, evidence-backed context, consequences, failure modes, or tradeoffs; common mistakes are tied to realistic decisions. |
+| **5** | Integrates practical context throughout with accurate, bounded examples, competing tradeoffs, and decision guidance; the explanation makes when and why the concept matters clear. |
 
 ### Dimension 5: Assessment Alignment
 
@@ -117,11 +117,11 @@ follow-up, not silently re-tiered. Locked via #2141 / #2146 / #2181 / #2187 / #2
 
 | Score | Description |
 |-------|-------------|
-| **1** | Dry, robotic tone. No hook. Reader would close the tab. |
-| **2** | Functional but boring. Gets the job done but nothing memorable. |
-| **3** | Some personality. "Why This Matters" section present. Analogies used occasionally. |
-| **4** | Conversational, authoritative tone. Strong opening hook. Good analogies. "Did You Know?" facts are genuinely interesting. Reader feels mentored by a senior engineer. |
-| **5** | Memorable. Reader would recommend this module to a colleague. Stories stick. Analogies are vivid and accurate. Humor used sparingly but effectively. Reader feels they understand the topic at a level they couldn't get from official docs. |
+| **1** | Tone or organization obstructs learning; prose is confusing or inaccessible. |
+| **2** | Functional but flat or inconsistent; explanations are readable but weakly signposted. |
+| **3** | Clear, respectful tone with purposeful signposting and examples; engagement comes from relevance and active practice. |
+| **4** | Conversational, authoritative, well-paced explanation with precise examples and useful emphasis; optional devices, when used, are accurate and restrained. |
+| **5** | Memorable through exceptional clarity, cohesion, and usefulness; examples and emphasis deepen the explanation without relying on stories, analogies, humor, mystery, or gamification. |
 
 ### Dimension 8: Practitioner Depth (complexity-scaled)
 

--- a/scripts/prompts/module-writer.md
+++ b/scripts/prompts/module-writer.md
@@ -35,14 +35,14 @@ TASK: Write a complete KubeDojo educational module.
 
 1. **Frontmatter and metadata blockquote** — frontmatter `title:` + `slug:` + `sidebar.order:` (Starlight renders the page H1 from `title:`, so do NOT add a source `# Module X.Y` heading after the frontmatter — this would render as a duplicate visible title). Then a blockquote with `> **Complexity**: ...`, `> **Time to Complete**: ...`, `> **Prerequisites**: ...`, separated by `>` blank-quote lines, terminated with `---`.
 2. **Learning Outcomes** — 3-5 measurable outcomes using Bloom's Taxonomy Level 3+ action verbs: "debug", "design", "evaluate", "compare", "diagnose", "implement". NOT "understand" or "know". Each outcome must be testable by the quiz or exercise.
-3. **Why This Module Matters** — Open with a concrete scenario that makes the operational stakes clear, then transition to what the learner will build or diagnose. Use a real incident only when it is sourced and specific enough to verify. Otherwise label it explicitly with `Hypothetical scenario:` or `Exercise scenario:` so the reader never mistakes invented framing for a real event. 2-3 paragraphs minimum.
+3. **Why This Module Matters** — Open with a clear explanation of why the topic matters and what the learner will build or diagnose. Use a sourced incident or explicitly labeled `Hypothetical scenario:`/`Exercise scenario:` only when it clarifies the outcome. 2-3 paragraphs minimum.
 4. **Core content sections** (3-6 sections) — Each section should include:
    - **Theory before practice** — explain WHY this approach exists, what problem it solves, and what tradeoffs it makes BEFORE showing the commands. Prose must explain concepts between code blocks — never stack 3 code blocks without explanation.
-   - Clear explanations with analogies (treat the reader as a smart beginner)
+   - Clear explanations for a smart beginner; use an analogy only when it clarifies the outcome and state its limits
    - Runnable code blocks (bash, YAML, Go, Python — whatever fits)
    - ASCII diagrams where architecture or flow needs visualization
    - Tables for comparisons, decision matrices, or reference data
-   - Sourced real incident or clearly labeled hypothetical practical example within the section
+   - Sourced real incident or clearly labeled hypothetical practical example when it materially supports the section; omit it when evidence is insufficient
    - **At least 2 inline active learning prompts** across all sections: "Pause and predict: what do you think happens if...?", "Before running this, what output do you expect?", or "Which approach would you choose here and why?"
    - **Cost lens (cross-cutting)** — If the module covers any cloud service, infrastructure component, or operational practice with a measurable price tag, the core content MUST address the cost dimension. At minimum: (a) what does this cost in production at moderate scale, (b) which knobs reduce cost (rightsizing, scheduling, tiering, autoscaling), (c) what makes cost spike unexpectedly (cross-AZ traffic, idle resources, log volume, log-retention defaults). Treat "what does it cost" as a first-class engineering concern alongside "how does it work." Skip only for pure-theory modules (mental models, philosophy, prerequisite concepts) where no cost surface exists.
 5. **Patterns & Anti-Patterns** — Required for `[MEDIUM]`, `[COMPLEX]`, `[ADVANCED]`, `[EXPERT]` modules. For `[QUICK]` introductory modules, this can be a single "When This Doesn't Apply" subsection instead of full patterns/anti-patterns.
@@ -69,7 +69,7 @@ TASK: Write a complete KubeDojo educational module.
 **TONE**:
 - Conversational but authoritative — like a senior engineer mentoring you
 - Explain "why" before "what" — motivation before instruction
-- Use analogies from everyday life to explain abstract concepts
+- Use familiar analogies only when they clarify abstract concepts; state where the mapping stops
 - Be direct and practical — no filler, no corporate-speak
 - When discussing tools, be honest about trade-offs (no marketing language)
 
@@ -110,6 +110,7 @@ TASK: Write a complete KubeDojo educational module.
 **WHAT TO AVOID**:
 - Do NOT repeat the number 47 in timestamps, durations, or counts (this is a known LLM pattern — vary your numbers)
 - Do NOT invent business incidents, client stories, anonymized companies, or anecdotal incident claims. Use sourced real incidents or clearly labeled hypothetical/exercise scenarios.
+- Do NOT add a mystery, clue hunt, or gamification layer solely to make a module engaging.
 - Do NOT write thin outlines — every section needs depth, examples, and explanation
 - Do NOT skip the exercise — it's the most important part for learning
 - Do NOT use emojis


### PR DESCRIPTION
The writer and reviewer still demanded stories and analogies after the canonical writing skill made them optional. The rubric also tied passing descriptors to incidents and narrative devices. This patch makes practical relevance, evidence, clear explanations and useful decisions the requirements across those prompts and D4/D7 descriptors.

Real incidents still require support; hypotheticals need labels and analogies need mapping/limits. Scenario-based practice remains. Numerical thresholds, density/word floors, provider routing, other quotas and the separate7/8dimension mismatch are unchanged. No existing module is accepted or rescored.

Validation: 176 pipeline tests passed at the final patch;19 focused prompt tests passed before the final wording clarification; mirror deployment check and deployment-check tests passed; git diff --check clean. No Python, published-content or Astro changes, so local Ruff/build are not applicable. Independent Gemini review approved the exact head; its findings and two ancillary corrections are recorded in the PR comment.

Five files,26insertions/18deletions (44aggregate), within the issue budget. No generated runtime artifacts included. Addresses #2313, parent #2274, epic #2272.
