### PR TITLE
fix(quality): hold pilot merges pending source acceptance (#2316)

### DIFF
--- a/scripts/quality/dispatch_388_pilot.py
+++ b/scripts/quality/dispatch_388_pilot.py
@@ -6,12 +6,17 @@ For each module path in --input (default scripts/quality/pilot-2026-05-02.txt):
   2. Codex (gpt-5.5, mode=danger) rewrites per module-rewriter-388.md,
      runs verifier, commits, pushes, opens PR
   3. Cross-family review on the PR (agy — the Google lane — with claude/qwen fallback)
-  4. APPROVE       -> squash-merge with --delete-branch
+  4. APPROVE       -> retain PR/review and hold for a real source-acceptance receipt
      APPROVE_WITH_NITS -> log + post review; orchestrator triages (C3 fix-up lane)
      NEEDS CHANGES -> log + hold; orchestrator decides (re-dispatch vs inline)
   5. Brief pause; next module
 
 Sequential per item. JSONL log under logs/.
+
+The APPROVE hold is an interim containment measure: this dispatcher does not
+merge or run post-merge citation backfill until a real source-acceptance gate
+is integrated. It does not treat ordinary review, CI, or inherited metadata
+as source evidence.
 """
 from __future__ import annotations
 
@@ -22,9 +27,9 @@ import re
 import subprocess
 import sys
 import time
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable
 
 import yaml
 
@@ -40,13 +45,13 @@ WRITER_BRIEF = REPO / "scripts/prompts/module-writer.md"
 VENV_PYTHON = PRIMARY_REPO / ".venv" / "bin" / "python"
 
 sys.path.insert(0, str(REPO / "scripts"))
-from agent_runtime.runner import invoke  # noqa: E402
-from agent_runtime.errors import (  # noqa: E402
+from agent_runtime.errors import (
     AgentTimeoutError,
     AgentUnavailableError,
     RateLimitedError,
 )
-from lib.pr_merge import PrMergeError, merge_when_green  # noqa: E402
+from agent_runtime.runner import invoke
+from lib.pr_merge import PrMergeError, merge_when_green
 
 
 def module_slug_for_pipeline(module_path: str) -> str:
@@ -72,15 +77,11 @@ def module_slug_for_pipeline(module_path: str) -> str:
 
 def _module_path_for_marker(module_path: str) -> str:
     module = Path(module_path)
-    if module.is_absolute():
-        try:
-            module = module.relative_to(PRIMARY_REPO)
-        except ValueError:
-            module = module
+    if module.is_absolute() and module.is_relative_to(PRIMARY_REPO):
+        module = module.relative_to(PRIMARY_REPO)
     normalized = module.as_posix().replace("\\", "/")
     normalized = normalized.removeprefix("./")
-    if normalized.startswith("/"):
-        normalized = normalized[1:]
+    normalized = normalized.removeprefix("/")
     return normalized
 
 
@@ -106,14 +107,14 @@ def _parse_yaml_queue(queue_text: str) -> list[dict[str, object]]:
     loaded = yaml.safe_load(queue_text) or {}
     entries = loaded.get("queue", loaded) if isinstance(loaded, dict) else loaded
     if not isinstance(entries, list):
-        raise ValueError("YAML dispatch queue must be a dict with a 'queue' list or a list")
+        raise TypeError("YAML dispatch queue must be a dict with a 'queue' list or a list")
     normalized: list[dict[str, object]] = []
     for row in entries:
         if isinstance(row, str):
             normalized.append({"path": row})
             continue
         if not isinstance(row, dict):
-            raise ValueError("YAML dispatch queue entries must be strings or mappings")
+            raise TypeError("YAML dispatch queue entries must be strings or mappings")
         if "path" not in row:
             raise ValueError("YAML dispatch queue entry missing required 'path'")
         normalized.append(row)
@@ -671,13 +672,18 @@ def main(argv: list[str] | None = None) -> int:
         if review_text:
             post_review_comment(pr_num, review_text)
         if verdict == "APPROVE":
-            merge_sha = merge_pr(pr_num)
-            if merge_sha:
-                log({"event": "merged", "pr": pr_num, "module": module_path, "merge_sha": merge_sha})
-                # dispatch_backfill is best-effort and must never block the merge chain.
-                dispatch_backfill(slug, module_path)
-            else:
-                log({"event": "merge_held", "pr": pr_num, "module": module_path, "verdict": "MERGE_FAILED"})
+            log({
+                "event": "source_acceptance_unverified",
+                "pr": pr_num,
+                "module": module_path,
+                "verdict": verdict,
+                "action": "merge_held",
+            })
+            print(
+                f"[source_acceptance_unverified] holding PR #{pr_num} for {module_path}; "
+                "a real source-acceptance receipt gate is required before merge or backfill.",
+                flush=True,
+            )
         elif verdict == "APPROVE_WITH_NITS":
             # C3 fix-up lane: orchestrator triages inline (trivial nits) or
             # re-dispatches codex (semantic). Do NOT auto-merge — the

--- a/tests/test_dispatch_388_pilot.py
+++ b/tests/test_dispatch_388_pilot.py
@@ -111,36 +111,74 @@ def test_dispatch_backfill_backfill_failure_logs_and_continues():
     assert failed["reason"] == "pipeline_failed"
 
 
-def test_main_chain_calls_backfill_after_merge_and_continues_on_failure(tmp_path):
+def test_main_approve_holds_merge_and_backfill_for_all_queued_items(tmp_path, capsys):
     queue = tmp_path / "queue.txt"
     queue.write_text(
-        "\n".join(
-            [
-                "src/content/docs/k8s/cka/module-1.md",
-                "src/content/docs/k8s/cka/module-2.md",
-            ]
-        )
+        "src/content/docs/k8s/cka/module-1.md\n"
+        "src/content/docs/k8s/cka/module-2.md"
     )
     codex_result = MagicMock(ok=True, response="Opened PR: https://github.com/org/repo/pull/42")
+    reviewer = MagicMock(return_value=("VERDICT: APPROVE", "APPROVE"))
+    for name in ("module-1.md", "module-2.md"):
+        module = tmp_path / "src/content/docs/k8s/cka" / name
+        module.parent.mkdir(parents=True, exist_ok=True)
+        module.write_text("---\ncitations_verified: true\nrevision_pending: false\n---\nDraft\n")
 
-    with patch("scripts.quality.dispatch_388_pilot.make_worktree", return_value=tmp_path), \
+    with patch.object(pilot, "REPO", tmp_path), \
+         patch.object(pilot, "PILOT_FILE", queue), \
+         patch.object(pilot, "LOG", tmp_path / "pilot.jsonl"), \
+         patch.object(pilot, "invoke", side_effect=AssertionError("unexpected provider call")), \
+         patch.object(pilot.subprocess, "run", side_effect=AssertionError("unexpected subprocess")), \
+         patch("scripts.quality.dispatch_388_pilot.make_worktree", return_value=tmp_path), \
          patch("scripts.quality.dispatch_388_pilot.dispatch_codex", return_value=codex_result), \
-         patch("scripts.quality.dispatch_388_pilot.dispatch_agy_review", return_value=("VERDICT: APPROVE", "APPROVE")), \
-         patch("scripts.quality.dispatch_388_pilot.merge_pr", return_value="abc123"), \
-         patch("scripts.quality.dispatch_388_pilot.dispatch_backfill", side_effect=[False, True]) as mock_backfill, \
-         patch("scripts.quality.dispatch_388_pilot.post_review_comment"), \
+         patch("scripts.quality.dispatch_388_pilot.build_reviewer_cascade", return_value=[("claude", reviewer)]), \
+         patch("scripts.quality.dispatch_388_pilot.merge_pr", return_value="abc123") as mock_merge, \
+         patch("scripts.quality.dispatch_388_pilot.dispatch_backfill", return_value=True) as mock_backfill, \
+         patch("scripts.quality.dispatch_388_pilot.post_review_comment") as mock_post_review, \
          patch("scripts.quality.dispatch_388_pilot.time.sleep"), \
          patch("scripts.quality.dispatch_388_pilot.log") as mock_log:
         rc = pilot.main(["--input", str(queue)])
 
     assert rc == 0
-    expected_slug_1 = pilot.module_slug_for_pipeline("src/content/docs/k8s/cka/module-1.md")
-    expected_slug_2 = pilot.module_slug_for_pipeline("src/content/docs/k8s/cka/module-2.md")
-    mock_backfill.assert_any_call(expected_slug_1, "src/content/docs/k8s/cka/module-1.md")
-    mock_backfill.assert_any_call(expected_slug_2, "src/content/docs/k8s/cka/module-2.md")
-    assert mock_backfill.call_count == 2
+    assert reviewer.call_count == 2
+    assert mock_post_review.call_count == 2
+    mock_merge.assert_not_called()
+    mock_backfill.assert_not_called()
     events = [c.args[0]["event"] for c in mock_log.call_args_list]
-    assert events.count("merged") == 2
+    assert events.count("source_acceptance_unverified") == 2
+    assert "merged" not in events
+    assert capsys.readouterr().out.count("[source_acceptance_unverified]") == 2
+
+
+@pytest.mark.parametrize(
+    ("verdict", "expected_event"),
+    [
+        ("APPROVE_WITH_NITS", "merge_held_nits"),
+        ("NEEDS CHANGES", "merge_held"),
+    ],
+)
+def test_main_nonapprove_verdicts_remain_held(tmp_path, verdict, expected_event):
+    queue = tmp_path / "queue.txt"
+    queue.write_text("src/content/docs/k8s/cka/module-1.md")
+    codex_result = MagicMock(ok=True, response="Opened PR: https://github.com/org/repo/pull/42")
+    reviewer = MagicMock(return_value=(f"VERDICT: {verdict}", verdict))
+
+    with patch.object(pilot, "invoke", side_effect=AssertionError("unexpected provider call")), \
+         patch.object(pilot.subprocess, "run", side_effect=AssertionError("unexpected subprocess")), \
+         patch("scripts.quality.dispatch_388_pilot.make_worktree", return_value=tmp_path), \
+         patch("scripts.quality.dispatch_388_pilot.dispatch_codex", return_value=codex_result), \
+         patch("scripts.quality.dispatch_388_pilot.build_reviewer_cascade", return_value=[("claude", reviewer)]), \
+         patch("scripts.quality.dispatch_388_pilot.merge_pr") as mock_merge, \
+         patch("scripts.quality.dispatch_388_pilot.dispatch_backfill") as mock_backfill, \
+         patch("scripts.quality.dispatch_388_pilot.post_review_comment"), \
+         patch("scripts.quality.dispatch_388_pilot.time.sleep"), \
+         patch("scripts.quality.dispatch_388_pilot.log") as mock_log:
+        assert pilot.main(["--input", str(queue)]) == 0
+
+    mock_merge.assert_not_called()
+    mock_backfill.assert_not_called()
+    events = [c.args[0]["event"] for c in mock_log.call_args_list]
+    assert expected_event in events
 
 
 def test_slugify_uses_repo_relative_path_not_stem():
@@ -159,9 +197,10 @@ def test_make_worktree_rejects_existing_worktree_for_different_module(tmp_path, 
     worktree.mkdir(parents=True)
     (worktree / ".module_path").write_text("src/content/docs/k8s/cks/module-1.md", encoding="utf-8")
 
-    with patch("scripts.quality.dispatch_388_pilot.subprocess.run"):
-        with pytest.raises(RuntimeError, match="existing worktree"):
-            pilot.make_worktree(slug, "src/content/docs/k8s/cka/module-1.md")
+    with patch("scripts.quality.dispatch_388_pilot.subprocess.run"), pytest.raises(
+        RuntimeError, match="existing worktree"
+    ):
+        pilot.make_worktree(slug, "src/content/docs/k8s/cka/module-1.md")
 
 
 def test_make_worktree_reuses_existing_worktree_for_same_module_and_records_marker(tmp_path, monkeypatch):
@@ -199,12 +238,10 @@ def test_make_worktree_writes_module_path_marker_for_new_tree(tmp_path, monkeypa
 
 
 def test_dispatch_backfill_sha_regex_parses_ok_line():
-    output = "\n".join(
-        [
-            "[no-op] k8s-cka-module-9: already clean",
-            "[ok]    k8s-cka-module-8: deadbeef12",
-            "[ok]    k8s-cka-module-9: c0ffee99",
-        ]
+    output = (
+        "[no-op] k8s-cka-module-9: already clean\n"
+        "[ok]    k8s-cka-module-8: deadbeef12\n"
+        "[ok]    k8s-cka-module-9: c0ffee99"
     )
     match = re.search(r"^\[ok\]\s+k8s-cka-module-8:\s+([0-9a-f]+)", output, re.MULTILINE)
     assert match is not None
@@ -269,13 +306,17 @@ def test_dispatch_agy_review_uses_danger_mode(monkeypatch: pytest.MonkeyPatch) -
         # URL plus a timed-out message; no VERDICT line present.
         (
             True,
-            "Authentication required. Please visit the URL to log in: "
-            "https://accounts.google.com/o/oauth2/auth?...\n"
-            "Error: authentication timed out.",
+            (
+                "Authentication required. Please visit the URL to log in: "
+                "https://accounts.google.com/o/oauth2/auth?...\n"
+                "Error: authentication timed out."
+            ),
             "UNCLEAR",
-            "Authentication required. Please visit the URL to log in: "
-            "https://accounts.google.com/o/oauth2/auth?...\n"
-            "Error: authentication timed out.",
+            (
+                "Authentication required. Please visit the URL to log in: "
+                "https://accounts.google.com/o/oauth2/auth?...\n"
+                "Error: authentication timed out."
+            ),
         ),
     ],
 )


### PR DESCRIPTION
The rewrite pilot could auto-merge after ordinary review/CI and only then run best-effort citation backfill. Its APPROVE branch now retains the PR and review but logs and prints source_acceptance_unverified, without calling merge or post-merge backfill. This is an explicit interim hold until the real source-receipt gate exists.

Other verdict handling and low-level helpers remain. This contains one publisher, not every repository publication path; #2310 owns the complete evidence integration. No receipt, source acceptance or live publication result is fabricated.

Validation:35focused tests across pilot, queue and PR-fallback behavior;176pipeline tests; full Ruff on both changed Python files; git diff --check. Main-loop tests fully mock reviewers and reject escaped provider/subprocess calls, including approved queued items with inherited verified metadata. Existing same-file Ruff findings were fixed; the script is executable to match its shebang. No published content/Astro change, so local build is not applicable. Independent Gemini R2 approved the exact head after correcting R1's branch-tip comparison artifact; both reviews are posted. All CI passed before merge.

Two files,+102/-55 (157aggregate), within budget; no generated artifacts. Addresses #2316, parent #2310/#2274, epic #2272.
