### PR TITLE
fix(citations): bind fetched text to cache provenance (#2321)

### DIFF
--- a/scripts/fetch_citation.py
+++ b/scripts/fetch_citation.py
@@ -19,9 +19,13 @@ Output schema (JSON):
       "content_type": "text/html; charset=utf-8",
       "allowlist_tier": "standards" | ... | null,
       "bytes": 123456,
+      "truncated": false,                  # null on failed fetches
       "text_length": 45678,
+      "text_sha256": "...",                 # exact cached UTF-8 bytes
+      "text_bytes": 45678,
       "text_preview": "first ~400 chars",
       "cached_at": "2026-04-19T...",
+      "fetch_attempt_completed_at": "2026-04-19T...",
       "from_cache": false,
       "issues": []
     }
@@ -44,7 +48,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 try:
     import yaml
@@ -77,7 +81,7 @@ MAX_BYTES = 4 * 1024 * 1024  # 4 MiB ceiling; large PDFs skip text extraction
 class _TextExtractor(html.parser.HTMLParser):
     """Strip script/style, collapse whitespace, emit readable plain text."""
 
-    _SKIP_TAGS = {"script", "style", "noscript", "template", "svg", "iframe"}
+    _SKIP_TAGS: ClassVar[set[str]] = {"script", "style", "noscript", "template", "svg", "iframe"}
 
     def __init__(self) -> None:
         super().__init__(convert_charrefs=True)
@@ -113,7 +117,7 @@ def _html_to_text(body: str) -> str:
         parser.feed(body)
         parser.close()
     except Exception:  # noqa: BLE001 - malformed HTML shouldn't kill us
-        pass
+        return parser.text()
     return parser.text()
 
 
@@ -176,13 +180,13 @@ def _load_cached(url: str) -> dict[str, Any] | None:
     return data
 
 
-def _store_cache(url: str, meta: dict[str, Any], text: str) -> None:
+def _store_cache(url: str, meta: dict[str, Any], text_bytes: bytes) -> None:
     meta_path, text_path = _cache_paths(url)
     meta_path.write_text(
         json.dumps(meta, indent=2, ensure_ascii=False),
         encoding="utf-8",
     )
-    text_path.write_text(text, encoding="utf-8")
+    text_path.write_bytes(text_bytes)
 
 
 def cached_text_path(url: str) -> Path:
@@ -219,7 +223,7 @@ def _fetch_once(url: str, timeout: int) -> tuple[dict[str, Any], bytes]:
         try:
             body = e.read(MAX_BYTES + 1)[:MAX_BYTES]
         except Exception:  # noqa: BLE001
-            pass
+            body = b""
         return {
             "final_url": getattr(e, "url", url) or url,
             "status": int(e.code),
@@ -248,6 +252,7 @@ def fetch(url: str, *, refresh: bool = False, timeout: int = DEFAULT_TIMEOUT) ->
             return cached
 
     meta, body = _fetch_once(url, timeout=timeout)
+    fetch_attempt_completed_at = _dt.datetime.now(_dt.UTC).isoformat(timespec="seconds")
     issues: list[str] = []
     if meta.get("error"):
         issues.append(str(meta["error"]))
@@ -278,6 +283,8 @@ def fetch(url: str, *, refresh: bool = False, timeout: int = DEFAULT_TIMEOUT) ->
     if meta.get("truncated"):
         issues.append("truncated_body")
 
+    text_bytes = text.encode("utf-8")
+
     out = {
         "url": url,
         "final_url": meta.get("final_url", url),
@@ -285,13 +292,17 @@ def fetch(url: str, *, refresh: bool = False, timeout: int = DEFAULT_TIMEOUT) ->
         "content_type": content_type,
         "allowlist_tier": allowlist_tier(meta.get("final_url", url) or url),
         "bytes": int(meta.get("bytes", 0)),
+        "truncated": bool(meta.get("truncated", False)) if 0 < status < 400 else None,
         "text_length": len(text),
+        "text_sha256": hashlib.sha256(text_bytes).hexdigest(),
+        "text_bytes": len(text_bytes),
         "text_preview": text[:400],
         "cached_at": _dt.datetime.now(_dt.UTC).isoformat(timespec="seconds"),
+        "fetch_attempt_completed_at": fetch_attempt_completed_at,
         "from_cache": False,
         "issues": issues,
     }
-    _store_cache(url, out, text)
+    _store_cache(url, out, text_bytes)
     return out
 
 
@@ -353,7 +364,7 @@ def run_dry_run(refresh: bool = False) -> int:
         marker = " " if passed else "!"
         if not passed:
             bad += 1
-        print(f"{marker} {url[:68]:<68}  {tier:<10}  {str(expected or '-'):<10}  {status:<6}  {textlen:<6}  {issues}")
+        print(f"{marker} {url[:68]:<68}  {tier:<10}  {expected or '-'!s:<10}  {status:<6}  {textlen:<6}  {issues}")
     print("-" * 140)
     print(f"failed: {bad}/{len(_DRY_RUN_URLS)}")
     return 0 if bad == 0 else 1

--- a/tests/test_fetch_citation.py
+++ b/tests/test_fetch_citation.py
@@ -1,0 +1,152 @@
+"""Deterministic cache-provenance tests for the citation fetcher."""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import urllib.error
+from datetime import datetime
+from pathlib import Path
+from typing import Self
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts import fetch_citation
+
+
+class _Response:
+    def __init__(self, body: bytes, *, final_url: str, content_type: str = "text/plain") -> None:
+        self._body = body
+        self._final_url = final_url
+        self.headers = {"Content-Type": content_type}
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self, _limit: int = -1) -> bytes:
+        return self._body
+
+    def geturl(self) -> str:
+        return self._final_url
+
+    def getcode(self) -> int:
+        return 200
+
+
+@pytest.fixture
+def cache_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    monkeypatch.setattr(fetch_citation, "CACHE_DIR", tmp_path)
+    monkeypatch.setattr(fetch_citation, "allowlist_tier", lambda _url: "standards")
+    return tmp_path
+
+
+def test_new_fetch_hashes_exact_utf8_bytes_and_records_completion(cache_dir):
+    url = "https://source.example/article"
+    body = "<p>Café</p><p>Line\nTwo</p>".encode()
+    expected = "Café\nLine\nTwo".encode()
+    with patch.object(
+        fetch_citation.urllib.request,
+        "urlopen",
+        return_value=_Response(
+            body,
+            final_url="https://source.example/article",
+            content_type="text/html; charset=utf-8",
+        ),
+    ):
+        result = fetch_citation.fetch(url)
+
+    text_path = fetch_citation.cached_text_path(url)
+    assert text_path.read_bytes() == expected
+    assert result["text_sha256"] == hashlib.sha256(expected).hexdigest()
+    assert result["text_bytes"] == len(expected)
+    assert result["truncated"] is False
+    datetime.fromisoformat(result["fetch_attempt_completed_at"])
+    assert result["from_cache"] is False
+    assert result["allowlist_tier"] == "standards"
+    assert cache_dir.joinpath(text_path.name).read_bytes() == expected
+
+
+def test_redirect_and_truncation_are_recorded(cache_dir, monkeypatch):
+    monkeypatch.setattr(fetch_citation, "MAX_BYTES", 5)
+    allowlist = MagicMock(return_value="standards")
+    monkeypatch.setattr(fetch_citation, "allowlist_tier", allowlist)
+    url = "https://source.example/start"
+    final_url = "https://source.example/final"
+    with patch.object(
+        fetch_citation.urllib.request,
+        "urlopen",
+        return_value=_Response(b"abcdef", final_url=final_url),
+    ):
+        result = fetch_citation.fetch(url)
+
+    assert result["final_url"] == final_url
+    assert result["bytes"] == 6
+    assert result["truncated"] is True
+    assert "truncated_body" in result["issues"]
+    allowlist.assert_called_once_with(final_url)
+    assert result["text_bytes"] == 5
+    assert result["text_sha256"] == hashlib.sha256(b"abcde").hexdigest()
+    assert fetch_citation.cached_text_path(url).read_bytes() == b"abcde"
+
+
+def test_failed_and_pdf_fetches_keep_issues_without_acceptance(cache_dir):
+    failed_url = "https://source.example/fails"
+    with patch.object(
+        fetch_citation.urllib.request,
+        "urlopen",
+        side_effect=urllib.error.URLError("offline"),
+    ):
+        failed = fetch_citation.fetch(failed_url)
+
+    assert failed["status"] == 0
+    assert failed["truncated"] is None
+    assert "network_failure" in failed["issues"]
+    assert failed["text_bytes"] == 0
+    assert "source_acceptance" not in failed
+
+    pdf_url = "https://source.example/report.pdf"
+    with patch.object(
+        fetch_citation.urllib.request,
+        "urlopen",
+        return_value=_Response(b"%PDF-1.7", final_url=pdf_url, content_type="application/pdf"),
+    ):
+        pdf = fetch_citation.fetch(pdf_url)
+
+    assert "pdf_needs_adapter" in pdf["issues"]
+    assert pdf["text_sha256"] == hashlib.sha256(b"").hexdigest()
+    assert "source_acceptance" not in pdf
+    assert fetch_citation.cached_text_path(pdf_url).read_bytes() == b""
+
+
+def test_legacy_cache_hit_does_not_gain_provenance(cache_dir):
+    url = "https://source.example/legacy"
+    meta_path, text_path = fetch_citation._cache_paths(url)
+    legacy = {
+        "url": url,
+        "final_url": url,
+        "status": 200,
+        "content_type": "text/plain",
+        "bytes": 6,
+        "text_length": 6,
+        "cached_at": "2024-01-01T00:00:00+00:00",
+        "issues": [],
+    }
+    meta_path.write_text(json.dumps(legacy), encoding="utf-8")
+    text_path.write_bytes(b"legacy")
+
+    with patch.object(fetch_citation.urllib.request, "urlopen") as urlopen:
+        result = fetch_citation.fetch(url)
+
+    urlopen.assert_not_called()
+    assert result["from_cache"] is True
+    assert result["cached_at"] == legacy["cached_at"]
+    assert all(
+        key not in result
+        for key in ("text_sha256", "text_bytes", "fetch_attempt_completed_at", "truncated")
+    )


### PR DESCRIPTION
Fetched citation sources currently have a URL-keyed cache but no digest of the extracted text. New fetches now record the exact cached UTF-8 text SHA-256 and byte count, fetch-attempt completion time, and successful-response truncation state. Failed-fetch truncation is unknown. Writing bytes preserves the digest across platform newline rules; old cache hits receive no invented historical provenance.

Closes #2321; part of #2310 and epic#2272. This is a producer correction. Consumer integrity checks, immutable snapshots, full-page claim coverage and reviewer-run evidence remain required follow-ups. Empty/error/PDF results retain their limitations and are not accepted evidence.

Validation:57 focused tests (4new cache tests plus53existing citation-residual tests), full changed-file Ruff,176pipeline tests and diff check passed. Tests mock network and allowlist behavior. No actual source fetch/provider verification was performed; no Astro build required for this pure-Python change. Independent Google-family review approved exact head f8479034f426ef8e770193f38fa282e86aa21f7f and is posted as a PR comment.

Scope:2files,171additions/8deletions. Includes five baseline Ruff fixes in the touched script, preserving exception behavior. No generated artifacts or live cache migration.
