### PR TITLE
docs(quality): align length guidance with evidence limits (#2325)

### DIFF
--- a/.claude/rules/module-quality.md
+++ b/.claude/rules/module-quality.md
@@ -49,7 +49,7 @@ paths:
 - Do NOT add a Markdown `# Module ...` heading after frontmatter. Starlight renders the page H1 from `title:` frontmatter, so a source H1 creates a duplicate visible title.
 - The top-of-module metadata must be a blockquote immediately after frontmatter:
   `> **Complexity**: ...`, blank quoted line, `> **Time to Complete**: ...`, blank quoted line, `> **Prerequisites**: ...`, then `---`, then `## What You'll Be Able to Do`.
-- 600-800+ lines of CONTENT minimum (250+ for KCNA theory modules). Visual aids (ASCII diagrams, code blocks for illustration) do NOT count toward the minimum — they supplement teaching, not substitute for it.
+- Depth follows the topic scope, measurable outcomes, runnable examples, assessment alignment, and verified evidence. Length estimates may guide planning and routing, but are not evidence of factual support, learning effectiveness, or acceptance. Do not pad with repeated prose, decorative structure, or unsupported facts. If verified material is insufficient, state the shortfall for review rather than claiming completion; a concise module does not automatically pass. Visual aids supplement teaching and do not replace explanation.
 - Explain "why" before "what"
 - All code must be runnable (not pseudocode)
 - Code blocks specify language (```bash, ```yaml, ```go)

--- a/scripts/prompts/audit_teaching.md
+++ b/scripts/prompts/audit_teaching.md
@@ -31,7 +31,7 @@ You are a senior curriculum reviewer for KubeDojo, a free open-source cloud nati
 - **≥ 2 inline active-learning prompts** distributed through core content (e.g., "Pause and predict", "Stop and think", "Active check").
 - **≥ 1 worked example** before asking the learner to solve a similar problem on their own.
 - **Quiz questions must be scenario-based** ("Your team deployed X and Y happens — what do you check?"), not recall.
-- **600–800+ lines of content** (250+ for KCNA-style theory modules). Visual aids (Mermaid, ASCII, code blocks) supplement teaching, they do NOT substitute for it.
+- Assess whether the module provides enough substantive explanation for its stated outcomes, exercise, assessment, and topic. The supplied line count is context for routing and review, not a pass/fail proxy for factual support, learning, or acceptance. Do not reward padding, repeated restatements, or unsupported detail to reach a count; do not penalize a concise module solely for being short when its teaching and evidence are complete. A short module is not automatically acceptable.
 
 ## What to score
 
@@ -78,5 +78,7 @@ Constraints:
 - `has_why_before_what`: bool — true if a "Why This Module Matters" appears before the first technical section.
 - `missing_required_sections`: array of strings, each matching one of the 9 required sections above.
 - `verdict`: one of `"poor"`, `"adequate"`, `"strong"`.
+
+If verified material cannot support the requested scope, report that limitation in `teaching_gaps` or `verdict_reasoning` rather than inventing detail or claiming completion. Keep the exact JSON output format; this reporting rule does not create a machine-enforced publication guard.
 
 Return ONLY the JSON object. Do not add a "reasoning" prefix, do not wrap in code fences, do not append "I hope this helps."

--- a/scripts/prompts/module-rewriter-388.md
+++ b/scripts/prompts/module-rewriter-388.md
@@ -1,9 +1,9 @@
 # #388 Module Rewriter — Density-First Brief Addendum
-Word-count target for THIS module: {{BODY_WORDS_TARGET}}. Replaced by dispatch with per-module budget if set, otherwise default 5000.
+Configured body-word budget for THIS module: {{BODY_WORDS_TARGET}}. Dispatch supplies a per-module budget when set, otherwise the pilot verifier uses its existing default of 5000. This prompt does not change that executable check or any acceptance state.
 
 This addendum is layered on top of `scripts/prompts/module-writer.md`. It is binding for all #388 site-wide rewrite dispatches. The audit gates here are derived from the Codex architectural consult of 2026-05-01 (bridge messages #3384 and #3386) and the empirical baseline established by the density fix-pass batch of the same session (PRs #720-723).
 
-The brief has historically optimized for visible structure and quotas (DYK count, sections, sources, "600+ content lines"). That conditioning produces choppy single-sentence prose and consistent failure on prose-density gates. This addendum reframes the contract.
+The brief has historically optimized for visible structure and quotas (DYK count, sections, and sources). That conditioning produces choppy single-sentence prose and consistent failure on prose-density gates. This addendum reframes the contract.
 
 ## PROSE DENSITY IS A HARD GATE
 
@@ -54,10 +54,9 @@ Meet the required counts for Did You Know, Common Mistakes, quiz questions, hand
 
 Before finalizing, scan every consecutive body-prose paragraph. If three paragraphs in a row each have fewer than 18 words, the module is invalid. Merge, expand, or rewrite those paragraphs until the maximum consecutive short-paragraph run is 2 or less.
 
-## DEPTH TARGET (REPLACES "600+ CONTENT LINES")
+## DEPTH AND EVIDENCE
 
-Target substantial depth: {{BODY_WORDS_TARGET}}-7,000 words of original instructional content. Do not satisfy depth by adding short lines, fragmented paragraphs, or decorative structure. Word count is the floor; density gates are the ceiling on how those words can be packaged.
-The {{BODY_WORDS_TARGET}}-7,000 target is a depth budget, not a quota. If a topic naturally fits in 4,500 words of substantive teaching, write 4,500 words. Padding to hit {{BODY_WORDS_TARGET}} with restated content is a hard failure of this contract (see NO RESTATEMENT ACROSS H2 SECTIONS above).
+Use the configured budget as a planning and reporting signal for substantial depth, guided by the topic, outcomes, assessment, and verified material. Do not satisfy it by adding short lines, fragmented paragraphs, decorative structure, or restated content. The pilot verifier separately checks its configured body-word value; that number is not proof of factual support, learning, or publication acceptance. If evidence cannot support the requested scope or the configured check, report the shortfall in the required output rather than inventing detail or claiming completion; do not create a placeholder.
 
 ## RUNNABILITY, FABRICATION, AND PRACTICE QUESTIONS
 
@@ -96,7 +95,7 @@ All must pass before commit. The deterministic verifier (`scripts/quality/verify
 2. median_wpp >= 28
 3. short_paragraph_rate <= 20%
 4. max_consecutive_short_run <= 2
-5. body_words >= {{BODY_WORDS_TARGET}} (absolute floor — not relative)
+5. The pilot verifier must check body words against its configured `{{BODY_WORDS_TARGET}}`; report its pass/fail result and any shortfall. A passing number is not evidence of factual support, learning effectiveness, or a v2 publication verdict.
 6. mean_sentence_length 12-28 words
 7. >= 2 inline active-learning prompts in core content (not just in the final hands-on)
 8. Each Learning Outcome maps to >= 1 core section AND >= 1 quiz item OR lab task
@@ -121,9 +120,9 @@ Per the Codex consult, classify each `revision_pending: true` module into one of
 After draft, the dispatched agent must report:
 - mean_wpp, median_wpp, short_paragraph_rate, max_consecutive_short_run, body_words, paragraph_count, mean_sentence_length
 - Which gates passed/failed
-- Body-words-before / body-words-after (and confirmation that absolute floor {{BODY_WORDS_TARGET}} is met)
+- Body-words-before / body-words-after, the configured budget result, and any shortfall
 - Salvageable assets preserved (count of code blocks, diagrams, tables before/after)
 - Forbidden tokens grep result
 - Sources verification status (200/redirect/404 + relevance assessment)
 
-If any gate fails, the agent revises before declaring complete. The orchestrator's verifier re-checks before commit.
+If any gate fails, revise when verified material supports the needed correction; otherwise report the failed gate and material shortfall instead of claiming completion. The orchestrator's verifier re-checks before commit. This prompt-level honesty exception does not create a new machine-enforced publication guard.

--- a/scripts/prompts/module-writer.md
+++ b/scripts/prompts/module-writer.md
@@ -29,13 +29,13 @@ TASK: Write a complete KubeDojo educational module.
 
 ### Quality Standard: 10/10 on the Dojo Scale
 
-**LENGTH**: 600-800 lines of **content** minimum. This is a deep, rich learning module — not an outline or reference doc. Visual aids (ASCII diagrams, mermaid charts, code blocks used purely for illustration) do NOT count toward the line minimum — they are supplements to the teaching, not substitutes for it.
+**DEPTH AND LENGTH**: Set the module's substantive scope from its topic, measurable outcomes, exercise, assessment, and verified evidence. Line and word counts are planning signals for routing and review; they are not proof of factual support, learning quality, or acceptance. Do not add repeated prose, decorative structure, or unsupported facts to reach a number. If verified material cannot support the requested scope, report the shortfall in the requested output format instead of inventing detail or claiming completion. Visual aids supplement teaching; they do not replace explanation.
 
 **REQUIRED SECTIONS** (in this exact order):
 
 1. **Frontmatter and metadata blockquote** — frontmatter `title:` + `slug:` + `sidebar.order:` (Starlight renders the page H1 from `title:`, so do NOT add a source `# Module X.Y` heading after the frontmatter — this would render as a duplicate visible title). Then a blockquote with `> **Complexity**: ...`, `> **Time to Complete**: ...`, `> **Prerequisites**: ...`, separated by `>` blank-quote lines, terminated with `---`.
 2. **Learning Outcomes** — 3-5 measurable outcomes using Bloom's Taxonomy Level 3+ action verbs: "debug", "design", "evaluate", "compare", "diagnose", "implement". NOT "understand" or "know". Each outcome must be testable by the quiz or exercise.
-3. **Why This Module Matters** — Open with a clear explanation of why the topic matters and what the learner will build or diagnose. Use a sourced incident or explicitly labeled `Hypothetical scenario:`/`Exercise scenario:` only when it clarifies the outcome. 2-3 paragraphs minimum.
+3. **Why This Module Matters** — Open with a clear explanation of why the topic matters and what the learner will build or diagnose. Use a sourced incident or explicitly labeled `Hypothetical scenario:`/`Exercise scenario:` only when it clarifies the outcome. Give the learner enough explanation to connect the stakes to the stated outcome; do not pad this section to meet a paragraph count.
 4. **Core content sections** (3-6 sections) — Each section should include:
    - **Theory before practice** — explain WHY this approach exists, what problem it solves, and what tradeoffs it makes BEFORE showing the commands. Prose must explain concepts between code blocks — never stack 3 code blocks without explanation.
    - Clear explanations for a smart beginner; use an analogy only when it clarifies the outcome and state its limits

--- a/scripts/quality/prompts.py
+++ b/scripts/quality/prompts.py
@@ -90,7 +90,7 @@ def rewrite_prompt(
 
 ## Your task
 
-Produce a complete, replacement module that teaches the topic from beginner to senior level. Output ONLY the module markdown — no preamble, no code-fence wrap. Start with the `---` frontmatter line, end with a trailing newline.
+Produce a complete, replacement module that teaches the topic from beginner to senior level. For a complete module, output ONLY its markdown — no preamble, no code-fence wrap, starting with `---` frontmatter and ending with a newline. If verified material is insufficient, return a shortfall report instead of a replacement module; do not disguise that report as publishable lesson content.
 
 Mandatory:
 - Preserve the `title:` and `sidebar.order:` from existing frontmatter.
@@ -101,29 +101,29 @@ Mandatory:
 - **NEVER replace an ` ```ascii ` or ` ```text ` block with a Markdown table.** If a table reads better in your judgment, **add the table next to the ASCII block** — do not remove the ASCII. The same applies to Mermaid: never replace ASCII with Mermaid; keep both. The visual-aid count is checked PER TYPE (mermaid count, ascii count, table count) — substituting one type for another is detected and rejected.
 - Preserve any existing `## Sources` section verbatim (heading, ordering, citation lines, URLs). Do NOT modify, reorder, deduplicate, or "improve" entries. Do NOT add a NEW `## Sources` section if one isn't already present — citation insertion runs in a separate downstream stage.
 - Address each gap from the audit explicitly.
-- Minimum 600 content lines (250 for KCNA theory modules). Code/visuals don't count.
+- Plan enough substantive content to address the stated outcomes, exercise, assessment, sources, and topic. Counts can inform routing and review, but are not proof of factual support, learning, or acceptance. Do not pad with repeated prose, decorative structure, or unsupported facts. If verified material cannot support the requested scope, report the shortfall rather than inventing detail or claiming completion.
 - All quiz questions scenario-based (Bloom L3+). No recall questions.
 - Exactly 4 "Did You Know?" facts. 6-8 rows in "Common Mistakes". 6-8 quiz questions.
 - Do NOT use emojis. Do NOT use the number 47.
 
-**Prose density (HARD GATE — automatically enforced after merge):**
+**Prose density (v2 routing and pre-commit/merge behavior):**
 
-Your output is run through a density classifier before it can ship. Modules that fail bounce back to you and after 2 retries are FAILED for manual rewrite. The classifier rejects three patterns we've seen LLMs produce:
+The unchanged v2 classifier uses these tiers: REWRITE is below 1000 prose words, 12 words per non-blank line, or 18 words per prose paragraph; PASS is at least 1500 prose words, 18 words per non-blank line, and 22 words per prose paragraph; REVIEW is intermediate. REWRITE is the density rejection tier checked before commit/merge. PASS and REVIEW do not establish factual support, source verification, learning effectiveness, or acceptance; the other review and executable gates still apply. These figures are not a total line or word quota.
 
 1. **Pad-bomb (one-sentence-per-paragraph)** — every sentence on its own line, single newlines between sentences. Looks "structured" but reads like a stack of bullets without the bullets. Fail signal: words-per-line < 12.
 2. **Punchy-bullets / fragments** — short stubs, two-clause "headers" used as paragraphs, heavy bullet-only sections with no surrounding prose. Fail signal: words-per-paragraph < 18.
 3. **Essay-filler** — paragraphs that look dense but say nothing concrete (corporate generality, no examples, no sequencing). Fail signal: w/ln passes but reviewer + audit both downgrade teaching.
 
 **Required prose shape:**
-- **Average ≥ 22 words per prose paragraph** (target 25–60). A paragraph is text between blank lines, NOT counting code fences, lists, tables, or front-matter blocks.
-- **Average ≥ 18 words per non-blank line** (target ≥ 20). Wrap your sentences into multi-sentence paragraphs; do not put one sentence per line.
-- **Minimum 1500 prose words** (≥ 2500 strongly preferred). Prose words = words outside code fences, frontmatter, and tables.
+- Prefer an average of 22 words per prose paragraph (target 25–60) and 18 words per non-blank line (target ≥20). A paragraph is text between blank lines, NOT counting code fences, lists, tables, or front-matter blocks.
+- Treat 1500 prose words as the stronger PASS classifier tier, not a total-content quota. Prose words are outside code fences, frontmatter, and tables; a REVIEW result is intermediate and is not automatically blocked.
+- If verified material cannot support the requested scope or an active gate, use the shortfall-report exception above rather than fabricating detail or claiming completion. This prompt instruction does not create a new machine-enforced publication guard.
 - A teaching paragraph should typically be 3–6 sentences long, with the first sentence stating the claim and the rest grounding it with mechanism, example, or trade-off. Do not split that into 4 separate one-sentence paragraphs.
 - Bullets are allowed for genuine lists (steps, options, anti-patterns, rules). They are NOT a substitute for explanation. A section that's 90% bullets fails. If you find yourself writing 5+ consecutive single-line bullets where each is essentially a sentence of an argument, merge them into a paragraph.
 
 You are writing for a learner who reads the page top-to-bottom. Flowing multi-sentence paragraphs are how you teach mechanism, sequence, and nuance. Fragmented one-line "paragraphs" are how style guides for status pages are written, and that is the wrong genre.
 
-Return the complete module. Starting with `---`.
+Return the complete module starting with `---`, or a shortfall report if the honesty exception applies.
 """
 
 


### PR DESCRIPTION
Writer and audit guidance mixed600-800line quotas with a separate pilot body-word check, even allowing naturally shorter content while calling the word count an absolute floor. The revised guidance requires depth supported by outcomes, assessment and verified material; insufficient evidence must be reported instead of padded or presented as complete.

Closes #2325, part of #2274/#2272. It describes existing v2 density tiers and their pre-commit/merge timing accurately, keeps the pilot verifier separate, and leaves all numeric executable gates unchanged. The writer's output-only instruction has a shortfall-report exception; it does not create a new machine publication guard or make short content automatically acceptable. Audit reports limitations in existing JSON fields.

Validation:20prompt/queue tests,176pipeline tests, changed-fileRuff and diffcheck passed. NoAstrobuild required (no publishedcontent/config changes). Independent Google-family static review approved exacthead19c7e4899b7d007154b6e855ef69b3aaf1ab1d65; posted as a PR comment. No claim that length proves learning or factual support.

Scope:5files,+21/-20. No generated artifacts, threshold changes or unrelated scoring/device-quota changes.
