### PR TITLE
fix(ai): correct next-lesson URL resolution (#2343)

### DIFF
--- a/src/content/docs/ai/foundations/module-1.1-what-is-ai.md
+++ b/src/content/docs/ai/foundations/module-1.1-what-is-ai.md
@@ -314,7 +314,7 @@ A spam filter may combine rules and machine learning because it can block messag
 
 ## Next Module
 
-Continue to [What Are LLMs?](./module-1.2-what-are-llms/) to learn why modern chatbots can respond in natural language and why that ability is useful but not the same as guaranteed understanding.
+Continue to [What Are LLMs?](/ai/foundations/module-1.2-what-are-llms/) to learn why modern chatbots can respond in natural language and why that ability is useful but not the same as guaranteed understanding.
 
 ## Sources
 


### PR DESCRIPTION
Fix the What Is AI next-lesson link for the site's canonical trailing-slash URLs. The old relative href resolved below the current lesson directory, producing a nonexistent nested page. The root-relative href resolves to the existing What Are LLMs lesson.

Refs #2343 and #2272. This PR changes only the English link. The corresponding Ukrainian correction and source-revision update are coordinated with draft #2342; #2343 stays open until that work is delivered. No prose or source claims change.

Validation at 54f874a6e1ae0cd006843d1d40c3e73bb8a545ad: all 176 pipeline tests passed; primary-root Astro build passed (2,169 pages); rendered canonical URL plus actual browser-style URL resolution points to an existing rendered target; diff check passed. Google static review smart-agy-review-1788575149 returned PASS. One file, one insertion / one deletion; no generated artifacts.
