### PR TITLE
feat(quality): add canonical browser URL resolver (#2346)

### DIFF
--- a/scripts/quality/route-resolver.mjs
+++ b/scripts/quality/route-resolver.mjs
@@ -1,0 +1,60 @@
+export class UnsupportedRoute extends TypeError {}
+
+function text(value, label) {
+  if (typeof value !== 'string') throw new UnsupportedRoute(`${label} must be text`);
+  return value;
+}
+
+function parsed(value, label, base) {
+  try {
+    return new URL(text(value, label), base);
+  } catch (error) {
+    throw new UnsupportedRoute(`${label} is not a valid URL`, { cause: error });
+  }
+}
+
+function siteOrigin(value) {
+  const origin = parsed(value, 'site origin');
+  if (!['http:', 'https:'].includes(origin.protocol) || origin.username || origin.password || origin.search || origin.hash || origin.pathname !== '/') {
+    throw new UnsupportedRoute('site origin must be an HTTP(S) origin without a path, query, or fragment');
+  }
+  return origin;
+}
+
+function canonicalSource(value, origin) {
+  const source = text(value, 'canonical source');
+  if (source.startsWith('//') || (!source.startsWith('/') && !/^[a-z][a-z\d+.-]*:\/\//i.test(source))) {
+    throw new UnsupportedRoute('canonical source must be an absolute URL or root-relative path');
+  }
+  const result = parsed(source, 'canonical source', origin);
+  if (!['http:', 'https:'].includes(result.protocol)) throw new UnsupportedRoute('canonical source must be HTTP(S)');
+  return result;
+}
+
+/** Manifest entries are URL-serialized pathnames; normalization is never a fallback. */
+function manifestRoutes(paths, origin) {
+  if (typeof paths === 'string' || !paths || typeof paths[Symbol.iterator] !== 'function') throw new UnsupportedRoute('manifest paths must be a non-string iterable');
+  const routes = new Set();
+  for (const value of paths) {
+    const path = text(value, 'manifest route');
+    if (!path.startsWith('/') || path.startsWith('//') || path.includes('?') || path.includes('#')) {
+      throw new UnsupportedRoute('manifest routes must be root-relative paths');
+    }
+    const route = parsed(path, 'manifest route', origin);
+    if (route.origin !== origin.origin || route.search || route.hash || route.pathname !== path) throw new UnsupportedRoute('manifest route must be a serialized pathname');
+    routes.add(route.pathname);
+  }
+  return routes;
+}
+
+/** Resolve one URL; routeExists checks paths only, never anchors or redirect destinations. */
+export function resolveRoute(href, canonicalSourceValue, siteOriginValue, knownPaths) {
+  const origin = siteOrigin(siteOriginValue);
+  const source = canonicalSource(canonicalSourceValue, origin);
+  const routes = manifestRoutes(knownPaths, origin);
+  const target = parsed(href, 'href', source);
+  if (target.protocol === 'mailto:') return { url: target.href, kind: 'mailto', path: null, routeExists: null };
+  if (!['http:', 'https:'].includes(target.protocol)) throw new UnsupportedRoute('only HTTP(S) and mailto links are supported');
+  const internal = target.origin === origin.origin;
+  return { url: target.href, kind: internal ? 'internal' : 'external-http', path: target.pathname, routeExists: internal ? routes.has(target.pathname) : null };
+}

--- a/scripts/quality/route-resolver.test.mjs
+++ b/scripts/quality/route-resolver.test.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { resolveRoute, UnsupportedRoute } from './route-resolver.mjs';
+
+const ORIGIN = 'https://site.test';
+const resolve = (href, source = '/source/page/', routes = ['/source/page/']) => resolveRoute(href, source, ORIGIN, routes);
+
+test('manifest routes are explicit: EN, UK, index, slug, dotted file, redirect alias', () => {
+  const cases = [
+    ['/en/page/', '../../uk/page/', ['/uk/page/'], '/uk/page/', true],
+    ['/index/', './', ['/index/'], '/index/', true],
+    ['/source/', '../custom-slug/', ['/custom-slug/'], '/custom-slug/', true],
+    ['/docs/source/', './module-1.1-dotted.md', ['/docs/source/module-1.1-dotted/'], '/docs/source/module-1.1-dotted.md', false],
+    ['/canonical/', '/old-route/', ['/old-route/'], '/old-route/', true],
+  ];
+  for (const [source, href, routes, path, exists] of cases) {
+    const result = resolveRoute(href, source, ORIGIN, routes);
+    assert.equal(result.url, ORIGIN + path);
+    assert.equal(result.kind, 'internal');
+    assert.equal(result.routeExists, exists);
+  }
+});
+
+test('native URL resolves one root, parent, nested, and slash-policy target', () => {
+  const cases = [
+    ['/section/page/', '../correct/', '/section/correct/'],
+    ['/section/page/', './nestedbad/', '/section/page/nestedbad/'],
+    ['/section/page', './nested/', '/section/nested/'],
+    ['/section/page/', '/root/', '/root/'],
+  ];
+  for (const [source, href, path] of cases) {
+    const result = resolve(href, source, [path]);
+    assert.equal(result.url, ORIGIN + path);
+    assert.equal(result.routeExists, true);
+  }
+});
+
+test('relative sibling resolution does not invent a parent route', () => {
+  for (const locale of ['en', 'uk']) {
+    const source = `/${locale}/section/page/`;
+    const routes = [`/${locale}/section/sibling/`];
+    assert.equal(resolveRoute('./sibling/', source, ORIGIN, routes).routeExists, false);
+    assert.equal(resolveRoute('../sibling/', source, ORIGIN, routes).routeExists, true);
+  }
+});
+
+test('same-origin, external HTTP, and mailto remain separate', () => {
+  const same = resolve('//site.test/known/?q=1#missing-anchor', '/source/', ['/known/']);
+  assert.deepEqual(same, { url: 'https://site.test/known/?q=1#missing-anchor', kind: 'internal', path: '/known/', routeExists: true });
+  assert.equal(resolve('https://other.test/known/').kind, 'external-http');
+  assert.equal(resolve('mailto:ops@example.test').kind, 'mailto');
+  assert.equal(resolve('mailto:ops@example.test').routeExists, null);
+});
+
+test('query and fragment references clear or preserve state without anchor checks', () => {
+  const source = 'https://site.test/source/page/?old=1#old';
+  assert.equal(resolveRoute('?', source, ORIGIN, ['/source/page/']).url, 'https://site.test/source/page/?');
+  const fragment = resolveRoute('#', source, ORIGIN, ['/source/page/']);
+  assert.equal(fragment.url, 'https://site.test/source/page/?old=1#');
+  assert.equal(fragment.routeExists, true);
+});
+
+test('base path comes from the actual canonical URL', () => {
+  const result = resolveRoute('../next/?q=1#part', 'https://site.test/kube-dojo/en/page/', ORIGIN, ['/kube-dojo/en/next/']);
+  assert.equal(result.url, 'https://site.test/kube-dojo/en/next/?q=1#part');
+  assert.equal(result.routeExists, true);
+});
+
+test('former Python divergences follow native WHATWG URL output', () => {
+  const cases = [
+    ['/✓/', 'https://site.test/%E2%9C%93/'],
+    ['./a//b/', 'https://site.test/source/page/a//b/'],
+    ['https://%73ite.test/known/', 'https://site.test/known/'],
+    ['..\\next/', 'https://site.test/source/next/'],
+    ['/x/%2e%2e/y', 'https://site.test/y'],
+    ['/x/%ZZ', 'https://site.test/x/%ZZ'],
+  ];
+  for (const [href, expected] of cases) {
+    const path = new URL(expected).pathname;
+    const result = resolve(href, '/source/page/', [path]);
+    assert.equal(result.url, expected);
+    assert.equal(result.routeExists, true);
+  }
+});
+
+test('unsupported schemes fail closed', () => {
+  for (const href of ['javascript:alert(1)', 'ftp://other.test/file']) {
+    assert.throws(() => resolve(href), UnsupportedRoute);
+  }
+});
+
+test('explicit inputs and manifest paths must be canonical', () => {
+  for (const path of ['/a/../b/', '/a/\u0000b/', '/a/\tb/', '/✓/']) {
+    assert.throws(() => resolveRoute('/b/', '/source/', ORIGIN, [path]), { name: 'TypeError', message: /serialized pathname/ });
+  }
+  assert.throws(() => resolveRoute('/x/', 'relative', ORIGIN, ['/x/']), { name: 'TypeError', message: /absolute URL/ });
+  assert.throws(() => resolveRoute('/x/', '/x/', `${ORIGIN}/base/`, ['/x/']), { name: 'TypeError', message: /HTTP\(S\) origin/ });
+  assert.throws(() => resolveRoute('/x/', '/x/', ORIGIN, '/x/'), { name: 'TypeError', message: /non-string iterable/ });
+});


### PR DESCRIPTION
The existing link gates can accept a source-adjacent file even when a browser requests a missing nested URL. This first packet adds a pure resolver using native WHATWG URL semantics, with explicit canonical source, site origin and serialized route-manifest inputs. It reproduces the wrong-sibling regression for English and Ukrainian and rejects manifest entries that would create aliases through normalization.

Part of #2346/#2293/#2272. Manifest production, content repair waves and gate integration remain separate work. This does not change the existing gate, baseline or published content. Path existence does not validate fragments or redirect destinations.

Validation: nine native Node test groups, syntax checks for both modules, 176 pipeline tests and diff checks pass. Two files, 159 added lines. No Python/content/config changes; Ruff and Astro build are not applicable. The Node tests currently run explicitly; wiring them into the automated gate belongs to the integration packet, since existing Vitest targets tests/**/*.test.ts.
