### PR TITLE
fix(i18n): restore nine Ukrainian hubs at their existing URLs (#2351)

### DIFF
--- a/src/content/docs/uk/cloud/advanced-operations/index.md
+++ b/src/content/docs/uk/cloud/advanced-operations/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Просунуті хмарні операції"
-slug: uk/cloud/advanced-operations/index
+slug: uk/cloud/advanced-operations
 sidebar:
   order: 0
   label: "Просунуті операції"

--- a/src/content/docs/uk/cloud/managed-services/index.md
+++ b/src/content/docs/uk/cloud/managed-services/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Хмарні керовані сервіси"
-slug: uk/cloud/managed-services/index
+slug: uk/cloud/managed-services
 sidebar:
   order: 0
   label: "Керовані сервіси"

--- a/src/content/docs/uk/k8s/cba/index.md
+++ b/src/content/docs/uk/k8s/cba/index.md
@@ -3,7 +3,7 @@ title: "CBA - Certified Backstage Associate"
 sidebar:
   order: 0
   label: "CBA"
-slug: uk/k8s/cba/index
+slug: uk/k8s/cba
 en_commit: "47bf257c3ec7632099185c630faf64d73e48caea"
 en_file: "src/content/docs/k8s/cba/index.md"
 calque_review:

--- a/src/content/docs/uk/k8s/kca/index.md
+++ b/src/content/docs/uk/k8s/kca/index.md
@@ -3,7 +3,7 @@ title: "KCA - Kyverno Certified Associate"
 sidebar:
   order: 0
   label: "KCA"
-slug: uk/k8s/kca/index
+slug: uk/k8s/kca
 en_commit: "7e01a3686e7eed601474920f79697275be77476d"
 en_file: "src/content/docs/k8s/kca/index.md"
 calque_review:

--- a/src/content/docs/uk/k8s/pca/index.md
+++ b/src/content/docs/uk/k8s/pca/index.md
@@ -1,6 +1,6 @@
 ---
 title: "PCA — Prometheus Certified Associate"
-slug: uk/k8s/pca/index
+slug: uk/k8s/pca
 sidebar:
   order: 0
   label: "PCA"

--- a/src/content/docs/uk/on-premises/provisioning/index.md
+++ b/src/content/docs/uk/on-premises/provisioning/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Розгортання на Bare Metal"
-slug: "uk/on-premises/provisioning/index"
+slug: "uk/on-premises/provisioning"
 sidebar:
   order: 0
 en_commit: "47bf257c3ec7632099185c630faf64d73e48caea"

--- a/src/content/docs/uk/on-premises/resilience/index.md
+++ b/src/content/docs/uk/on-premises/resilience/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Відмовостійкість та міграція"
-slug: uk/on-premises/resilience/index
+slug: uk/on-premises/resilience
 sidebar:
   order: 0
 en_commit: "b786b1cd55e06502c1f698c42c8b5cb69a303e93"

--- a/src/content/docs/uk/platform/foundations/advanced-networking/index.md
+++ b/src/content/docs/uk/platform/foundations/advanced-networking/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Просунуті мережі"
-slug: "uk/platform/foundations/advanced-networking/index"
+slug: "uk/platform/foundations/advanced-networking"
 sidebar:
   order: 0
   label: "Просунуті мережі"

--- a/src/content/docs/uk/platform/foundations/engineering-leadership/index.md
+++ b/src/content/docs/uk/platform/foundations/engineering-leadership/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Інженерне лідерство"
-slug: uk/platform/foundations/engineering-leadership/index
+slug: uk/platform/foundations/engineering-leadership
 sidebar:
   order: 0
   label: "Інженерне лідерство"


### PR DESCRIPTION
Nine existing Ukrainian hubs were hidden by English fallback routes: their explicit IDs ended in `/index`, so Starlight did not recognize them as translations of the corresponding English entries, then normalized both entries to the same URL. This change removes that suffix from the nine UK slugs, restoring the Ukrainian source at the existing canonical URL.

Only nine slug lines change (+9/-9). Entire-file comparisons confirm that translated bodies, titles, EN revision pins and every other byte are preserved. Translation fidelity and freshness remain subject to their existing review requirements; this PR adds no acceptance stamps.

Validation: 176 pipeline tests passed; primary-driven Astro build passed (2,169 pages); all nine Ukrainian opening-body markers, canonical URLs and language attributes checked; no prior route-conflict warnings remain; `git diff --check` clean. Independent Google review `smart-agy-review-1788581376`: PASS at 03882b6f0. Deployment verification remains pending.

Refs #2351, #2346, #2291. Close #2351 only after all nine deployed pages are verified.
