### PR TITLE
docs(book): anchor Physical Bridge chronology and attribution corrections (#2339)

### DIFF
--- a/docs/research/ai-history/chapters/ch-03-the-physical-bridge/context-corrections-2026-09-05.md
+++ b/docs/research/ai-history/chapters/ch-03-the-physical-bridge/context-corrections-2026-09-05.md
@@ -1,0 +1,88 @@
+# Chapter 3 context corrections — research record
+
+**Date:** 2026-09-05
+**Research worktree:** `codex/content-book-ch03-context-research` at
+`673ac3686`
+**Chapter source binding:** `src/content/docs/ai-history/ch-03-the-physical-bridge.md`
+at blob `b7a793f1148035f299023da07b4df01e53d262f5`
+
+This is an unpublished evidence record for a separate research PR. It does not
+edit chapter prose, certify claims, or provide a final acceptance decision.
+
+## Source bindings
+
+Owens, Yamada and TICSP's historical introduction are secondary historical
+accounts; TICSP's reproduced original paper pages are primary facsimile evidence
+only for the text actually visible. Do not treat a later account as a contemporary
+record of Shannon's motives or a complete priority survey.
+
+### Analyzer chronology
+
+- Larry Owens, “Vannevar Bush and the Differential Analyzer,” *Technology and
+  Culture* 27 (1986), pp. 63–95. Publisher record:
+  `https://www.jstor.org/stable/3104945`; accessible PDF mirror:
+  `https://worrydream.com/refs/Owens_1986_-_Vannevar_Bush_and_the_Differential_Analyzer.pdf`.
+- Owens printed p. 63 describes the 1942 wartime dedication and large finished
+  machine; its note dates the first demonstration to 13 December 1941. Printed
+  p. 72 identifies the 1931 six-disc-integrator machine. Printed p. 79 dates
+  the March 1936 $85,000 grant and calls automatic control “a software
+  problem.” Printed p. 81 repeats 13 December 1941 and says Pearl Harbor was
+  six days before Caldwell’s demonstration.
+- **Bounded correction:** chapter line 70’s “post-war scale” conflicts with
+  these dates. Use “1941–42 wartime” or “finished-machine” scale. Owens does
+  not name Shannon, so it cannot independently establish Shannon’s duties or
+  motivation in lines 72–74.
+
+### Yamada attribution and priority
+
+- Akihiko Yamada, “History of Research on Switching Theory in Japan,” *IEEJ
+  Transactions on Fundamentals and Materials* 124(8) (2004), pp. 720–726,
+  DOI `10.1541/ieejfms.124.720`, J-STAGE:
+  `https://www.jstage.jst.go.jp/article/ieejfms/124/8/124_8_720/_article`.
+- The English abstract records Nakashima’s September 1935 invited speech,
+  1934 publications, 1936 Nakashima/Hanzawa design method, and Shannon’s 1938
+  publication. Visual review of printed p. 725 supports a cautious manual
+  translation: Nakashima was about 1–2 years ahead; whether Shannon saw his
+  papers before his first publication was unknown; their approaches differed
+  over prior knowledge/use of Boolean algebra. **Flag this translation for
+  Japanese-language review; it is not accepted wording.**
+- Stanković & Astola, TICSP Report 40 (2008), printed p. 17, says that Yamada
+  identified Nakashima’s 1935 work as “the first paper on switching theory in
+  the World.” Its reference `[21]` is Yamada’s 2003 `C` article; `[22]` is the
+  retrieved 2004 IEEJ article (printed p. 20). The chapter line 80 therefore
+  should not present that sentence as a directly checked Yamada-2004 quotation.
+- Accessible archive: [ETHW TICSP reprints](https://ethw.org/Archives:TICSP_Reprints_from_the_Early_Days_of_Information_Technologies),
+  linked [Report 40 PDF](https://ethw-images.s3.us-east-va.perf.cloud.ovh.us/ethw/2/2f/Report-40.pdf).
+  Retrieved PDF SHA-256: `6e1cc3acd974120529649e2a5b88369e158b4d6fb5710241225209d531ad6dd3`.
+- **Bounded correction:** attribute the global-priority wording to the TICSP
+  report, or defer it until Yamada 2003 `[21]` is retrieved and page-anchored.
+  Preserve the independent-discovery hedge; do not infer influence from the
+  chronology.
+
+### Piesch and Plechl/Duschek
+
+- TICSP Report 40’s accessible facsimile, printed p. 183, is the first page of
+  Hansi Piesch, “Begriff der allgemeinen Schaltungstechnik,” *Archiv für
+  Elektrotechnik* 33 (1939), 672–686. Its overview describes a systematic
+  treatment of general circuit questions, and footnote 1 cites a Nakashima /
+  Hanzawa February 1938 paper. Springer metadata/DOI:
+  `https://doi.org/10.1007/BF01656419`; full PDF redirected to access control.
+- The same facsimile, printed p. 185, is the first page of Otto Plechl and
+  Adolf Duschek, “Grundzüge einer Algebra der elektrischen Schaltungen,”
+  *Österreichisches Ingenieur-Archiv* I (1946), 203–230. Printed p. 186
+  references Nakashima/Hanzawa and Piesch; no Shannon reference is visible on
+  the two reprinted pages.
+- **Bounded correction:** dates/titles and the accessible scope are supported.
+  “First sustained German-language formulation,” “too late to be a true
+  parallel discovery,” and a whole-publication claim that Plechl/Duschek’s
+  first publication cited Nakashima but not Shannon exceed these page limits;
+  qualify or withdraw them pending complete paper/reference access.
+
+## Access record and disposition
+
+Local retrieval cache, relative to this worktree root: `../content-canonical-routes/.agent/`
+(`ch03-2339-primary-retrieval-manifest.json`). TICSP direct asset was retrieved
+from the ETHW-linked S3 host; its original ETHW PDF URL returns 404. Yamada’s
+PDF is image-only; TICSP’s relevant pages and Owens pp. 63, 72, 79, 81 were
+visually checked. No source acceptance flag, prose revision, or final chapter
+verdict follows from this record.

--- a/docs/research/ai-history/chapters/ch-03-the-physical-bridge/context-corrections-2026-09-05.md
+++ b/docs/research/ai-history/chapters/ch-03-the-physical-bridge/context-corrections-2026-09-05.md
@@ -72,6 +72,11 @@ record of Shannon's motives or a complete priority survey.
   *Österreichisches Ingenieur-Archiv* I (1946), 203–230. Printed p. 186
   references Nakashima/Hanzawa and Piesch; no Shannon reference is visible on
   the two reprinted pages.
+- The Plechl/Duschek p. 204 facsimile labels its Piesch references “1937.”
+  Do not silently normalize that printed detail: the [Piesch publisher record](https://link.springer.com/article/10.1007/BF01656419)
+  gives receipt on 28 February 1939 and publication in October 1939 (checked
+  2026-09-05). Use the publisher's date for Piesch's article chronology and
+  preserve the citation discrepancy when discussing Plechl/Duschek's footnotes.
 - **Bounded correction:** dates/titles and the accessible scope are supported.
   “First sustained German-language formulation,” “too late to be a true
   parallel discovery,” and a whole-publication claim that Plechl/Duschek’s


### PR DESCRIPTION
Chapter 3 mixes a wartime analyzer with “post-war” wording, attributes an indirectly reported priority quotation to the wrong Yamada publication, and draws publication-wide conclusions from short facsimile extracts. This research record binds the corrective wording to accessible pages and separates supported claims from those that need withdrawal or further evidence.

It also preserves a bibliographic discrepancy: Plechl and Duschek's facsimile prints 1937 for Piesch, while Piesch's publisher record dates the article to October 1939. Japanese-language interpretation and inaccessible portions remain explicitly bounded. No published prose or acceptance flags change.

Refs #2339 and #2289. A separately reviewed prose packet follows this research merge.

Validation: one unpublished research file, 93 added lines; `git diff --check` clean; no generated artifacts; primary remains clean on `main`. Claude source-fidelity review `smart-claude-review-1788582111` passed the initial record; follow-up `smart-claude-review-1788582448` passed the final facsimile/date-discrepancy check. The book-only exception applies: local curriculum pipeline and site build were not run for this research-only PR. Required Google review will be posted before merge.
