### PR TITLE
fix(linux): repair seven next-module browser links (#2354)

### DIFF
--- a/src/content/docs/linux/foundations/container-primitives/module-2.2-cgroups.md
+++ b/src/content/docs/linux/foundations/container-primitives/module-2.2-cgroups.md
@@ -679,4 +679,4 @@ This optional exercise should be done only on a disposable host or lab VM. If th
 
 ## Next Module
 
-[Next Module: Capabilities & Linux Security Modules](./module-2.3-capabilities-lsms/) shows how Linux narrows what a process may do even after namespaces shape its view and cgroups constrain its resource use.
+[Next Module: Capabilities & Linux Security Modules](../module-2.3-capabilities-lsms/) shows how Linux narrows what a process may do even after namespaces shape its view and cgroups constrain its resource use.

--- a/src/content/docs/linux/foundations/networking/module-3.4-iptables-netfilter.md
+++ b/src/content/docs/linux/foundations/networking/module-3.4-iptables-netfilter.md
@@ -672,7 +672,7 @@ The busiest rule is not automatically the broken rule; it is the rule most traff
 
 ## Next Module
 
-[Next Module: Security](../../security/) moves from packet-level controls to process and kernel hardening with AppArmor, SELinux, seccomp, and practical host defense.
+[Next Module: Security](../../../security/) moves from packet-level controls to process and kernel hardening with AppArmor, SELinux, seccomp, and practical host defense.
 
 ## Sources
 

--- a/src/content/docs/linux/foundations/system-essentials/module-1.1-kernel-architecture.md
+++ b/src/content/docs/linux/foundations/system-essentials/module-1.1-kernel-architecture.md
@@ -786,4 +786,4 @@ A strong judgment might say, "This host is a reasonable candidate for a lab node
 
 ## Next Module
 
-Continue to [Module 1.2: Processes & systemd](./module-1.2-processes-systemd/), where you will connect the kernel's process model to services, PID 1, supervision, and the way containers behave as isolated Linux processes.
+Continue to [Module 1.2: Processes & systemd](../module-1.2-processes-systemd/), where you will connect the kernel's process model to services, PID 1, supervision, and the way containers behave as isolated Linux processes.

--- a/src/content/docs/linux/foundations/system-essentials/module-1.4-users-permissions.md
+++ b/src/content/docs/linux/foundations/system-essentials/module-1.4-users-permissions.md
@@ -495,7 +495,7 @@ kubectl delete namespace users-perms-lab
 
 ## Next Module
 
-[Container Primitives](../container-primitives/) shows how namespaces, cgroups, capabilities, and filesystems combine with the identity and permission model from this module to create container isolation.
+[Container Primitives](../../container-primitives/) shows how namespaces, cgroups, capabilities, and filesystems combine with the identity and permission model from this module to create container isolation.
 
 ## Sources
 

--- a/src/content/docs/linux/operations/performance/module-5.3-memory-management.md
+++ b/src/content/docs/linux/operations/performance/module-5.3-memory-management.md
@@ -780,7 +780,7 @@ docker rm -f mem-test
 
 ## Next Module
 
-[Module 5.4: I/O Performance](module-5.4-io-performance/) shows how disk I/O, filesystems, block devices, and storage latency shape the memory symptoms you just learned to read.
+[Module 5.4: I/O Performance](../module-5.4-io-performance/) shows how disk I/O, filesystems, block devices, and storage latency shape the memory symptoms you just learned to read.
 
 ## Sources
 

--- a/src/content/docs/linux/operations/troubleshooting/module-6.2-log-analysis.md
+++ b/src/content/docs/linux/operations/troubleshooting/module-6.2-log-analysis.md
@@ -847,7 +847,7 @@ The retention commands help you design rather than merely consume logs. If a jou
 
 ## Next Module
 
-[Module 6.3: Process Debugging](./module-6.3-process-debugging/) shows how to trace process behavior with `strace`, inspect `/proc`, and debug hung or misbehaving processes when logs tell you where to look but not what the process is doing.
+[Module 6.3: Process Debugging](../module-6.3-process-debugging/) shows how to trace process behavior with `strace`, inspect `/proc`, and debug hung or misbehaving processes when logs tell you where to look but not what the process is doing.
 
 ## Sources
 

--- a/src/content/docs/linux/security/hardening/module-4.3-selinux.md
+++ b/src/content/docs/linux/security/hardening/module-4.3-selinux.md
@@ -760,7 +760,7 @@ sudo rm -rf /srv/testapp
 
 ## Next Module
 
-Next, read [Module 4.4: seccomp Profiles](./module-4.4-seccomp/) to learn how system call filtering blocks dangerous kernel interactions even when the process, file labels, and Linux permissions would otherwise allow execution.
+Next, read [Module 4.4: seccomp Profiles](../module-4.4-seccomp/) to learn how system call filtering blocks dangerous kernel interactions even when the process, file labels, and Linux permissions would otherwise allow execution.
 
 ## Sources
 


### PR DESCRIPTION
Seven Linux “Next Module” links resolved to missing nested paths in the browser. This changes only their hrefs so five reach sibling lessons and two reach the intended section hubs from the current page's canonical URL.

All surrounding prose, quizzes, labs and translation files are unchanged. The exact seven source replacements were independently checked; the rendered links resolve with native URL semantics to existing targets with the intended canonical URL and title.

Validation: 176 pipeline tests passed (3.147s), primary-driven build passed (2,169 pages, 33.89s), all seven rendered Next links checked, diff clean. Independent Google review `smart-agy-review-1788582811` passed at `f077bc4176c9cd83993dc9061446f6dfbd107cf6`. Seven files, +7/-7 lines.

Refs #2354 and #2346. Deployment smoke remains pending; #2354 stays open until the public links and destinations are verified. This is navigation repair, not Linux factual or lab acceptance.
