### PR TITLE
feat(quality): export audited Starlight document routes (#2346)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import { unified } from '@astrojs/markdown-remark';
 import starlight from '@astrojs/starlight';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
+import { routeManifestIntegration } from './scripts/quality/route-manifest-integration.mjs';
 
 const projectRoot = fileURLToPath(new URL('.', import.meta.url));
 const ignoredDevWatchPaths = [
@@ -691,5 +692,6 @@ export default defineConfig({
         { label: 'Glossary', link: '/glossary/' },
       ],
     }),
+    routeManifestIntegration(),
   ],
 });

--- a/scripts/quality/route-manifest-endpoint.ts
+++ b/scripts/quality/route-manifest-endpoint.ts
@@ -56,6 +56,7 @@ function routeRecord(route: (typeof routes)[number], value: ReturnType<typeof co
   const source = route.entry.filePath;
   if (source.startsWith('/') || source.split('/').includes('..')) unsupported(`Starlight source is not site-relative: ${source}`);
   const url = runtimeUrlFromPathname(value.site, value.base, slugToPathname(route.id));
+  if (url.origin !== new URL(value.site as string).origin || url.search || url.hash) unsupported(`route id does not produce a same-origin pathname: ${route.id}`);
   const canonical = formatCanonical(url.href, { format: value.buildFormat, trailingSlash: value.trailingSlash });
   return { id: route.id, url: canonical, pathname: new URL(canonical).pathname, source, sourceSha256: hashSource(source), isFallback: route.isFallback === true, locale: route.locale ?? null, lang: route.lang ?? null };
 }

--- a/scripts/quality/route-manifest-endpoint.ts
+++ b/scripts/quality/route-manifest-endpoint.ts
@@ -1,0 +1,81 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { routes } from '#kubedojo-quality-starlight-routing';
+import { formatCanonical } from '#kubedojo-quality-starlight-canonical';
+import { slugToPathname } from '#kubedojo-quality-starlight-slugs';
+import project from 'virtual:starlight/project-context';
+import manifestConfig from 'virtual:kubedojo-quality-route-manifest-config';
+import { runtimeUrlFromPathname } from './route-manifest-integration.mjs';
+
+const configValue = manifestConfig as {
+  schemaVersion: number;
+  site: string | null;
+  base: string;
+  trailingSlash: 'always' | 'never' | 'ignore';
+  buildFormat: 'directory' | 'file' | 'preserve';
+  redirects: { source: string; target: string; status: number | null }[];
+};
+
+const unsupported = (reason: string): never => {
+  throw new Error(`KubeDojo route manifest unsupported: ${reason}`);
+};
+
+const sourceHashes = new Map<string, string>();
+
+function hashSource(source: string) {
+  const known = sourceHashes.get(source);
+  if (known) return known;
+  const root = new URL(project.root);
+  if (root.protocol !== 'file:') unsupported('Starlight project root is not file-based');
+  let bytes: Buffer;
+  try {
+    bytes = readFileSync(resolve(fileURLToPath(root), source));
+  } catch (error) {
+    throw new Error(`KubeDojo route manifest cannot hash Starlight source: ${source}`, { cause: error });
+  }
+  const hash = createHash('sha256').update(bytes).digest('hex');
+  sourceHashes.set(source, hash);
+  return hash;
+}
+
+function config() {
+  const value = configValue;
+  if (value?.schemaVersion !== 1) unsupported('unknown manifest configuration schema');
+  if (!value.site || value.buildFormat !== 'directory') unsupported('site and directory build format are required');
+  if (!['always', 'never', 'ignore'].includes(value.trailingSlash)) unsupported('unknown trailingSlash policy');
+  if (typeof value.base !== 'string' || !value.base.startsWith('/')) unsupported('base must be root-relative');
+  return value;
+}
+
+function routeRecord(route: (typeof routes)[number], value: ReturnType<typeof config>) {
+  if (typeof route?.id !== 'string' || typeof route.entry?.filePath !== 'string' || !route.entry.filePath) {
+    unsupported('Starlight route is missing an id or source mapping');
+  }
+  const source = route.entry.filePath;
+  if (source.startsWith('/') || source.split('/').includes('..')) unsupported(`Starlight source is not site-relative: ${source}`);
+  const url = runtimeUrlFromPathname(value.site, value.base, slugToPathname(route.id));
+  const canonical = formatCanonical(url.href, { format: value.buildFormat, trailingSlash: value.trailingSlash });
+  return { id: route.id, url: canonical, pathname: new URL(canonical).pathname, source, sourceSha256: hashSource(source), isFallback: route.isFallback === true, locale: route.locale ?? null, lang: route.lang ?? null };
+}
+
+function collisionSummary(records: ReturnType<typeof routeRecord>[]) {
+  const groups = new Map<string, ReturnType<typeof routeRecord>[]>();
+  for (const record of records) groups.set(record.pathname, [...(groups.get(record.pathname) ?? []), record]);
+  const collisions = [...groups].filter(([, entries]) => entries.length > 1);
+  if (!collisions.length) return;
+  const listed = collisions.slice(0, 6).map(([pathname, entries]) => `${pathname}: ${entries.slice(0, 3).map(({ id, source, isFallback }) => `${id} (${source}, fallback=${isFallback})`).join(' | ')}`).join('; ');
+  return `Starlight route ambiguity in ${collisions.length} canonical pathname(s): ${listed}${collisions.length > 6 ? '; additional collisions omitted' : ''}`;
+}
+
+export function GET() {
+  const value = config();
+  const records = routes.map((route) => routeRecord(route, value));
+  const collisions = collisionSummary(records);
+  if (collisions) unsupported(collisions);
+  const { redirects, schemaVersion: _schemaVersion, ...snapshot } = value;
+  return new Response(JSON.stringify({ schemaVersion: 1, scope: 'starlight-document-routes', config: snapshot, routes: records, redirects }, null, 2) + '\n', {
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+  });
+}

--- a/scripts/quality/route-manifest-integration.mjs
+++ b/scripts/quality/route-manifest-integration.mjs
@@ -1,0 +1,79 @@
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+export const ROUTE_MANIFEST_ENV = 'KUBEDOJO_ROUTE_MANIFEST';
+export const ROUTE_MANIFEST_PATTERN = '/_quality/routes.json';
+const CONFIG_MODULE = 'virtual:kubedojo-quality-route-manifest-config';
+
+/** Match Astro's absolute context.url.pathname before Starlight formats the canonical URL. */
+export function runtimeUrlFromPathname(site, base, pathname) {
+  if (!base.startsWith('/') || !pathname.startsWith('/')) throw new Error('KubeDojo route manifest requires root-relative base and pathname');
+  const normalizedBase = base.endsWith('/') ? base : `${base}/`;
+  return new URL(`${normalizedBase}${pathname.slice(1)}`, site);
+}
+
+function privateStarlightModule(pathname) {
+  let entrypoint;
+  try {
+    entrypoint = new URL(import.meta.resolve('@astrojs/starlight'));
+  } catch (error) {
+    throw new Error('KubeDojo route manifest requires a resolvable @astrojs/starlight package', { cause: error });
+  }
+  if (entrypoint.protocol !== 'file:') throw new Error('KubeDojo route manifest requires a file-based Starlight package');
+  const module = new URL(pathname, entrypoint);
+  if (!existsSync(module)) throw new Error(`KubeDojo route manifest is incompatible with this Starlight package: missing ${pathname}`);
+  return fileURLToPath(module);
+}
+
+function manifestConfig(config) {
+  return {
+    schemaVersion: 1,
+    site: typeof config.site === 'string' ? config.site : config.site?.href ?? null,
+    base: config.base,
+    trailingSlash: config.trailingSlash,
+    buildFormat: config.build.format,
+    redirects: Object.entries(config.redirects).map(([source, target]) => ({
+      source,
+      target: typeof target === 'string' ? target : target.destination,
+      status: typeof target === 'string' ? null : target.status,
+    })),
+  };
+}
+
+/** Inject the audit-only endpoint and bridge Starlight's runtime-only route modules. */
+export function routeManifestIntegration() {
+  let snapshot;
+  const configModule = {
+    name: 'kubedojo-route-manifest-config',
+    resolveId: (id) => id === CONFIG_MODULE ? `\0${CONFIG_MODULE}` : undefined,
+    load: (id) => {
+      if (id !== `\0${CONFIG_MODULE}`) return undefined;
+      if (!snapshot) throw new Error('KubeDojo route manifest did not receive resolved Astro config');
+      return `export default ${JSON.stringify(snapshot)}`;
+    },
+  };
+  return {
+    name: 'kubedojo-route-manifest',
+    hooks: {
+      'astro:config:setup': ({ injectRoute, updateConfig }) => {
+        if (process.env[ROUTE_MANIFEST_ENV] !== '1') return;
+        updateConfig({
+          vite: {
+            plugins: [configModule],
+            resolve: {
+              alias: {
+                '#kubedojo-quality-starlight-routing': privateStarlightModule('./utils/routing/index.ts'),
+                '#kubedojo-quality-starlight-slugs': privateStarlightModule('./utils/slugs.ts'),
+                '#kubedojo-quality-starlight-canonical': privateStarlightModule('./utils/canonical.ts'),
+              },
+            },
+          },
+        });
+        injectRoute({ pattern: ROUTE_MANIFEST_PATTERN, entrypoint: new URL('./route-manifest-endpoint.ts', import.meta.url), prerender: true });
+      },
+      'astro:config:done': ({ config }) => {
+        if (process.env[ROUTE_MANIFEST_ENV] === '1') snapshot = manifestConfig(config);
+      },
+    },
+  };
+}

--- a/scripts/quality/route-manifest.test.mjs
+++ b/scripts/quality/route-manifest.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { ROUTE_MANIFEST_ENV, ROUTE_MANIFEST_PATTERN, routeManifestIntegration, runtimeUrlFromPathname } from './route-manifest-integration.mjs';
+
+const config = { site: 'https://site.test/contained-path/', base: '/docs/', trailingSlash: 'always', build: { format: 'directory' }, redirects: { '/old/': '/new/' } };
+
+test('does not change standard builds', () => {
+  const prior = process.env[ROUTE_MANIFEST_ENV];
+  delete process.env[ROUTE_MANIFEST_ENV];
+  const hook = routeManifestIntegration().hooks['astro:config:setup'];
+  let calls = 0;
+  hook({ config, injectRoute: () => calls++, updateConfig: () => calls++ });
+  if (prior === undefined) delete process.env[ROUTE_MANIFEST_ENV]; else process.env[ROUTE_MANIFEST_ENV] = prior;
+  assert.equal(calls, 0);
+});
+
+test('enabled build injects the audit endpoint and exact resolved config', () => {
+  const prior = process.env[ROUTE_MANIFEST_ENV];
+  process.env[ROUTE_MANIFEST_ENV] = '1';
+  const integration = routeManifestIntegration();
+  const hook = integration.hooks['astro:config:setup'];
+  let update, route;
+  hook({ config, updateConfig: (value) => update = value, injectRoute: (value) => route = value });
+  integration.hooks['astro:config:done']({ config });
+  if (prior === undefined) delete process.env[ROUTE_MANIFEST_ENV]; else process.env[ROUTE_MANIFEST_ENV] = prior;
+  assert.deepEqual(route.pattern, ROUTE_MANIFEST_PATTERN);
+  assert.equal(route.prerender, true);
+  const source = update.vite.plugins[0].load('\0virtual:kubedojo-quality-route-manifest-config');
+  const snapshot = JSON.parse(source.replace('export default ', ''));
+  assert.deepEqual(snapshot, { schemaVersion: 1, site: 'https://site.test/contained-path/', base: '/docs/', trailingSlash: 'always', buildFormat: 'directory', redirects: [{ source: '/old/', target: '/new/', status: null }] });
+  assert.deepEqual(Object.keys(update.vite.resolve.alias).sort(), ['#kubedojo-quality-starlight-canonical', '#kubedojo-quality-starlight-routing', '#kubedojo-quality-starlight-slugs']);
+});
+
+test('canonical runtime pathname stays absolute when site has a path and base changes', () => {
+  assert.equal(runtimeUrlFromPathname('https://site.test/contained-path/', '/docs/', '/uk/lesson/').href, 'https://site.test/docs/uk/lesson/');
+});


### PR DESCRIPTION
When source slugs collide, a source-file check can miss the English fallback actually selected at a Ukrainian URL. Add an opt-in audit endpoint that exports the installed Starlight document routes, canonical paths, locales, fallback status, source paths, and SHA-256 hashes. Duplicate paths or unsupported configuration fail the audit build.

Refs #2346 and #2272. Enable with `KUBEDOJO_ROUTE_MANIFEST=1`; ordinary builds do not emit the endpoint. This is the document-route producer only. Custom Astro homepages, consumer integration, redirect destination validation, and Node test wiring remain open under #2346.

Validation: three Node test groups; 176 pipeline tests; full audit build (2,169 pages); reconciliation of 2,166 unique document routes against rendered canonicals and all 1,639 tracked source hashes at the reviewed commit. Controlled fixtures cover a configured base, Unicode source and slug, Ukrainian fallback, ordinary-build endpoint absence, duplicate paths, unsupported file build format, and query-bearing route rejection. Literal hash/percent source filenames are not claimed supported: the upstream loader omitted that negative fixture.

Google review `smart-agy-review-1788583229` passed the exact head `9e11910b4b01988105a2a84d7e42738141ac3019`; review posted separately. Four files, 199 added lines. No generated artifacts. Source hashes are a build-time snapshot, not a race-free provenance guarantee.
