### PR TITLE
feat(quality): validate document route-set metadata (#2358)

### DIFF
--- a/scripts/quality/document-route-set.mjs
+++ b/scripts/quality/document-route-set.mjs
@@ -1,0 +1,94 @@
+export class UnsupportedDocumentRouteManifest extends TypeError {}
+
+const fail = (message) => { throw new UnsupportedDocumentRouteManifest(message); };
+const object = (value, label) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(`${label} must be an object`);
+  return value;
+};
+const text = (value, label) => {
+  if (typeof value !== 'string' || !value) fail(`${label} must be non-empty text`);
+  return value;
+};
+const optionalText = (value, label) => {
+  if (value !== null && (typeof value !== 'string' || !value)) fail(`${label} must be non-empty text or null`);
+  return value;
+};
+
+function originFor(config) {
+  const site = text(config.site, 'config.site');
+  let url;
+  try { url = new URL(site); } catch { fail('config.site must be a URL'); }
+  if (!['http:', 'https:'].includes(url.protocol) || url.username || url.password || url.search || url.hash) fail('config.site must be an HTTP(S) URL without credentials, query, or fragment');
+  if (typeof config.base !== 'string' || !config.base.startsWith('/') || config.base.startsWith('//') || config.base.includes('?') || config.base.includes('#')) fail('config.base must be a root-relative path');
+  if (new URL(config.base, url.origin).pathname !== config.base) fail('config.base must be a serialized root-relative path');
+  if (!['always', 'never', 'ignore'].includes(config.trailingSlash)) fail('config.trailingSlash is unsupported');
+  if (config.buildFormat !== 'directory') fail('config.buildFormat is unsupported');
+  return { origin: url.origin, base: config.base };
+}
+
+function safeSource(value) {
+  const source = text(value, 'route.source');
+  if (/[\u0000-\u001f\u007f]/.test(source) || source.startsWith('/') || source.startsWith('\\') || source.includes('\\') || source.split('/').some((part) => !part || part === '.' || part === '..')) fail('route.source must be a safe relative path');
+  return source;
+}
+
+function serializedPath(value, origin) {
+  const pathname = text(value, 'route.pathname');
+  if (!pathname.startsWith('/') || pathname.startsWith('//') || pathname.includes('?') || pathname.includes('#')) fail('route.pathname must be a root-relative serialized pathname');
+  let url;
+  try { url = new URL(pathname, origin); } catch { fail('route.pathname must be a URL pathname'); }
+  if (url.origin !== origin || url.pathname !== pathname || url.search || url.hash) fail('route.pathname must be a serialized pathname');
+  return pathname;
+}
+
+function record(value, { origin, base }) {
+  object(value, 'route');
+  const pathname = serializedPath(value.pathname, origin);
+  const root = base.endsWith('/') ? base.slice(0, -1) : base;
+  if (base !== '/' && pathname !== root && !pathname.startsWith(`${root}/`)) fail('route.pathname must lie under config.base');
+  const urlText = text(value.url, 'route.url');
+  let url;
+  try { url = new URL(urlText); } catch { fail('route.url must be a URL'); }
+  if (url.href !== urlText || url.origin !== origin || url.username || url.password || url.search || url.hash || url.pathname !== pathname) fail('route.url must be a same-origin serialized URL matching route.pathname');
+  if (typeof value.isFallback !== 'boolean') fail('route.isFallback must be boolean');
+  const hash = text(value.sourceSha256, 'route.sourceSha256');
+  if (!/^[a-f\d]{64}$/.test(hash)) fail('route.sourceSha256 must be lowercase SHA-256 hex');
+  return { id: text(value.id, 'route.id'), url: urlText, pathname, source: safeSource(value.source), sourceSha256: hash, isFallback: value.isFallback, locale: optionalText(value.locale, 'route.locale'), lang: optionalText(value.lang, 'route.lang') };
+}
+
+function validateRedirects(value) {
+  if (!Array.isArray(value)) fail('manifest.redirects must be an array');
+  value.forEach((redirect) => {
+    object(redirect, 'redirect');
+    if (redirect.status !== null && (!Number.isInteger(redirect.status) || redirect.status < 300 || redirect.status > 399)) fail('redirect.status must be a 3xx integer or null');
+    text(redirect.source, 'redirect.source');
+    text(redirect.target, 'redirect.target');
+  });
+}
+
+/** Validate a schema-1 document manifest without inferring routes from source files. */
+export function buildDocumentRouteSet(manifest) {
+  object(manifest, 'manifest');
+  if (manifest.schemaVersion !== 1 || manifest.scope !== 'starlight-document-routes') fail('unsupported manifest schema or scope');
+  const config = originFor(object(manifest.config, 'manifest.config'));
+  validateRedirects(manifest.redirects);
+  if (!Array.isArray(manifest.routes)) fail('manifest.routes must be an array');
+  const routes = manifest.routes.map((route) => record(route, config));
+  const targetPaths = new Set();
+  const bySource = new Map();
+  for (const route of routes) {
+    if (targetPaths.has(route.pathname)) fail(`duplicate route.pathname: ${route.pathname}`);
+    targetPaths.add(route.pathname);
+    const entries = bySource.get(route.source) ?? [];
+    entries.push(route);
+    bySource.set(route.source, entries);
+  }
+  const primaryBySource = new Map();
+  for (const [source, entries] of bySource) {
+    if (new Set(entries.map((entry) => entry.sourceSha256)).size !== 1) fail(`inconsistent sourceSha256 for ${source}`);
+    const primary = entries.filter((entry) => !entry.isFallback);
+    if (primary.length !== 1) fail(`source requires exactly one primary route: ${source}`);
+    primaryBySource.set(source, primary[0]);
+  }
+  return { origin: config.origin, config: manifest.config, routes, targetPaths, primaryBySource, fallbacks: routes.filter((route) => route.isFallback) };
+}

--- a/scripts/quality/document-route-set.test.mjs
+++ b/scripts/quality/document-route-set.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildDocumentRouteSet } from './document-route-set.mjs';
+
+const hash = (digit = 'a') => digit.repeat(64);
+const route = (overrides = {}) => ({ id: 'guide/one', url: 'https://site.test/docs/guide/one/', pathname: '/docs/guide/one/', source: 'guide/one.md', sourceSha256: hash(), isFallback: false, locale: null, lang: null, ...overrides });
+const manifest = (routes = [route()], overrides = {}) => ({ schemaVersion: 1, scope: 'starlight-document-routes', config: { site: 'https://site.test/contained/', base: '/docs/', trailingSlash: 'always', buildFormat: 'directory' }, routes, redirects: [], ...overrides });
+const rejects = (value, pattern) => assert.throws(() => buildDocumentRouteSet(value), { name: 'TypeError', message: pattern });
+
+test('keeps primary and UK fallback target metadata separate', () => {
+  const fallback = route({ id: 'uk/guide/one', url: 'https://site.test/docs/uk/guide/one/', pathname: '/docs/uk/guide/one/', isFallback: true, locale: 'uk', lang: 'uk' });
+  const ukrainian = route({ id: 'uk/guide/two', url: 'https://site.test/docs/uk/guide/two/', pathname: '/docs/uk/guide/two/', source: 'uk/guide/two.md', locale: 'uk', lang: 'uk' });
+  const result = buildDocumentRouteSet(manifest([route(), fallback, ukrainian]));
+  assert.deepEqual([...result.targetPaths], ['/docs/guide/one/', '/docs/uk/guide/one/', '/docs/uk/guide/two/']);
+  assert.equal(result.primaryBySource.get('guide/one.md').url, 'https://site.test/docs/guide/one/');
+  assert.equal(result.primaryBySource.get('uk/guide/two.md').locale, 'uk');
+  assert.deepEqual(result.fallbacks, [fallback]);
+});
+
+test('keeps a percent-serialized Unicode dotted pathname and accepts root base paths', () => {
+  const unicode = route({ id: 'lab/naïve-1.2', url: 'https://site.test/docs/lab/na%C3%AFve-1.2/', pathname: '/docs/lab/na%C3%AFve-1.2/', source: 'lab/naïve-source.md' });
+  assert.equal(buildDocumentRouteSet(manifest([unicode])).targetPaths.has(unicode.pathname), true);
+  assert.equal(buildDocumentRouteSet(manifest([route({ url: 'https://site.test/elsewhere/', pathname: '/elsewhere/' })], { config: { ...manifest().config, base: '/' } })).targetPaths.has('/elsewhere/'), true);
+});
+
+test('rejects source hash conflicts and absent or ambiguous primaries', () => {
+  rejects(manifest([route(), route({ id: 'alias', url: 'https://site.test/docs/alias/', pathname: '/docs/alias/', sourceSha256: hash('b') })]), /inconsistent sourceSha256/);
+  rejects(manifest([route({ isFallback: true })]), /exactly one primary/);
+  rejects(manifest([route(), route({ id: 'alias', url: 'https://site.test/docs/alias/', pathname: '/docs/alias/' })]), /exactly one primary/);
+});
+
+test('rejects duplicate paths and non-serialized or cross-origin route URLs', () => {
+  rejects(manifest([route(), route({ id: 'two' })]), /duplicate route.pathname/);
+  rejects(manifest([route({ pathname: '/docs/%E2%9C%93/', url: 'https://site.test/docs/✓/' })]), /serialized URL/);
+  rejects(manifest([route({ url: 'https://other.test/docs/guide/one/' })]), /same-origin/);
+  rejects(manifest([route({ pathname: '/docs/../escape/', url: 'https://site.test/escape/' })]), /serialized pathname/);
+  rejects(manifest([route({ url: 'https://site.test/docs/other/' })]), /matching route.pathname/);
+  rejects(manifest([route({ url: 'https://site.test/docs/guide/one/?q=1' })]), /same-origin serialized URL/);
+  rejects(manifest([route({ url: 'https://site.test/elsewhere/', pathname: '/elsewhere/' })]), /lie under config.base/);
+});
+
+test('rejects unsupported schema/config/source metadata and leaves redirects out of targets', () => {
+  rejects(manifest([route()], { schemaVersion: 2 }), /schema or scope/);
+  rejects(manifest([route()], { scope: 'whole-site-routes' }), /schema or scope/);
+  rejects(manifest([route()], { config: { ...manifest().config, buildFormat: 'file' } }), /buildFormat/);
+  rejects(manifest([route()], { config: { ...manifest().config, base: '/✓/' } }), /serialized root-relative/);
+  rejects(manifest([route()], { config: { ...manifest().config, site: 'https://user@site.test/' } }), /credentials/);
+  rejects(manifest([route()], { config: { ...manifest().config, site: 'https://site.test/?q=1' } }), /query/);
+  rejects(manifest([route({ source: '../outside.md' })]), /safe relative/);
+  rejects(manifest([route({ source: 'bad\u0000name.md' })]), /safe relative/);
+  rejects(manifest([route({ source: 'bad\u001fname.md' })]), /safe relative/);
+  rejects(manifest([route({ sourceSha256: 'A'.repeat(64) })]), /SHA-256/);
+  rejects(manifest([route({ sourceSha256: 1 })]), /sourceSha256/);
+  rejects(manifest([route({ isFallback: 'false' })]), /isFallback/);
+  rejects(manifest([route({ locale: 1 })]), /locale/);
+  rejects(manifest([route()], { redirects: [{ source: '/old/', target: '/new/', status: 302.5 }] }), /3xx integer/);
+  rejects(manifest([route()], { redirects: [{ source: '/old/', target: '/new/', status: Number.NaN }] }), /3xx integer/);
+  rejects(manifest([route()], { redirects: [{ source: '/old/', target: '/new/', status: 200 }] }), /3xx integer/);
+  const result = buildDocumentRouteSet(manifest([route()], { redirects: [{ source: '/old/', target: '/docs/guide/one/', status: 301 }] }));
+  assert.equal(result.targetPaths.has('/old/'), false);
+  assert.equal('redirects' in result, false);
+});


### PR DESCRIPTION
Validate the document manifest before a link checker uses its routes. The adapter rejects malformed configuration, inconsistent URL/path pairs, duplicate paths, conflicting source hashes, and missing or ambiguous primary source mappings. Real Ukrainian fallback routes remain valid document targets while authored sources use their unique primary URL.

Refs #2358 and #2346. This is a pure metadata adapter: it does not verify current source bytes/completeness, add custom Astro routes, resolve redirects, or replace the legacy link gate. Redirect metadata never becomes an accepted target through this adapter.

Validation: five focused Node test groups; 176 pipeline tests; acceptance of the prior controlled manifest's2,166 targets/1,639 sources/527 fallbacks, pinned by manifest hash; diff check; independent Google review posted separately. No build needed for these two pure-code files. 156 added lines, no generated artifacts, clean primary main. Parent #2346 stays open for full integration.
