### PR TITLE
fix(quality): verify manifest source bytes and coverage (#2346)

### DIFF
--- a/scripts/quality/document-source-validation.mjs
+++ b/scripts/quality/document-source-validation.mjs
@@ -1,0 +1,63 @@
+import { createHash } from 'node:crypto';
+import { readFileSync, readdirSync, realpathSync, statSync } from 'node:fs';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
+import { buildDocumentRouteSet } from './document-route-set.mjs';
+
+export class UnsupportedDocumentSource extends Error {}
+const SOURCE_PREFIX = 'src/content/docs/';
+const fail = (message) => { throw new UnsupportedDocumentSource(message); };
+const hash = (path) => createHash('sha256').update(readFileSync(path)).digest('hex');
+const isInside = (root, path) => {
+  const value = relative(root, path);
+  return value !== '..' && !value.startsWith(`..${sep}`) && !isAbsolute(value);
+};
+
+function docsRoot(checkoutRoot) {
+  if (typeof checkoutRoot !== 'string' || !checkoutRoot) fail('checkout root must be text');
+  try {
+    const checkout = realpathSync(checkoutRoot);
+    const root = realpathSync(resolve(checkout, 'src/content/docs'));
+    if (!statSync(root).isDirectory()) fail('content docs root is not a directory');
+    if (!isInside(checkout, root)) fail('content docs root escapes checkout');
+    return { checkout, root };
+  } catch (error) {
+    if (error instanceof UnsupportedDocumentSource) throw error;
+    fail('content docs root is missing');
+  }
+}
+
+function sourceFile({ checkout, root }, source) {
+  if (!source.startsWith(SOURCE_PREFIX)) fail(`source must start with ${SOURCE_PREFIX}: ${source}`);
+  if (!/\.mdx?$/i.test(source)) fail(`source is not MD/MDX: ${source}`);
+  let path;
+  try { path = realpathSync(resolve(checkout, source)); } catch { fail(`source is missing: ${source}`); }
+  if (!isInside(root, path)) fail(`source escapes content root: ${source}`);
+  if (!statSync(path).isFile()) fail(`source is not a file: ${source}`);
+  return path;
+}
+
+function concreteSources(root, directory = root, found = new Set()) {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = resolve(directory, entry.name);
+    if (entry.isSymbolicLink()) fail(`content docs contains symlink: ${relative(root, path).split(sep).join('/')}`);
+    if (entry.isDirectory()) concreteSources(root, path, found);
+    else if (entry.isFile() && /\.mdx?$/i.test(entry.name)) found.add(`${SOURCE_PREFIX}${relative(root, path).split(sep).join('/')}`);
+  }
+  return found;
+}
+
+/** Compare manifest source-hash metadata with a checkout; this does not prove an immutable snapshot. */
+export function validateDocumentSources(manifest, checkoutRoot) {
+  const routeSet = buildDocumentRouteSet(manifest);
+  const root = docsRoot(checkoutRoot);
+  const represented = new Set();
+  for (const [source, primary] of routeSet.primaryBySource) {
+    const actual = hash(sourceFile(root, source));
+    if (actual !== primary.sourceSha256) fail(`stale source bytes: ${source}`);
+    represented.add(source);
+  }
+  for (const source of concreteSources(root.root)) {
+    if (!represented.has(source)) fail(`missing source coverage: ${source}`);
+  }
+  return { sourceCount: represented.size, fallbackCount: routeSet.fallbacks.length };
+}

--- a/scripts/quality/document-source-validation.test.mjs
+++ b/scripts/quality/document-source-validation.test.mjs
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { validateDocumentSources } from './document-source-validation.mjs';
+
+const hash = (text) => createHash('sha256').update(text).digest('hex');
+const source = (path) => `src/content/docs/${path}`;
+const route = (source, text, overrides = {}) => ({ id: source.replace(/\.mdx?$/, ''), url: `https://site.test/${source}/`, pathname: `/${source}/`, source, sourceSha256: hash(text), isFallback: false, locale: null, lang: null, ...overrides });
+const manifest = (routes) => ({ schemaVersion: 1, scope: 'starlight-document-routes', config: { site: 'https://site.test/', base: '/', trailingSlash: 'always', buildFormat: 'directory' }, routes, redirects: [] });
+const fixture = () => {
+  const root = mkdtempSync(join(tmpdir(), 'document-source-'));
+  const docs = join(root, 'src/content/docs');
+  mkdirSync(docs, { recursive: true });
+  return { root, docs, write: (source, text) => { mkdirSync(dirname(join(docs, source)), { recursive: true }); writeFileSync(join(docs, source), text); } };
+};
+const rejects = (fn, pattern) => assert.throws(fn, { name: 'Error', message: pattern });
+
+test('validates concrete EN, UK, and fallback source coverage', () => {
+  const f = fixture();
+  try {
+    f.write('guide.md', 'English'); f.write('uk/guide.md', 'Українська');
+    const en = route(source('guide.md'), 'English');
+    const fallback = route(source('guide.md'), 'English', { id: 'uk/guide', url: 'https://site.test/uk/guide/', pathname: '/uk/guide/', isFallback: true, locale: 'uk', lang: 'uk' });
+    const uk = route(source('uk/guide.md'), 'Українська', { id: 'uk/translated', url: 'https://site.test/uk/translated/', pathname: '/uk/translated/', locale: 'uk', lang: 'uk' });
+    assert.deepEqual(validateDocumentSources(manifest([en, fallback, uk]), f.root), { sourceCount: 2, fallbackCount: 1 });
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test('rejects changed bytes and missing or unrepresented files', () => {
+  const f = fixture();
+  try {
+    f.write('guide.md', 'before');
+    const stale = manifest([route(source('guide.md'), 'before')]);
+    f.write('guide.md', 'after');
+    rejects(() => validateDocumentSources(stale, f.root), /stale source bytes/);
+    rejects(() => validateDocumentSources(manifest([route('guide.md', 'after')]), f.root), /must start with src\/content\/docs/);
+    rejects(() => validateDocumentSources(manifest([route(source('missing.md'), 'none')]), f.root), /source is missing/);
+    f.write('extra.mdx', 'extra');
+    rejects(() => validateDocumentSources(manifest([route(source('guide.md'), 'after')]), f.root), /missing source coverage: src\/content\/docs\/extra.mdx/);
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test('rejects an external symlink and non-file source', () => {
+  const f = fixture();
+  try {
+    const outside = join(f.root, 'outside.md'); writeFileSync(outside, 'outside');
+    symlinkSync(outside, join(f.docs, 'escape.md'));
+    rejects(() => validateDocumentSources(manifest([route(source('escape.md'), 'outside')]), f.root), /escapes content root/);
+    mkdirSync(join(f.docs, 'folder.md'));
+    rejects(() => validateDocumentSources(manifest([route(source('folder.md'), 'none')]), f.root), /source is not a file/);
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test('rejects a docs-root escape and unrepresented symlink entries', () => {
+  const f = fixture();
+  const outside = mkdtempSync(join(tmpdir(), 'outside-docs-'));
+  try {
+    rmSync(f.docs, { recursive: true }); symlinkSync(outside, f.docs);
+    rejects(() => validateDocumentSources(manifest([]), f.root), /root escapes checkout/);
+  } finally { rmSync(f.root, { recursive: true, force: true }); rmSync(outside, { recursive: true, force: true }); }
+  const g = fixture();
+  try {
+    g.write('guide.md', 'guide');
+    const outside = join(g.root, 'outside.md'); writeFileSync(outside, 'outside');
+    symlinkSync(outside, join(g.docs, 'unrepresented.md'));
+    rejects(() => validateDocumentSources(manifest([route(source('guide.md'), 'guide')]), g.root), /contains symlink: unrepresented.md/);
+    rmSync(join(g.docs, 'unrepresented.md'));
+    const directory = join(g.root, 'outside-dir'); mkdirSync(directory);
+    symlinkSync(directory, join(g.docs, 'unrepresented-dir'));
+    rejects(() => validateDocumentSources(manifest([route(source('guide.md'), 'guide')]), g.root), /contains symlink: unrepresented-dir/);
+  } finally { rmSync(g.root, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
The route manifest's hash fields alone cannot establish that the referenced source files still exist, match the build, or cover the content tree. This validator checks the manifest against an explicit checkout: it requires producer-style `src/content/docs/` source keys, verifies MD/MDX bytes, checks complete file coverage, and rejects missing/non-file sources, escaping paths, and symlink entries under the docs tree.

Refs #2346. This is a separate validation component, not link-gate or CI integration. It does not prove an immutable snapshot or Git provenance, and it does not accept custom routes or redirect chains.

Validation: nine focused Node tests passed, including stale/missing/extra files and symlink/prefix failures; 176 curriculum tests passed (4.718s); `git diff --check` clean. The preserved real producer manifest SHA-256 `422c15acf0f9757990b7a371b37a741c6eb8d580ff2c334b7f8954a6e91a6b0b` passed against its source checkout: 1,639 source files, 527 fallbacks. This was not a fresh build or current-main site acceptance.

Two files, 138 added lines. No published content/config changed, so local Astro build was not required. No generated artifacts; primary remains clean main. Google adversarial review `smart-agy-review-1788588514` passed after 231 seconds, including focused tests and the real-manifest check. The earlier three timeout attempts contributed no coverage. All CI passed on the reviewed head.
