### PR TITLE
fix(k8s): repair five CKS and CKAD Next links (#2371)

### DIFF
--- a/src/content/docs/k8s/ckad/part1-design-build/module-1.4-volumes.md
+++ b/src/content/docs/k8s/ckad/part1-design-build/module-1.4-volumes.md
@@ -950,7 +950,7 @@ k delete namespace volumes-lab --ignore-not-found
 
 ## Next Module
 
-Continue to the [Part 1 Cumulative Quiz](./part1-cumulative-quiz/) to practice designing and debugging Pods, Jobs, multi-container patterns, and volume-backed workloads together.
+Continue to the [Part 1 Cumulative Quiz](../part1-cumulative-quiz/) to practice designing and debugging Pods, Jobs, multi-container patterns, and volume-backed workloads together.
 
 ## Sources
 

--- a/src/content/docs/k8s/cks/part0-environment/module-0.4-exam-strategy.md
+++ b/src/content/docs/k8s/cks/part0-environment/module-0.4-exam-strategy.md
@@ -622,4 +622,4 @@ Before you continue, explain how the three-pass strategy uses that scoreboard vi
 
 ## Next Module
 
-[Module 1.1: Network Policies](../part1-cluster-setup/module-1.1-network-policies/) - Start Part 1 by turning the exam strategy into concrete network isolation skills.
+[Module 1.1: Network Policies](../../part1-cluster-setup/module-1.1-network-policies/) - Start Part 1 by turning the exam strategy into concrete network isolation skills.

--- a/src/content/docs/k8s/cks/part4-microservice-vulnerabilities/module-4.4-runtime-sandboxing.md
+++ b/src/content/docs/k8s/cks/part4-microservice-vulnerabilities/module-4.4-runtime-sandboxing.md
@@ -760,4 +760,4 @@ kind delete cluster --name cks-gvisor
 
 ## Next Module
 
-[Module 5.1: Image Security](../part5-supply-chain-security/module-5.1-image-security/) - Shift from runtime isolation to supply-chain hardening by auditing container images, reducing image attack surface, and controlling which artifacts are allowed into the cluster.
+[Module 5.1: Image Security](../../part5-supply-chain-security/module-5.1-image-security/) - Shift from runtime isolation to supply-chain hardening by auditing container images, reducing image attack surface, and controlling which artifacts are allowed into the cluster.

--- a/src/content/docs/k8s/cks/part5-supply-chain-security/module-5.2-image-scanning.md
+++ b/src/content/docs/k8s/cks/part5-supply-chain-security/module-5.2-image-scanning.md
@@ -560,4 +560,4 @@ When a scan returns more than one hundred CVEs and the timer is running, use a t
 
 ## Next Module
 
-[Module 5.3: Static Analysis with kubesec and OPA](./module-5.3-static-analysis/) - Scan Kubernetes manifests and enforce supply-chain policy before risky objects reach the API server.
+[Module 5.3: Static Analysis with kubesec and OPA](../module-5.3-static-analysis/) - Scan Kubernetes manifests and enforce supply-chain policy before risky objects reach the API server.

--- a/src/content/docs/k8s/cks/part5-supply-chain-security/module-5.4-admission-controllers.md
+++ b/src/content/docs/k8s/cks/part5-supply-chain-security/module-5.4-admission-controllers.md
@@ -684,4 +684,4 @@ Before moving on, explain why a mutating webhook that adds a sidecar can cause a
 
 ## Next Module
 
-[Module 6.1: Kubernetes Audit Logging](../part6-runtime-security/module-6.1-audit-logging/) - Continue from admission-time policy into runtime audit logging and forensics for workloads that have already been admitted.
+[Module 6.1: Kubernetes Audit Logging](../../part6-runtime-security/module-6.1-audit-logging/) - Continue from admission-time policy into runtime audit logging and forensics for workloads that have already been admitted.


### PR DESCRIPTION
Five CKS/CKAD Next links resolved beneath the current lesson URL and led to missing pages. Their hrefs now reach the intended existing English lesson or cumulative quiz. Link labels, frontmatter, and all other body bytes are unchanged.

Refs #2371. The issue stays open until deployment and live source/target checks succeed. This does not certify lesson facts, labs, exam currency, translations, or whole-track navigation.

Validation: exact one-substitution byte preservation for all five files; 176 pipeline tests passed (3.686s); Astro built 2,169 pages (54.14s); actual rendered source anchors and unique source/target canonical pages checked with native Node `new URL()`, intended titles, and source-hash bindings to runtime metadata; `git diff --check` clean. Five files, 5 added/5 removed lines; no generated artifacts; primary clean main.

Google cross-family review `smart-agy-review-1788589272` passed (130s), inspecting the five substitutions and runtime targets. Its URL check used Python `urljoin`; the separate lead-verified rendered check uses actual native Node URL resolution for these five cases. No claim of general browser equivalence for the Python check is made.
