### PR TITLE
fix(ai): repair five Next lesson links (#2374)

### DIFF
--- a/src/content/docs/ai/ai-building/module-1.1-from-chat-to-ai-systems.md
+++ b/src/content/docs/ai/ai-building/module-1.1-from-chat-to-ai-systems.md
@@ -408,4 +408,4 @@ Use evidence from your own design rather than optimism. If the model only drafts
 
 ## Next Module
 
-Continue to [Models, APIs, Context, and Structured Output](./module-1.2-models-apis-context-structured-output/) to turn this system map into concrete model calls and validated outputs.
+Continue to [Models, APIs, Context, and Structured Output](../module-1.2-models-apis-context-structured-output/) to turn this system map into concrete model calls and validated outputs.

--- a/src/content/docs/ai/ai-engineering-foundations/module-1.1-prompt-fundamentals.md
+++ b/src/content/docs/ai/ai-engineering-foundations/module-1.1-prompt-fundamentals.md
@@ -702,7 +702,7 @@ Use the exercise setup above to produce one prompt contract that can be reviewed
 
 This module gives the baseline contract model for the prompt layer.
 
-Next Module: [Reasoning and Logic Prompts](module-1.2-reasoning-and-logic-prompts/) builds on this baseline by separating task instructions from reasoning-control instructions and by deciding when the prompt should ask for explanation, hidden deliberation, direct answers, or proof-like structure.
+Next Module: [Reasoning and Logic Prompts](../module-1.2-reasoning-and-logic-prompts/) builds on this baseline by separating task instructions from reasoning-control instructions and by deciding when the prompt should ask for explanation, hidden deliberation, direct answers, or proof-like structure.
 
 [Prompt Safety and Evaluation](module-1.3-prompt-safety-and-evaluation/) extends the same contract model into adversarial input, refusal behavior, jailbreak resistance, and evaluation suites that make prompt safety reviewable instead of anecdotal.
 

--- a/src/content/docs/ai/ai-engineering-foundations/module-1.3-prompt-safety-and-evaluation.md
+++ b/src/content/docs/ai/ai-engineering-foundations/module-1.3-prompt-safety-and-evaluation.md
@@ -698,7 +698,7 @@ You will build a five-prompt LLM-as-judge eval suite for a content moderation ta
 
 ## Next Module
 
-Next module: [Prompt Libraries and Contracts](module-1.4-prompt-libraries-and-contracts/).
+Next module: [Prompt Libraries and Contracts](../module-1.4-prompt-libraries-and-contracts/).
 
 That module turns the harness mindset into a reusable prompt system: versioned prompt libraries, explicit prompt contracts, migration notes, compatibility checks, and reviewable change control for teams that maintain more than one prompt.
 

--- a/src/content/docs/ai/ai-engineering-foundations/module-2.3-retrieval-tools-and-memory-boundaries.md
+++ b/src/content/docs/ai/ai-engineering-foundations/module-2.3-retrieval-tools-and-memory-boundaries.md
@@ -931,6 +931,6 @@ Each item should be answerable from code, configuration, traces, or a documented
 
 ## Next Module
 
-Next module: [Dynamic Context Orchestration](module-2.4-dynamic-context-orchestration/).
+Next module: [Dynamic Context Orchestration](../module-2.4-dynamic-context-orchestration/).
 
 That module ties retrieval, tools, and memory together at request time so a harness can choose what to load, evict, summarize, or refresh on each turn instead of following one fixed context recipe for every task.

--- a/src/content/docs/ai/ai-for-kubernetes-platform-work/module-1.1-ai-for-yaml-manifests-config-review.md
+++ b/src/content/docs/ai/ai-for-kubernetes-platform-work/module-1.1-ai-for-yaml-manifests-config-review.md
@@ -718,4 +718,4 @@ Success criteria:
 
 ## Next Module
 
-Continue to [AI for Kubernetes Troubleshooting and Triage](./module-1.2-ai-for-kubernetes-troubleshooting-and-triage/) to practice using AI for incident investigation without letting the assistant outrank cluster evidence.
+Continue to [AI for Kubernetes Troubleshooting and Triage](../module-1.2-ai-for-kubernetes-troubleshooting-and-triage/) to practice using AI for incident investigation without letting the assistant outrank cluster evidence.


### PR DESCRIPTION
Five explicit Next links in EN AI lessons resolve under the current lesson's URL and lead to missing pages. Correct the relative traversal so they reach the existing sibling lessons identified by their labels and title/order.

Refs #2374, #2293. Five files, +5/-5; only the href tokens change. Ukrainian pages and module claims are outside this packet.

Validation: 176 pipeline tests; primary-run Astro build (2,169 pages); exact before/after source-byte checks; runtime manifest source/destination hashes; rendered document canonicals and anchors checked using native Node URL resolution; git diff --check. Google review `smart-agy-review-1788591017` PASS. The ignored rendered helper initially mishandled canonical-less helper pages and redirect aliases; lead corrected it to check unique concrete documents and reran all five checks successfully. No change to a shared gate is included.

Issue remains open until CI, merge and live deployment smoke complete.
