### PR TITLE
fix(progress): preserve malformed and legacy saved data (#2384)

### DIFF
--- a/src/scripts/progress-data.ts
+++ b/src/scripts/progress-data.ts
@@ -1,0 +1,45 @@
+/** Legacy route → completion-time records. Keys are retained, not catalog-filtered. */
+export type ProgressData = Record<string, number>;
+export type ProgressResult =
+  | { ok: true; data: ProgressData }
+  | { ok: false; reason: 'json' | 'shape' | 'entry'; raw: string };
+
+/** A failed read must not become an empty record that callers then overwrite. */
+export function parseProgress(raw: string | null): ProgressResult {
+  if (raw === null) return { ok: true, data: {} };
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return { ok: false, reason: 'json', raw };
+  }
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return { ok: false, reason: 'shape', raw };
+  }
+  const entries = Object.entries(value);
+  if (entries.some(([key, timestamp]) =>
+    key.length === 0 || typeof timestamp !== 'number' ||
+    !Number.isSafeInteger(timestamp) || timestamp <= 0)) {
+    return { ok: false, reason: 'entry', raw };
+  }
+  // fromEntries treats even "__proto__" as an own data property.
+  return { ok: true, data: Object.fromEntries(entries) };
+}
+
+export type ProgressMergeResult =
+  | { ok: true; data: ProgressData; serialized: string }
+  | { ok: false; source: 'existing' | 'import'; error: Extract<ProgressResult, { ok: false }> };
+
+/** Pure preparation: callers write only a successful result, reporting write failures. */
+export function prepareProgressImport(existingRaw: string | null, importedRaw: string): ProgressMergeResult {
+  const existing = parseProgress(existingRaw);
+  if (!existing.ok) return { ok: false, source: 'existing', error: existing };
+  const imported = parseProgress(importedRaw);
+  if (!imported.ok) return { ok: false, source: 'import', error: imported };
+  const entries = new Map(Object.entries(existing.data));
+  for (const [key, timestamp] of Object.entries(imported.data)) {
+    entries.set(key, Math.max(entries.get(key) ?? 0, timestamp));
+  }
+  const data = Object.fromEntries(entries);
+  return { ok: true, data, serialized: JSON.stringify(data) };
+}

--- a/tests/progress-data.test.ts
+++ b/tests/progress-data.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { parseProgress, prepareProgressImport } from '../src/scripts/progress-data';
+
+describe('legacy progress validation', () => {
+  it('distinguishes absent storage from malformed storage', () => {
+    expect(parseProgress(null)).toEqual({ ok: true, data: {} });
+    expect(parseProgress('')).toEqual({ ok: false, reason: 'json', raw: '' });
+  });
+
+  it.each(['null', '[]', 'true', '42', '"lesson"'])('rejects a non-map: %s', raw => {
+    expect(parseProgress(raw)).toEqual({ ok: false, reason: 'shape', raw });
+  });
+
+  it.each(['true', 'null', '"123"', '0', '-1', '1.5', '1e400', '9007199254740992', '{}', '[]'])
+  ('rejects an invalid timestamp without salvaging partial data: %s', timestamp => {
+    const raw = `{"known":123,"bad":${timestamp}}`;
+    expect(parseProgress(raw)).toEqual({ ok: false, reason: 'entry', raw });
+  });
+
+  it('rejects an empty route key', () => {
+    expect(parseProgress('{"":123}')).toMatchObject({ ok: false, reason: 'entry' });
+  });
+
+  it('preserves unknown, retired and language-specific keys without rewriting', () => {
+    const data = { 'retired/lesson': 1, 'uk/ai/lesson': 2, 'ai/lesson': 3 };
+    expect(parseProgress(JSON.stringify(data))).toEqual({ ok: true, data });
+  });
+});
+
+describe('non-destructive import preparation', () => {
+  it('merges both maps, retaining the newest timestamp for an exact key', () => {
+    const result = prepareProgressImport('{"old":2,"same":8}', '{"new":3,"same":4}');
+    expect(result).toEqual({
+      ok: true, data: { old: 2, same: 8, new: 3 }, serialized: '{"old":2,"same":8,"new":3}',
+    });
+    expect(prepareProgressImport(null, '{"new":3}')).toMatchObject({ ok: true, data: { new: 3 } });
+  });
+
+  it('does not replace unreadable existing data with an otherwise valid import', () => {
+    expect(prepareProgressImport('broken backup', '{"new":3}')).toEqual({
+      ok: false, source: 'existing', error: { ok: false, reason: 'json', raw: 'broken backup' },
+    });
+  });
+
+  it('returns no writable replacement for an invalid import', () => {
+    const result = prepareProgressImport('{"old":2}', '{"new":false}');
+    expect(result).toMatchObject({ ok: false, source: 'import' });
+    expect(result).not.toHaveProperty('serialized');
+  });
+
+  it('keeps prototype-like keys as data through merge and export', () => {
+    const result = prepareProgressImport('{"__proto__":2}', '{"constructor":3,"__proto__":4}');
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('Expected a valid legacy map');
+    expect(Object.getPrototypeOf(result.data)).toBe(Object.prototype);
+    expect(Object.hasOwn(result.data, '__proto__')).toBe(true);
+    expect(JSON.parse(result.serialized)).toEqual(JSON.parse('{"__proto__":4,"constructor":3}'));
+  });
+});


### PR DESCRIPTION
Malformed saved progress must remain recoverable when the new progress UI reads or imports it. Add a pure parser and merge helper that preserve unknown route keys and retain invalid raw text for the caller. Valid imports merge completion timestamps without replacing newer existing values.

Refs #2384, #2300, #2272. This is the storage-helper dependency; it does not yet change the dashboard or completion buttons.

Validation: 22 focused Vitest cases, ESLint on both files, 176 pipeline tests, clean diff check. Two files, 104 added lines. No Python files changed; no content/config changes, so no build required for this unconsumed helper. Independent Google review of exact head db128ccb8aea574a7157c058f51e1a5760d195ae passed with consumer-boundary limitations; review record follows.
