### PR TITLE
feat(progress): derive eligible lessons from published routes (#2384)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,6 +6,7 @@ import starlight from '@astrojs/starlight';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import { routeManifestIntegration } from './scripts/quality/route-manifest-integration.mjs';
+import { progressIntegration } from './scripts/progress-integration.mjs';
 
 const projectRoot = fileURLToPath(new URL('.', import.meta.url));
 const ignoredDevWatchPaths = [
@@ -693,5 +694,6 @@ export default defineConfig({
       ],
     }),
     routeManifestIntegration(),
+    progressIntegration(),
   ],
 });

--- a/scripts/progress-integration.mjs
+++ b/scripts/progress-integration.mjs
@@ -1,0 +1,39 @@
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/** Deliberate private-runtime boundary: fail the build if Starlight moves these APIs. */
+export function progressIntegration() {
+  let format;
+  const configId = 'virtual:kubedojo-progress-format';
+  const entrypoint = new URL(import.meta.resolve('@astrojs/starlight'));
+  const runtime = (relative) => {
+    const url = new URL(relative, entrypoint);
+    if (url.protocol !== 'file:' || !existsSync(url)) {
+      throw new Error(`Progress catalog cannot resolve Starlight runtime: ${relative}`);
+    }
+    return fileURLToPath(url);
+  };
+  return {
+    name: 'kubedojo-progress-catalog',
+    hooks: {
+      'astro:config:setup': ({ injectRoute, updateConfig }) => {
+        updateConfig({ vite: { plugins: [{
+          name: 'kubedojo-progress-format',
+          resolveId: id => id === configId ? `\0${configId}` : undefined,
+          load: id => id === `\0${configId}` ? `export default ${JSON.stringify(format)}` : undefined,
+        }], resolve: { alias: {
+          '#kubedojo-progress-routes': runtime('./utils/routing/index.ts'),
+          '#kubedojo-progress-slugs': runtime('./utils/slugs.ts'),
+          '#kubedojo-progress-canonical': runtime('./utils/canonical.ts'),
+        } } } });
+        injectRoute({ pattern: '/progress-catalog.json', entrypoint: new URL('../src/progress-endpoint.ts', import.meta.url), prerender: true });
+      },
+      'astro:config:done': ({ config }) => {
+        if (!config.site || config.build.format !== 'directory') {
+          throw new Error('Progress catalog requires a configured site and directory build format');
+        }
+        format = { format: config.build.format, trailingSlash: config.trailingSlash };
+      },
+    },
+  };
+}

--- a/src/progress-endpoint.ts
+++ b/src/progress-endpoint.ts
@@ -1,0 +1,19 @@
+import type { APIContext } from 'astro';
+import { routes } from '#kubedojo-progress-routes';
+import { slugToPathname } from '#kubedojo-progress-slugs';
+import { formatCanonical } from '#kubedojo-progress-canonical';
+import format from 'virtual:kubedojo-progress-format';
+import { buildLessonCatalog } from './scripts/progress-catalog';
+
+export function GET(context: APIContext) {
+  if (!context.site) throw new Error('Progress catalog requires site metadata');
+  const base = import.meta.env.BASE_URL.replace(/\/?$/, '/');
+  const lessons = buildLessonCatalog(routes.map(route => {
+    const url = new URL(base + slugToPathname(route.id).slice(1), context.site);
+    const pathname = new URL(formatCanonical(url.href, format)).pathname;
+    return { source: route.entry.filePath, pathname };
+  }));
+  return new Response(JSON.stringify({ schemaVersion: 1, lessons }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/src/scripts/progress-catalog.ts
+++ b/src/scripts/progress-catalog.ts
@@ -1,0 +1,62 @@
+export interface Lesson {
+  id: string;
+  track: string;
+  kind: 'module' | 'chapter';
+  keys: string[];
+}
+export interface LessonRoute { source: string; pathname: string }
+
+/** Use source identity for translations, but actual runtime paths for saved keys. */
+export function buildLessonCatalog(routes: LessonRoute[]): Lesson[] {
+  const lessons = new Map<string, Lesson>();
+  const seenPaths = new Set<string>();
+  for (const { source, pathname } of routes) {
+    if (!pathname.startsWith('/') || pathname.startsWith('//') || /[?#]/.test(pathname) ||
+      new URL(pathname, 'https://catalog.invalid').pathname !== pathname) {
+      throw new Error(`Invalid lesson pathname: ${pathname}`);
+    }
+    if (seenPaths.has(pathname)) throw new Error(`Duplicate lesson pathname: ${pathname}`);
+    seenPaths.add(pathname);
+    if (!source.startsWith('src/content/docs/')) continue;
+    const relative = source.slice('src/content/docs/'.length);
+    if (relative.split('/').some(part => !part || part === '.' || part === '..')) {
+      throw new Error(`Invalid lesson source: ${source}`);
+    }
+    if (/\.staging\./.test(relative) || !/\.(md|mdx|markdown|mdown|mkdn|mkd|mdwn)$/.test(relative)) continue;
+    const id = relative.replace(/^uk\//, '').replace(/\.(md|mdx|markdown|mdown|mkdn|mkd|mdwn)$/, '');
+    const parts = id.split('/');
+    const name = parts.at(-1)!;
+    const kind = name.startsWith('module-') ? 'module'
+      : parts[0] === 'ai-history' && name.startsWith('ch-') ? 'chapter' : null;
+    if (!kind || parts.length < 2) continue;
+    const lesson = lessons.get(id) ?? { id, track: parts[0], kind, keys: [] };
+    const key = pathname.replace(/^\/|\/$/g, '');
+    // Slash variants can refer to the same saved key; never count them twice.
+    if (!lesson.keys.includes(key)) lesson.keys.push(key);
+    lessons.set(id, lesson);
+  }
+  const owners = new Map<string, string>();
+  for (const lesson of lessons.values()) {
+    for (const key of lesson.keys) {
+      const owner = owners.get(key);
+      if (owner && owner !== lesson.id) throw new Error(`Ambiguous lesson key: ${key}`);
+      owners.set(key, lesson.id);
+    }
+    lesson.keys.sort();
+  }
+  return [...lessons.values()].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/** Pass keys only after progress-data validation; completion is self-reported. */
+export function countLessonProgress(catalog: Lesson[], completedKeys: Iterable<string>) {
+  const keys = new Set(completedKeys);
+  const recognized = new Set(catalog.flatMap(lesson => lesson.keys));
+  const tracks: Record<string, { total: number; completed: number }> = Object.create(null);
+  let completed = 0;
+  for (const lesson of catalog) {
+    const row = tracks[lesson.track] ??= { total: 0, completed: 0 };
+    row.total++;
+    if (lesson.keys.some(key => keys.has(key))) { row.completed++; completed++; }
+  }
+  return { total: catalog.length, completed, tracks, unknownKeys: [...keys].filter(key => !recognized.has(key)) };
+}

--- a/tests/progress-catalog.test.ts
+++ b/tests/progress-catalog.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { buildLessonCatalog, countLessonProgress } from '../src/scripts/progress-catalog';
+
+const route = (source: string, pathname: string) => ({ source: `src/content/docs/${source}`, pathname });
+
+describe('eligible lesson catalog', () => {
+  it('uses runtime paths, unifies translated sources and includes fallback routes', () => {
+    const catalog = buildLessonCatalog([
+      route('ai/module-1.1-test.md', '/ai/custom/'),
+      route('uk/ai/module-1.1-test.md', '/uk/ai/translated/'),
+      route('ai/module-1.2-next.md', '/ai/next/'),
+      route('ai/module-1.2-next.md', '/uk/ai/next/'),
+    ]);
+    expect(catalog).toHaveLength(2);
+    expect(catalog[0].keys).toEqual(['ai/custom', 'uk/ai/translated']);
+    const counts = countLessonProgress(catalog, ['ai/custom', 'uk/ai/translated', 'uk/ai/next']);
+    expect(counts).toMatchObject({ total: 2, completed: 2, tracks: { ai: { total: 2, completed: 2 } } });
+  });
+
+  it('includes book chapters and new module tracks but excludes hubs and staging', () => {
+    const catalog = buildLessonCatalog([
+      route('ai-history/ch-01-test.md', '/ai-history/ch-01-test/'),
+      route('new-track/module-1-test.mdx', '/new-track/module-1-test/'),
+      route('ai-history/index.md', '/ai-history/'),
+      route('progress.mdx', '/progress/'),
+      route('new-track/module-2-test.staging.md', '/staging/'),
+      route('new-track/module-picture.png', '/picture/'),
+    ]);
+    expect(catalog.map(({ kind }) => kind)).toEqual(['chapter', 'module']);
+    expect(countLessonProgress(catalog, []).total).toBe(2);
+  });
+
+  it('keeps removed or renamed route marks outside counts without deleting them', () => {
+    const keys = ['ai/retired', 'ai/new', 'uk/ai/retired'];
+    const catalog = buildLessonCatalog([route('ai/module-new.md', '/ai/new/')]);
+    expect(countLessonProgress(catalog, keys)).toMatchObject({
+      total: 1, completed: 1, unknownKeys: ['ai/retired', 'uk/ai/retired'],
+    });
+    expect(keys).toEqual(['ai/retired', 'ai/new', 'uk/ai/retired']);
+    expect(countLessonProgress([], keys)).toMatchObject({ total: 0, completed: 0, unknownKeys: keys });
+  });
+
+  it('retains a Ukrainian-only lesson in the shared catalog', () => {
+    const catalog = buildLessonCatalog([route('uk/linux/module-new.md', '/uk/linux/new/')]);
+    expect(catalog[0].id).toBe('linux/module-new');
+    expect(countLessonProgress(catalog, ['uk/linux/new']).completed).toBe(1);
+  });
+
+  it('fails on ambiguous routes or normalized keys instead of choosing an owner', () => {
+    expect(() => buildLessonCatalog([
+      route('ai/module-a.md', '/same/'), route('ai/module-b.md', '/same/'),
+    ])).toThrow('Duplicate');
+    expect(() => buildLessonCatalog([
+      route('ai/module-a.md', '/same/'), route('ai/module-b.md', '/same'),
+    ])).toThrow('Ambiguous');
+  });
+
+  it.each(['/ai/../other/', '//other.invalid/lesson/', '/lesson/?query', '/a\\b/'])
+  ('rejects a non-canonical input pathname: %s', pathname => {
+    expect(() => buildLessonCatalog([route('ai/module-a.md', pathname)])).toThrow('Invalid lesson pathname');
+  });
+});


### PR DESCRIPTION
Progress needs a list of eligible lessons and their actual published routes so English and Ukrainian versions count as one lesson. Add a build-time JSON catalog derived from Starlight routes, grouping module/chapter source identities and retaining the route keys used by saved progress. Shared reference pages are excluded.

Refs #2384, #2300, #2272. This catalog dependency does not yet change the dashboard or completion controls. The Starlight private-runtime boundary is explicit and fails the build if its expected files disappear.

Five files, 184 added lines. Validation: 9 focused catalog tests, ESLint, 176 pipeline tests, clean diff check, and a fresh 2,169-page build. The local receipt checks 901 distinct lessons and 1,802 rendered English/Ukrainian route keys against tracked sources and canonical output. These are local artifact checks, not deployed behavior or translation acceptance. Google review of exact head 9fb7a414976db857d99e96a3a03b57f7294c84dd passed; review record follows. Supported scope is the current English/Ukrainian source loader; a future loader or locale migration must revisit these assumptions.
