### PR TITLE
docs(ai-history): anchor learning and frog-eye corrections (#2373)

### DIFF
--- a/docs/research/ai-history/chapters/ch-05-the-neural-abstraction/frog-eye-source-note-2026-09-05.md
+++ b/docs/research/ai-history/chapters/ch-05-the-neural-abstraction/frog-eye-source-note-2026-09-05.md
@@ -1,0 +1,14 @@
+# Frog-eye forward pointer: source boundary
+
+Scope: Chapter 5's one-paragraph forward pointer, issue #2373. This note does not approve the whole chapter or change the biographical claims in `sources.md`.
+
+Primary source: J. Y. Lettvin, H. R. Maturana, W. S. McCulloch, and W. H. Pitts, *What the Frog's Eye Tells the Frog's Brain*, Proceedings of the IRE (November 1959), [MIT-hosted journal-layout scan](https://stuff.mit.edu/afs/athena/course/9/9.49/www/Supplementary/Frog.pdf).
+
+Inspected page images on 2026-09-05:
+
+- PDF page 1, printed 1940, summary: individual optic-nerve recordings; responses chiefly associated with local patterns; explicit frog-only interpretation.
+- PDF page 11, printed 1950, General Discussion: information reaching the brain has already undergone organization in the eye.
+
+The reader's closing question is an editorial invitation derived from those findings. It is not a historical quotation. This packet supplies no evidence about Pitts's private reaction, dissertation destruction, or a refutation of the 1943 calculus. Existing secondary-source claims about those topics retain their separate evidence status.
+
+Retrieval receipt: HTTP 200, `application/pdf`, 2,654,232 bytes; SHA-256 `db5c78443e48a953f2a3b92adb08d26183645b6d8bae4fbe1747f041a713fd26`. The hash identifies inspected bytes; it is not independent source-fidelity acceptance. Cached PDF and rendered pages are local `.agent/` artifacts, excluded from the commit. Independent source-fidelity and Google prose reviews remain required before publication.

--- a/docs/research/ai-history/chapters/ch-05-the-neural-abstraction/learning-rule-source-note-2026-09-05.md
+++ b/docs/research/ai-history/chapters/ch-05-the-neural-abstraction/learning-rule-source-note-2026-09-05.md
@@ -1,0 +1,17 @@
+# Learning-rule source note — 2026-09-05
+
+Supplement to the merged source records for #2373; independent review remains pending.
+
+Combined-draft continuity check: the later Hebbian-bridge transition also generalized Theorem7 to biological learning without qualification and asserted that algorithmic learning had to wait for Rosenblatt. The integrated draft removes those claims and cites visible p.101 to keep physiological explanation, circuit representation and learning a target behavior distinct. This correction makes no new priority claim about the first learning algorithm; that would require separate research.
+
+The opening Theorem7 glossary entry is narrowed to the same specified alteration rule and task-training limit, using the inspected reprint locator rather than an inferred original-page conversion.
+
+The CMU reprint identified in mp-source-corrections-2026-09-05.md was re-read at visible pp.101 and108. The page108 image places Theorem7 before the heading for Section3, within the preceding Section2 discussion. The current chapter incorrectly places it in Section3.
+
+The paragraph immediately before Theorem7 assumes that initially ineffective axonal terminations become ordinary excitatory synapses when their excitation coincides with firing of the succeeding neuron. This is an explicit activity-dependent alteration rule. The chapter's categorical claim that no mechanism for updating connections from experience is specified is therefore too broad. The narrower point is that the formal replacement of that alteration by a fixed net with circles does not establish successful training for a chosen task.
+
+Visible p.101 explicitly distinguishes the authors' formal equivalence from a factual explanation of physiological change. Do not turn Theorem7 into proof about all biological learning or all changing neural networks.
+
+Kleene's Alicante PDF was retrieved again and matches the merged record's SHA25681bf002582db2b3b6dc0324f4b2ff370db3a5ea56657165388dbd8bd4e02ba3c. Rendered reproduction pages31,37,40 were inspected directly: Theorems3/5 retain timing and starting-state conditions; p.40 distinguishes a Turing machine with its unbounded tape from a finite automaton. These remain reproduction locators, not inferred original-book pages.
+
+Local page-image evidence is in the worktree .agent/sources/kleene-31.png,kleene-37.png,kleene-40.png; MP page108 image is in content-book-ch03-context-research/.agent/ch05-mp/pages/cmu-10.png. No generated evidence is staged. This note does not accept the chapter's Hebb, von Neumann, frog-eye or biographical claims.


### PR DESCRIPTION
Chapter 5 overstates what the early neural-net results establish and needs a more precise boundary for its frog-eye forward pointer. Add two research notes documenting the activity-dependent alteration rule, formal-equivalence limits, finite-state qualification and frog-only evidence before the separate prose correction.

Refs #2373, #2289, #2272. Two files, 31 added lines; no published prose or generated artifacts.

Validation: byte equality with the previously inspected local notes, clean diff check, Claude source-image review and Google gap/capacity review of exact head e9c2eafb3563d550d2e6415a727c288913b5e7e7 passed. Detailed review record follows. Under the book-only exception, local curriculum pipeline and Astro build are skipped. Primary remains clean on main. The notes' pending-review language records their drafting state; subsequent review is recorded on this PR.

These notes do not accept the whole chapter, biographical claims, priority claims, general biological-learning claims or Ukrainian parity. Prose requires its own source-fidelity and Google editorial reviews after the research merge.
