### PR TITLE
fix(progress): persist shared lesson state with explicit errors (#2384)

### DIFF
--- a/src/scripts/progress-state.ts
+++ b/src/scripts/progress-state.ts
@@ -1,0 +1,45 @@
+import { parseProgress, type ProgressData } from './progress-data';
+import type { Lesson } from './progress-catalog';
+
+export const PROGRESS_KEY = 'kubedojo-progress';
+export type ProgressStorage = () => Pick<Storage, 'getItem' | 'setItem'>;
+export type StateResult =
+  | { ok: true; data: ProgressData }
+  | { ok: false; reason: 'unavailable' | 'invalid' | 'unknown-lesson' | 'timestamp' | 'write'; raw?: string };
+
+/** The accessor is called inside try: even obtaining window.localStorage can throw. */
+export function readSavedProgress(storage: ProgressStorage): StateResult {
+  let raw: string | null;
+  try { raw = storage().getItem(PROGRESS_KEY); }
+  catch { return { ok: false, reason: 'unavailable' }; }
+  const parsed = parseProgress(raw);
+  return parsed.ok ? parsed : { ok: false, reason: 'invalid', raw: parsed.raw };
+}
+
+export function lessonIsComplete(lesson: Lesson, data: ProgressData): boolean {
+  return lesson.keys.some(key => Object.hasOwn(data, key));
+}
+
+/** Explicit user action. Read fresh before writing; this is not a cross-tab transaction. */
+export function setLessonComplete(
+  storage: ProgressStorage, catalog: Lesson[], routeKey: string, complete: boolean, timestamp = Date.now(),
+): StateResult {
+  const lesson = catalog.find(item => item.keys.includes(routeKey));
+  if (!lesson) return { ok: false, reason: 'unknown-lesson' };
+  if (complete && (!Number.isSafeInteger(timestamp) || timestamp <= 0)) {
+    return { ok: false, reason: 'timestamp' };
+  }
+  const existing = readSavedProgress(storage);
+  if (!existing.ok) return existing;
+  const entries = new Map(Object.entries(existing.data));
+  if (complete) {
+    entries.set(routeKey, timestamp);
+  } else {
+    // Undo the shared lesson, including marks made through its other language routes.
+    for (const key of lesson.keys) entries.delete(key);
+  }
+  const data = Object.fromEntries(entries);
+  try { storage().setItem(PROGRESS_KEY, JSON.stringify(data)); }
+  catch { return { ok: false, reason: 'write' }; }
+  return { ok: true, data };
+}

--- a/tests/progress-state.test.ts
+++ b/tests/progress-state.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { buildLessonCatalog, countLessonProgress } from '../src/scripts/progress-catalog';
+import { lessonIsComplete, PROGRESS_KEY, readSavedProgress, setLessonComplete } from '../src/scripts/progress-state';
+
+const catalog = buildLessonCatalog([
+  { source: 'src/content/docs/ai/module-1.md', pathname: '/ai/lesson/' },
+  { source: 'src/content/docs/uk/ai/module-1.md', pathname: '/uk/ai/lesson/' },
+]);
+function fixture(initial: string | null, failWrite = false) {
+  let raw = initial;
+  const writes: string[] = [];
+  const storage = () => ({
+    getItem(key: string) { expect(key).toBe(PROGRESS_KEY); return raw; },
+    setItem(key: string, value: string) {
+      expect(key).toBe(PROGRESS_KEY);
+      if (failWrite) throw new Error('Quota exceeded');
+      writes.push(value); raw = value;
+    },
+  });
+  return { storage, writes, raw: () => raw };
+}
+
+describe('shared lesson completion', () => {
+  it('reflects a Ukrainian mark in the shared lesson and preserves unrelated keys', () => {
+    const f = fixture('{"retired":17}');
+    const result = setLessonComplete(f.storage, catalog, 'uk/ai/lesson', true, 100);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('Expected write');
+    expect(lessonIsComplete(catalog[0], result.data)).toBe(true);
+    expect(countLessonProgress(catalog, Object.keys(result.data))).toMatchObject({ completed: 1, unknownKeys: ['retired'] });
+    expect(JSON.parse(f.raw()!)).toEqual({ retired: 17, 'uk/ai/lesson': 100 });
+  });
+
+  it('explicit undo removes both language marks but retains other records', () => {
+    const f = fixture('{"ai/lesson":1,"uk/ai/lesson":2,"retired":17}');
+    expect(setLessonComplete(f.storage, catalog, 'ai/lesson', false)).toEqual({ ok: true, data: { retired: 17 } });
+    expect(JSON.parse(f.raw()!)).toEqual({ retired: 17 });
+  });
+
+  it('reads fresh state on each operation', () => {
+    const f = fixture(null);
+    setLessonComplete(f.storage, catalog, 'ai/lesson', true, 100);
+    setLessonComplete(f.storage, catalog, 'uk/ai/lesson', true, 101);
+    expect(readSavedProgress(f.storage)).toEqual({ ok: true, data: { 'ai/lesson': 100, 'uk/ai/lesson': 101 } });
+  });
+
+  it('retains malformed raw data and performs no write', () => {
+    const f = fixture('null');
+    expect(setLessonComplete(f.storage, catalog, 'ai/lesson', true)).toEqual({ ok: false, reason: 'invalid', raw: 'null' });
+    expect(f.writes).toHaveLength(0);
+    expect(f.raw()).toBe('null');
+  });
+
+  it('reports unavailable storage access and failed persistence', () => {
+    expect(readSavedProgress(() => { throw new Error('SecurityError'); })).toEqual({ ok: false, reason: 'unavailable' });
+    const f = fixture('{"retired":17}', true);
+    expect(setLessonComplete(f.storage, catalog, 'ai/lesson', true)).toEqual({ ok: false, reason: 'write' });
+    expect(f.raw()).toBe('{"retired":17}');
+  });
+
+  it('refuses non-lessons and invalid completion timestamps without writes', () => {
+    const f = fixture(null);
+    expect(setLessonComplete(f.storage, catalog, 'progress', true)).toMatchObject({ ok: false, reason: 'unknown-lesson' });
+    expect(setLessonComplete(f.storage, catalog, 'ai/lesson', true, NaN)).toMatchObject({ ok: false, reason: 'timestamp' });
+    expect(f.writes).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Add shared lesson-completion operations so marking either language completes the same lesson and explicit undo removes all its language aliases. Reads occur immediately before writes; invalid saved text and unrelated keys are preserved, and storage access/write failures are returned explicitly.

Refs #2384, #2300, #2272. This is the state-helper dependency, with no dashboard or button integration yet. UI consumers must display errors; the helper does not supply a cross-tab transaction.

Two files, 112 added lines, cherry-picked without edits onto the merged catalog and storage dependencies. Stable patch ID f169c12a49e22aa6522ec0804854b1ef5a78b9cd matches the prior candidate. Fresh verification: 37 focused tests, ESLint, 176 pipeline tests in 3.215s, clean diff check and clean worktree after restoring the test-generated review artifact. No content/config changes or Python edits; no additional build required for this unconsumed helper. Google final-head review passed; record follows.
