### PR TITLE
refactor(progress): share validated browser catalog loading (#2384)

### DIFF
--- a/src/scripts/progress-client.ts
+++ b/src/scripts/progress-client.ts
@@ -1,0 +1,26 @@
+import type { Lesson } from './progress-catalog';
+
+let pending: Promise<Lesson[]> | undefined;
+
+/** Cache successful loads per page session; failed requests can be retried. */
+export function loadLessonCatalog(): Promise<Lesson[]> {
+  return pending ??= fetch(`${import.meta.env.BASE_URL.replace(/\/?$/, '/')}progress-catalog.json`)
+    .then(async response => {
+      if (!response.ok) throw new Error('Progress catalog is unavailable');
+      const value = await response.json();
+      if (value?.schemaVersion !== 1 || !Array.isArray(value.lessons)) throw new Error('Invalid progress catalog');
+      const ids = new Set<string>();
+      const keys = new Set<string>();
+      for (const lesson of value.lessons) {
+        if (!lesson || typeof lesson.id !== 'string' || !lesson.id || ids.has(lesson.id) ||
+          typeof lesson.track !== 'string' || !lesson.track || !['module', 'chapter'].includes(lesson.kind) ||
+          !Array.isArray(lesson.keys) || !lesson.keys.length) throw new Error('Invalid progress lesson');
+        ids.add(lesson.id);
+        for (const key of lesson.keys) {
+          if (typeof key !== 'string' || !key || keys.has(key)) throw new Error('Invalid progress route');
+          keys.add(key);
+        }
+      }
+      return value.lessons as Lesson[];
+    }).catch(error => { pending = undefined; throw error; });
+}

--- a/src/scripts/progress-tracker.ts
+++ b/src/scripts/progress-tracker.ts
@@ -48,37 +48,6 @@ function isComplete(slug: string): boolean {
   return slug in getProgress();
 }
 
-function getTrackProgress(trackPrefix: string): { completed: number; total: number } {
-  const data = getProgress();
-  const sidebarLinks = document.querySelectorAll('.kd-sb a[href]');
-  let total = 0;
-  let completed = 0;
-  sidebarLinks.forEach((link) => {
-    const href = (link as HTMLAnchorElement).pathname;
-    if (href.startsWith(`/${trackPrefix}`)) {
-      total++;
-      const slug = href.replace(/^\/|\/$/g, '');
-      if (data[slug]) completed++;
-    }
-  });
-  return { completed, total };
-}
-
-function exportProgress(): string {
-  return JSON.stringify(getProgress(), null, 2);
-}
-
-function importProgress(json: string): boolean {
-  try {
-    const data = JSON.parse(json);
-    if (typeof data !== 'object') return false;
-    saveProgress(data);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 // ===== UI: Mark Complete Button =====
 
 function injectCompleteButton(): void {

--- a/tests/progress-client.test.ts
+++ b/tests/progress-client.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, expect, it, vi } from 'vitest';
+
+afterEach(() => { vi.unstubAllGlobals(); vi.resetModules(); });
+
+it('caches successful requests and retains runtime routes', async () => {
+  const lessons = [{ id: 'ai/module-a', track: 'ai', kind: 'module', keys: ['ai/a', 'uk/ai/a'] }];
+  const fetcher = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ schemaVersion: 1, lessons }) });
+  vi.stubGlobal('fetch', fetcher);
+  const { loadLessonCatalog } = await import('../src/scripts/progress-client');
+  expect(await loadLessonCatalog()).toEqual(lessons);
+  expect(await loadLessonCatalog()).toEqual(lessons);
+  expect(fetcher).toHaveBeenCalledTimes(1);
+  expect(fetcher).toHaveBeenCalledWith('/progress-catalog.json');
+});
+
+it('allows retry after failure and rejects conflicting route owners', async () => {
+  const lesson = { id: 'ai/module-a', track: 'ai', kind: 'module', keys: ['ai/a'] };
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({ ok: false }).mockResolvedValueOnce({
+    ok: true, json: async () => ({ schemaVersion: 1, lessons: [lesson, { ...lesson, id: 'ai/module-b' }] }),
+  }));
+  const { loadLessonCatalog } = await import('../src/scripts/progress-client');
+  await expect(loadLessonCatalog()).rejects.toThrow('unavailable');
+  await expect(loadLessonCatalog()).rejects.toThrow('Invalid progress route');
+});


### PR DESCRIPTION
Add a shared browser catalog loader with schema checks, cached successful loads and retry after failure. Remove three unused private tracker helpers whose import/counting behavior is superseded by the reviewed storage/catalog operations.

Refs #2384, #2300, #2272. This dependency prepares the completion controls and dashboard; it does not integrate their new UI yet.

Three files, 50 additions and 31 deletions. Exact cherry-pick onto merged dependencies, stable patch ID194b3b9591b8a3f472abc6ab6f932c0e6d53d376 matches the prior reviewed candidate. Fresh checks: 39 focused tests, 176 pipeline tests in6.481s, clean diff; ESLint has0errors and1inherited unused-target warning in the tracker. No content/config or Python changes. Final-head review record follows before submission.
