### PR TITLE
docs(ai-history): correct Hebb source anchors and inference limits (#2373)

### DIFF
--- a/docs/research/ai-history/chapters/ch-05-the-neural-abstraction/hebb-source-reassessment-2026-09-05.md
+++ b/docs/research/ai-history/chapters/ch-05-the-neural-abstraction/hebb-source-reassessment-2026-09-05.md
@@ -1,0 +1,24 @@
+# Hebb: passage locators and limits
+
+Scope: #2373, research only. Independent source review is pending; this note does not accept the whole chapter or the full book's historical reception.
+
+Source: D. O. Hebb, *The Organization of Behavior: A Neuropsychological Theory* (1949), [Max Planck-hosted scan](https://pure.mpg.de/rest/items/item_2346268/component/file_2346267/content), retrieved 2026-09-05. Local HTTP fetch succeeded with 11,226,123 bytes; SHA-256 `d4930e5fe699d98b1c82793740386d329a0b824bc33ec80c4d6694717df00f8c`. PDF metadata reports 365 scan pages. The web reader returned 403; the local fetch and rendered page images supplied this evidence.
+
+## Inspected anchors
+
+- PDF page 1: title, author, McGill affiliation and 1949 imprint. PDF page 2: 1949 copyright, John Wiley & Sons.
+- PDF page 7, printed xi, Introduction: Hebb names Rashevsky, Pitts, Householder, Landahl and McCulloch while describing mathematical work on populations of neurons. The paragraph also observes that the preliminary studies greatly simplified the psychological problem. PDF page 8, printed xii, continues: he describes potential value but says further results are needed before success is certain. Treat this as a qualified discussion, not blanket endorsement or proof of a causal lineage.
+- PDF page 11, printed xv: inspected directly; it does not contain that named list. The current chapter contract's repeated p.xv locator for the community passage is incorrect for this scan. Use printed xi–xii / PDF pages 7–8, not a constant offset between Roman page labels and PDF indices.
+- PDF page 78, printed 60: Chapter 4, *The First Stage of Perception: Growth of the Assembly*. Hebb proposes that repeated stimulation slowly forms a cell assembly whose activity briefly persists after stimulation, allowing time for structural changes. This is presented as a proposed account.
+- PDF page 80, printed 62: the neurophysiological postulate connects repeated participation of cell A in firing cell B with growth or metabolic change increasing A's effectiveness. The surrounding discussion considers transient reverberation cooperating with a more lasting structural change.
+- PDF page 81, printed 63: Hebb explicitly says there is no direct evidence for the particular synaptic-knob explanation being discussed. He distinguishes that proposed mechanism from the more general postulate on which the subsequent discussion depends. Do not present the proposed anatomical mechanism as an observed result.
+
+## Boundaries for revision
+
+The inspected postulate is a verbal cellular hypothesis. These pages support explaining that hypothesis and its distinction from a specific proposed mechanism. They do not establish successful training of an artificial network for a chosen task.
+
+They also do not constitute a whole-book search proving that Hebb never wrote any equation, specified any time scale or discussed any quantitative rule. The chapter's categorical absence claims should be narrowed to the inspected passage or supported by a separate, appropriately scoped audit. The later naming and mathematical development of rules called Hebbian require separate historical evidence.
+
+A supported learning prompt could ask the reader to distinguish the general postulate from the particular mechanism proposed to implement it. It would be an editorial exercise based on these pages, not a historical experiment or an invented conversation.
+
+Cache: `.agent/sources/hebb.pdf`, headers, `hebb-1.png`, `hebb-2.png`, `hebb-front-007.png`, `hebb-front-008.png`, `hebb-11.png`, `hebb-78.png`, `hebb-80.png`, `hebb-81.png`. Other inspected orientation pages were retained locally. No PDF or rendered image is included in the commit. Rendering emitted a Fontconfig warning but completed successfully; the images above were visually inspected.


### PR DESCRIPTION
The Chapter 5 research contract repeatedly locates Hebb's mathematical-biophysics discussion at printed page xv. Direct page inspection places it at xi–xii and shows qualifications missing from the contract. This research note records the corrected locator, the Chapter 4 cellular postulate and Hebb's distinction between that postulate and an anatomical mechanism lacking direct evidence.

One research file, 24 added lines. Refs #2373, #2289, #2272. Published prose remains a separate phase.

Validation: git diff --check passed; no generated artifacts. Claude source review smart-claude-review-1788607616 passed with limits after inspecting the page images. Google gap/capacity review smart-agy-review-1788608048 passed with limits. The book-only exception applies: local curriculum pipeline and Astro build were not run for this unpublished research-only note. Primary remains clean on main.
