### PR TITLE
feat(progress): render catalog-based lesson totals (#2384)

### DIFF
--- a/src/scripts/progress-dashboard.ts
+++ b/src/scripts/progress-dashboard.ts
@@ -1,0 +1,76 @@
+import { countLessonProgress, type Lesson } from './progress-catalog';
+import type { ProgressData } from './progress-data';
+import { loadLessonCatalog } from './progress-client';
+import { PROGRESS_KEY, readSavedProgress } from './progress-state';
+
+const names = new Map(Object.entries({
+  prerequisites: 'Fundamentals', linux: 'Linux', cloud: 'Cloud', k8s: 'Certifications',
+  platform: 'Platform Engineering', 'on-premises': 'On-Premises', ai: 'AI',
+  'ai-ml-engineering': 'AI/ML Engineering', 'ai-history': 'History of AI',
+}));
+
+function bar(label: string, completed: number, total: number): HTMLProgressElement {
+  const element = document.createElement('progress');
+  element.max = Math.max(1, total);
+  element.value = completed;
+  element.setAttribute('aria-label', label);
+  element.setAttribute('aria-valuetext', `${completed} of ${total} lessons marked complete`);
+  element.style.width = '100%';
+  return element;
+}
+
+/** Render only validated progress. Unknown keys remain stored but are not lessons. */
+export function renderProgressDashboard(target: HTMLElement, lessons: Lesson[], data: ProgressData): void {
+  const counts = countLessonProgress(lessons, Object.keys(data));
+  const summary = document.createElement('p');
+  const percentage = counts.total ? Math.round(100 * counts.completed / counts.total) : 0;
+  summary.textContent = `${counts.completed} of ${counts.total} lessons marked complete (${percentage}%).`;
+  target.replaceChildren(summary, bar('All lessons', counts.completed, counts.total));
+  for (const [track, count] of Object.entries(counts.tracks)) {
+    const section = document.createElement('section');
+    const title = document.createElement('h3');
+    const label = names.get(track) ?? track;
+    title.textContent = label;
+    const text = document.createElement('p');
+    text.textContent = `${count.completed} / ${count.total} lessons marked complete`;
+    section.append(title, text, bar(label, count.completed, count.total));
+    target.appendChild(section);
+  }
+  if (counts.unknownKeys.length) {
+    const note = document.createElement('p');
+    note.textContent = `${counts.unknownKeys.length} saved entries are outside the current lesson catalog. They remain in your backup and are not counted above.`;
+    target.appendChild(note);
+  }
+}
+
+export async function refreshProgressDashboard(): Promise<void> {
+  const target = document.getElementById('kd-progress-dashboard');
+  if (!target) return;
+  target.setAttribute('aria-busy', 'true');
+  try {
+    const lessons = await loadLessonCatalog();
+    const state = readSavedProgress(() => window.localStorage);
+    if (!state.ok) throw new Error(state.reason === 'invalid'
+      ? 'Saved progress is invalid. Export the original backup before importing or resetting.'
+      : 'Browser storage is unavailable. Progress cannot be read.');
+    renderProgressDashboard(target, lessons, state.data);
+  } catch (error) {
+    const note = document.createElement('p');
+    note.setAttribute('role', 'alert');
+    note.textContent = error instanceof Error ? error.message : 'Progress is unavailable.';
+    const retry = document.createElement('button');
+    retry.textContent = 'Retry progress';
+    retry.addEventListener('click', () => { void refreshProgressDashboard(); });
+    target.replaceChildren(note, retry);
+  } finally {
+    target.setAttribute('aria-busy', 'false');
+  }
+}
+
+if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', refreshProgressDashboard);
+else void refreshProgressDashboard();
+document.addEventListener('astro:page-load', refreshProgressDashboard);
+document.addEventListener('kubedojo:progress-change', refreshProgressDashboard);
+window.addEventListener('storage', event => {
+  if (event.key === PROGRESS_KEY || event.key === null) void refreshProgressDashboard();
+});

--- a/tests/progress-dashboard.test.ts
+++ b/tests/progress-dashboard.test.ts
@@ -1,0 +1,29 @@
+import { expect, it } from 'vitest';
+import { buildLessonCatalog } from '../src/scripts/progress-catalog';
+import { renderProgressDashboard } from '../src/scripts/progress-dashboard';
+
+it('renders shared language counts, book chapters, new tracks and retained unknown entries', () => {
+  const catalog = buildLessonCatalog([
+    { source: 'src/content/docs/ai/module-a.md', pathname: '/ai/a/' },
+    { source: 'src/content/docs/uk/ai/module-a.md', pathname: '/uk/ai/a/' },
+    { source: 'src/content/docs/ai-history/ch-01.md', pathname: '/ai-history/ch-01/' },
+    { source: 'src/content/docs/new-track/module-new.md', pathname: '/new-track/new/' },
+  ]);
+  const target = document.createElement('div');
+  renderProgressDashboard(target, catalog, { 'ai/a': 1, 'uk/ai/a': 2, retired: 3 });
+  expect(target.firstElementChild?.textContent).toBe('1 of 3 lessons marked complete (33%).');
+  expect([...target.querySelectorAll('h3')].map(h => h.textContent)).toEqual(['History of AI', 'AI', 'new-track']);
+  expect(target.textContent).toContain('1 saved entries are outside the current lesson catalog');
+  expect(target.querySelector('progress')?.getAttribute('aria-valuetext')).toBe('1 of 3 lessons marked complete');
+  renderProgressDashboard(target, catalog.slice(0, 1), { retired: 3 });
+  expect(target.querySelectorAll('section')).toHaveLength(1);
+  expect(target.firstElementChild?.textContent).toBe('0 of 1 lessons marked complete (0%).');
+});
+
+it('handles an empty catalog without false percentages or invalid progress bounds', () => {
+  const target = document.createElement('div');
+  renderProgressDashboard(target, [], {});
+  expect(target.firstElementChild?.textContent).toBe('0 of 0 lessons marked complete (0%).');
+  expect(target.querySelector('progress')?.max).toBe(1);
+  expect(target.querySelector('progress')?.value).toBe(0);
+});


### PR DESCRIPTION
Add the dashboard renderer that counts completion from the shared lesson catalog, including book chapters and dynamically discovered tracks. English and Ukrainian aliases count once; unknown saved entries remain stored and are excluded from lesson totals. Failed reads replace stale totals with an error and retry control.

Two files, 105 additions. This module is not wired into the page in this packet; page integration and backup/reset actions follow separately. Refs #2384, #2300, #2272.

Validation: 92 Vitest tests in nine files, 176 pipeline tests, targeted ESLint and git diff --check passed. Stable patch equivalence to original 989caf2bc verified (c135979e528a7b178ee61ae82b293ff09052585a). Google independent review smart-agy-review-1788608223 passed at 0e1e9dfd463225f1953e404e70637d407fac0eab. No new browser, download, screen-reader or translation acceptance is claimed.
