### PR TITLE
docs(book): verify Ashby publication metadata (#2405)

### DIFF
--- a/docs/research/ai-history/chapters/ch-06-the-cybernetics-movement/ashby-publication-evidence-2026-09-05.md
+++ b/docs/research/ai-history/chapters/ch-06-the-cybernetics-movement/ashby-publication-evidence-2026-09-05.md
@@ -1,0 +1,22 @@
+# Ashby's 1948 article: publication evidence and priority limit
+
+Research-only packet for #2405, parent #2289/#2290, epic #2272. Checked 2026-09-05. No published chapter change; independent source review pending.
+
+## Inspected records
+
+1. [W. Ross Ashby Digital Archive bibliography](https://www.ashby.info/bibliography.html), entry 32 as displayed during this inspection: W. R. Ashby, 1948, “Design for a Brain,” *Electronic Engineering* 20, 379–383. This is compiled bibliographic metadata, not inspected article text. The introduction credits Peter Asaro's 1999 compilation and explicitly warns that undiscovered works may remain; entry numbering can change.
+2. [King's College Cambridge, Turing Digital Archive, AMT/B/34](https://turingarchive.kings.cam.ac.uk/publications-lectures-and-talks-amtb/amt-b-34), second offprint in the item description: Ashby's “Design for a brain,” *Electronic Engineering*, December 1948. This is the holding archive's catalogue record for a printed offprint. It corroborates the title, journal and month/year, but the inspected web text does not expose the article's argument or construction details.
+
+Both public HTML records were read directly by the lead after the scout identified them. No article PDF was downloaded or inspected in this packet; no source-byte hash or article-page visual verification is claimed.
+
+## Allowed revision
+
+Use the bounded publication statement: **Ashby published “Design for a Brain” in Electronic Engineering in December 1948; the bibliography gives volume 20, pages 379–383.** Link the archive catalogue and bibliography where that statement is used.
+
+Do not infer **first published account**, first conception, first construction, first working machine or first-ever priority from these two records. The bibliography explicitly disclaims completeness. The scout initially recommended a first-publication formulation; lead review rejected that additional inference. This packet does not show that the priority claim is false, only that the inspected evidence does not establish it.
+
+The scout also identified private journal entries and a later collected-paper PDF as leads. They are outside this packet's lead inspection and cannot supply accepted construction dates or article-internal claims here. Earlier Green/Yellow ledger labels likewise do not replace source inspection.
+
+## Remaining work
+
+This resolves a path to narrowing the publication sentence, not the Homeostat's technical description or the other #2405 claim clusters. Retrieve and inspect the article or the relevant Ashby book passages before accepting technical claims. Follow independent research review with a separate prose phase and distinct Google editorial review; retain the book-only research validation exception for this file. Ukrainian parity remains open.


### PR DESCRIPTION
Chapter 6's publication-priority wording exceeds the evidence currently inspected. This research note corroborates Ashby's December 1948 Electronic Engineering article through the Ashby bibliography and King's College offprint catalogue, while rejecting an inference of first-publication or invention priority.

Claude independently retrieved both records and passed source review; separate Google research-gap review passed. Neither the full article nor private journal entries were inspected in this packet, so no technical construction claims are accepted. The other Chapter 6 findings remain open.

Validation: git diff --check passed; one book-research file,22 added lines; no generated artifacts; primary remains clean main. Book-only exception applies: no pipeline or Astro build required locally. Refs #2405, #2289, #2290, #2272.
