### PR TITLE
docs(platform): verify Cynefin domain evidence (#2403)

### DIFF
--- a/docs/content-upgrade/research/cynefin-domain-evidence.md
+++ b/docs/content-upgrade/research/cynefin-domain-evidence.md
@@ -1,0 +1,75 @@
+# Cynefin domain evidence — #2403
+
+Scope: research-only evidence for the complicated/complex tables in
+`src/content/docs/platform/foundations/systems-thinking/module-1.4-complexity-and-emergent-behavior.md`
+(audited head `b10971d302f50d8ef5408f4c587ee7ff7df42926`), especially lines 78-85,
+105-107, and 188-190. This note does not approve published prose.
+## Primary source inspected
+- C.F. Kurtz and D.J. Snowden, “The New Dynamics of Strategy: Sense-Making in a
+  Complex and Complicated World,” *IBM Systems Journal* 42(3), 2003, pp. 462-483.
+  IBM’s publication record identifies the authors, venue, and action-research basis:
+  https://research.ibm.com/publications/the-new-dynamics-of-strategy-sense-making-in-a-complex-and-complicated-world--1
+- Retrieved PDF URL: https://thecynefin.co/wp-content/uploads/2026/02/Sense-making-in-a-complex-and-complicated-world.pdf
+  Downloaded bytes: 229642. SHA-256:
+  `0de6da8885fe223c2806859d0ffcefb64281340e8ac3e472e3745d451f68d83c`.
+  `pdfinfo` reports 22 pages; PDF pages 6-8 and 11 were rendered with `pdftoppm`
+  and visually inspected: journal pages 467-469 and 472, including Figure 1.
+## Evidence and dispositions
+1. **Practice labels: CORRECTION REQUIRED.** The article’s Figure 1 places
+   repeatable, predictable cause/effect and “legitimate best practice” in the
+   **known** domain (journal p. 468, Figure 1). It describes the **knowable**
+   domain as expert analysis with Sense-Analyze-Respond (p. 468, Figure 1
+   and “Knowable” paragraph continuing on p. 469). Complex work uses probes
+   and emergent patterns (p. 469, “Complex” paragraph). Snowden’s accessible
+   primary-author article corroborates the practice distinction:
+   known = best practice, knowable = good practice, complex = emergent patterns:
+   https://asistdl.onlinelibrary.wiley.com/doi/10.1002/bult.284
+   (“The Third Age: Complicated, Complex and Chaotic”).
+   Therefore module line 83’s “Complicated = Best practice / Complex = Good
+   practice emerges” is materially misassigned. The table needs a clear/known
+   column or relabel complicated as good practice and complex as emergent
+   practice. The 2003 figure uses “known” and “knowable”; do not silently
+   substitute later labels when describing that historical figure.
+2. **Knowable/unknowable wording: QUALIFY.** The IBM article says stable
+   cause/effect in the knowable domain may be known only by a limited group and
+   may require time, resources, or expertise (pp. 468-469, “Knowable” paragraph).
+   For complex relationships it says patterns emerge through many agents and
+   can be perceived but not predicted; underlying sources are not open to
+   inspection (p. 469, “Complex” paragraph). This supports “not reliably predictable
+   in advance,” not the module’s absolute “unknowable relationships” and “no one
+   can understand fully” (lines 80-82). Avoid conflating complex with chaotic.
+3. **Predictability/hindsight: QUALIFY AND ADD THE MISSING DOMAIN.** The source
+   gives “repeatable, perceivable and predictable” to known, not all
+   complicated situations (Figure 1, p. 468). Complex patterns have
+   retrospective coherence but may not continue to repeat (p. 469, “Complex”
+   paragraph). Retain a hindsight heuristic only if the table distinguishes
+   clear/known from complicated/knowable and avoids “only” as universal causality.
+4. **Framework applicability: RETAIN WITH LIMIT.** The authors call Cynefin a
+   sense-making framework rather than a categorization framework
+   (p. 468, paragraph beside Figure 1). Their contextualization method constructs
+   the framework for each context of use (p. 472, Figure 3 and accompanying text).
+   Module line 107 should describe a production environment as
+   capable of exhibiting complex behavior in context, not as permanently one
+   domain.
+5. **Later terminology: VERSION EXPLICITLY.** The maintained institutional page
+   https://cynefin.io/index.php?title=Cynefin_Domains&oldid=5763
+   identifies its framework snapshot as February 2021. “Two aspects of order”
+   distinguishes Clear (self-evident cause/effect) from Complicated (expertise
+   or analysis required). “Practice types” assigns best practice to Clear and
+   good practice to Complicated, but calls Complex practice exaptive, focused
+   on repurposing capability. Thus do not claim “emergent practice” is the exact
+   label in this later account. A beginner table may describe probing and
+   responding to emerging patterns from the 2003 article, explicitly as a
+   teaching summary rather than a reproduction of every later domain label.
+   The introduction emphasizes context-specific applicability and changing
+   approaches. This is framework-owner guidance, not independent validation
+   that a particular Kubernetes system occupies a domain.
+## Access and source limits
+- IBM Research exposes metadata/abstract only; DOI/IEEE was robot-blocked. The
+  accessible PDF is a company-hosted copy of the original; retain page anchors
+  and hash in the source record.
+- Wiley is a condensed extract of Snowden’s 2002 *Journal of Knowledge
+  Management* article (publisher’s Editor’s Note); use for corroboration only.
+- The inspected institutional wiki revision is a later framework account, not
+  evidence of what the 2003 article said. HBR’s Snowden/Boone 2007 page exposes
+  metadata but not full text; it is not accepted as body evidence.


### PR DESCRIPTION
The complexity lesson mixes Cynefin practice labels and presents context-dependent distinctions as universal properties. This research note maps those claims to inspected original journal pages, Snowden's condensed article, and a separately identified later institutional account.

The note distinguishes 2003 known/knowable terminology from later Clear/Complicated labels and records that the later account calls Complex practice exaptive. It defines correction boundaries for a separate prose revision; no published lesson changes here.

Refs #2403, #2272.

Validation: 176 pipeline tests passed (3.327s); staged diff check passed; one file,75 added lines. No Python changes or published Astro content, so Ruff and site build are not applicable. Generated test output was restored. Primary remains clean main. Independent Google source review passed at this exact head; its posted comment records Wiley access limits. Issue #2403 remains open after this research packet.
