### PR TITLE
fix(platform): qualify Cynefin guidance and outage exercise (#2403)

### DIFF
--- a/src/content/docs/platform/foundations/systems-thinking/module-1.4-complexity-and-emergent-behavior.md
+++ b/src/content/docs/platform/foundations/systems-thinking/module-1.4-complexity-and-emergent-behavior.md
@@ -73,16 +73,13 @@ Understanding complexity changes how you approach operations. You stop trying to
 
 ### 1.1 The Two Types of Hard Problems
 
-Not all difficult problems are the same. A commercial jet engine is **complicated**. A flock of birds is **complex**. Understanding the difference will transform how you approach production systems.
+Not all difficult problems call for the same response. Can expertise reveal a relationship you do not yet understand, or must you learn through interactions whose outcomes are uncertain? The **Cynefin framework** offers a way to discuss that distinction. The table is a teaching summary of [Kurtz and Snowden's 2003 account, pp. 468–469](https://thecynefin.co/wp-content/uploads/2026/02/Sense-making-in-a-complex-and-complicated-world.pdf#page=7), using the later Clear and Complicated labels explained below.
 
-| Complicated | Complex |
-|-------------|---------|
-| Many parts, **knowable** relationships | Many parts, **unknowable** relationships |
-| Cause and effect **predictable** | Cause and effect only **visible in hindsight** |
-| Experts **can** understand fully | No one **can** understand fully |
-| **Best practice** exists | **Good practice** emerges |
-| Can be **designed** top-down | Must be **evolved** |
-| Example: Jet engine | Example: Air traffic control system |
+| Clear | Complicated | Complex |
+|-------|-------------|---------|
+| Relevant cause and effect are evident | Relationships require expertise or analysis | Interactions produce patterns that cannot reliably be predicted in advance |
+| Apply an appropriate established practice | Investigate with relevant experts | Use bounded probes and learn from emerging patterns |
+| Best practice within its conditions | Good practice informed by analysis | A pattern understood afterward may not repeat |
 
 ```mermaid
 graph TD
@@ -91,7 +88,7 @@ graph TD
         A[Fuel] --> B[Combustion] --> C[Turbine] --> D[Thrust]
     end
 
-    subgraph Complex [Complex System: Production Environment]
+    subgraph Complex [Illustrative Interactions in a Production Environment]
         direction LR
         O[Operators] --> S1[Service A]
         O --> S2[Service B]
@@ -102,13 +99,13 @@ graph TD
     end
 ```
 
-**Complicated systems** like a commercial jet engine have fixed relationships among parts that expert mechanics can model with high fidelity. The same input produces the same output under equivalent conditions, failure modes are enumerable, and the artifact can be disassembled, inspected, and reassembled from a blueprint. You can fully understand a complicated system in the operational sense that matters for maintenance: there is a right answer discoverable by analysis.
+**Complicated work** can reward analysis even when the answer is not immediately apparent. In the original article this domain is called *knowable*: relevant knowledge may require time, resources, or specialist expertise. That does not establish that every failure mode of an engineered system has been enumerated. The jet-engine diagram above is a simplified illustration, not a complete engineering model.
 
-**Complex systems** such as your production environment change relationships dynamically as code, traffic, configuration, and human behavior shift. No one understands full system behavior in advance, identical inputs can produce different outcomes depending on hidden state, and failure modes are open-ended rather than finite. Complexity emerges from evolution and interaction, not from a single design document. You cannot fully understand a complex system—and that limitation is fundamental physics of coupling, not a personal failure of your team.
+**Complex work** involves learning from interacting agents and emerging patterns. Kurtz and Snowden describe retrospective coherence: an explanation afterward does not guarantee that the pattern will recur. Applying that idea to production, ask which interactions your current model leaves out. The operators, users, and services in the diagram are an illustrative application; a production environment need not occupy one domain permanently.
 
 ### 1.2 Why Production Systems Are Complex
 
-Your Kubernetes cluster is complex, not just complicated, because production coupling shows up in five recurring patterns that reinforce one another.
+To look for complex behavior in a Kubernetes environment, consider these five illustrative patterns of production coupling. They are prompts for investigation, not a test that assigns every cluster to one domain.
 
 Non-linear interactions mean a slow database does not merely make queries slower—it can exhaust connection pools, trigger timeouts, provoke retries, and thereby make the database slower still until the effect is wildly disproportionate to the original trigger. Feedback loops are everywhere: autoscalers respond to load, retries respond to failures, circuit breakers respond to errors, caches respond to traffic shapes, and each loop interacts with the others in ways nobody fully designed ahead of time. Constant adaptation is unavoidable because users change behavior, traffic shifts, code ships daily, dependencies update, and teams rotate; the system you operate today is not the system you operated yesterday even if the architecture diagram stayed the same.
 
@@ -157,17 +154,17 @@ Evaluating architectural decisions through a complexity lens asks different ques
 
 ### 2.1 The Five Domains
 
-**Cynefin** (pronounced "kuh-NEV-in," Welsh for "habitat") is a sense-making framework created by Dave Snowden. It helps you recognize what kind of situation you're in and respond appropriately.
+**Cynefin** is a sense-making framework associated with Dave Snowden and developed in work including the article with Cynthia Kurtz cited above. Its labels have changed: the 2003 figure uses *known* and *knowable*, while the [institutional account identified as the February 2021 framework](https://cynefin.io/index.php?title=Cynefin_Domains&oldid=5763) uses *Clear* and *Complicated*. That later account reserves best practice for Clear and good practice for Complicated; it describes Complex practice as *exaptive*, repurposing existing capability.
 
-The most dangerous mistake isn't being in a complex domain—it's treating a complex problem like a complicated one, or treating chaos like complexity.
+The diagram below is a simplified teaching summary of response patterns, using later domain names. It is not a reproduction of either complete framework. The authors emphasize context: use the framework to question your choice of approach, and reconsider it as evidence changes.
 
 ```mermaid
 graph TD
-    Complex["<b>COMPLEX</b> (Unordered)<br/>Probe → Sense → Respond<br/><br/>• Emergent practice<br/>• Safe-to-fail probes"]
+    Complex["<b>COMPLEX</b><br/>Probe → Sense → Respond<br/><br/>• Learn from emerging patterns<br/>• Bound the probes"]
     Complicated["<b>COMPLICATED</b> (Ordered)<br/>Sense → Analyze → Respond<br/><br/>• Good practice<br/>• Expert analysis"]
-    Chaotic["<b>CHAOTIC</b> (Unordered)<br/>Act → Sense → Respond<br/><br/>• Novel practice<br/>• Stabilize first!"]
+    Chaotic["<b>CHAOTIC</b><br/>Act → Sense → Respond<br/><br/>• Seek stability<br/>• Observe the effect"]
     Clear["<b>CLEAR</b> (Ordered)<br/>Sense → Categorize → Respond<br/><br/>• Best practice<br/>• Follow playbook"]
-    Confused(("<b>CONFUSED</b><br/>(Disorder)"))
+    Confused(("<b>CONFUSED</b><br/>Domain unclear"))
 
     Complex --- Complicated
     Chaotic --- Clear
@@ -181,43 +178,46 @@ graph TD
 
 ### 2.2 Why the Order of Actions Matters
 
-Each domain requires a different response pattern, and using the wrong pattern is often worse than doing nothing because it burns time while the system state evolves. The table above is a map, not a mandate: your job during incidents is to reclassify quickly as evidence arrives, then announce the domain shift to the bridge so everyone stops arguing from incompatible playbooks.
+The framework suggests different response patterns. Treat a domain assignment as a working interpretation, not a diagnosis established by an alert's severity. In an incident, explain the evidence behind your approach and what would make you change it.
 
 | Domain | Characteristics | Response Strategy | Common Mistake |
 |--------|-----------------|-------------------|----------------|
-| **Clear** | Cause-effect obvious to everyone | Sense → Categorize → Respond (use the playbook) | Complacency—"we always do it this way" |
+| **Clear** | Relevant cause-effect is evident | Sense → Categorize → Respond (check the playbook applies) | Complacency—"we always do it this way" |
 | **Complicated** | Cause-effect discoverable by experts | Sense → Analyze → Respond (study then act) | Analysis paralysis—waiting too long |
-| **Complex** | Cause-effect only visible in hindsight | Probe → Sense → Respond (experiment then learn) | Premature convergence—jumping to conclusions |
+| **Complex** | Patterns become intelligible afterward but may not repeat | Probe → Sense → Respond (bound experiments and learn) | Premature convergence—jumping to conclusions |
 | **Chaotic** | No perceivable cause-effect | Act → Sense → Respond (stabilize first) | Continued analysis while burning |
 | **Confused** | Don't know which domain | Break down and gather information | Acting without knowing the domain |
 
-> **Pause and predict**: If your system goes completely down and you have no idea why, what should your first action be? Analyze the logs, or restart the system? (Hint: You are in the Chaotic domain).
+**Hypothetical decision exercise:** Checkout is unavailable. You have an approved rollback procedure for the latest release, but have not checked whether its database changes are reversible. A teammate proposes restarting everything. What evidence would you seek immediately, and what conditions would make a stabilization action reasonable? Does “we do not know why” establish the domain?
 
-### 2.3 Cynefin in Operations: Real Examples
+<details>
+<summary>Compare your reasoning</summary>
 
-For a **clear** disk-space alert, sense the signal, categorize it against a known playbook, and respond with the documented cleanup steps. The danger is overcomplicating a solved problem: if you launch a deep log-growth investigation before freeing space, you are borrowing complicated-domain latency for a clear-domain task. Fix first, learn second as a separate deliberate action.
+Unknown cause alone does not establish chaos. Check the rollback's compatibility and prerequisites, the affected scope, and available recovery procedures. Choose an authorized action whose risks and effects the team can assess; monitor it and keep investigating in parallel where possible. If the rollback could damage data, its availability on a checklist is not enough. Restarting everything is not justified by the framework. These are conditions for reasoning about the hypothetical case, not an instruction to operate a real cluster.
 
-For **complicated** performance degradation, gather metrics, traces, and logs; analyze with domain experts who can interpret query plans, profiles, and network paths; then implement the fix the evidence supports. The danger is analysis paralysis while users remain impacted—set explicit time boxes and be willing to act on the best current hypothesis when the clock expires.
+</details>
 
-For **complex** mystery failures where checkout complaints do not match global error rates, run safe-to-fail probes such as canaries with verbose tracing or segment-specific tests, sense the patterns that emerge (mobile Safari only, CDN cache age correlation, specific region skew), and respond by amplifying what works while dampening what fails. The danger is premature convergence: declaring "it must be the database" and shipping a risky change without learning context treats complexity as if it were merely complicated.
+### 2.3 Cynefin in Operations: Illustrative Applications
 
-For **chaotic** complete outage when the site is down and indicators are red everywhere, act immediately to stabilize—rollback, restart critical paths, failover, or shed load—then sense the effect, then iterate. The danger is analysis during chaos: waiting for perfect understanding while customers and revenue burn converts an urgent stabilization problem into a prolonged disaster. A coarse action that produces observable learning beats elegant analysis with no remediation attempt.
+For a **clear** disk-space problem, a verified playbook might identify disposable files and the conditions for removing them. Check that those conditions hold before acting. An unfamiliar full disk containing unknown data is not automatically a clear problem.
 
-> **Hypothetical scenario: The analysis meeting during a total outage**
->
-> A team treats every incident as "complicated" and spends the first phase of response gathering evidence before acting. During a major outage, they convene a bridge call and spend most of an hour examining dashboards, debating theories, and asking for one more chart. A leader finally asks whether the customer-facing site is still down. It is. They ask what remediation has been attempted. Nothing yet—the team is still analyzing. The crashed process was visible in monitoring within the first few minutes, but the group kept treating uncertainty as a reason to delay action rather than as a signal to stabilize first.
->
-> The eventual fix is restarting a single process and takes seconds. The expensive part was domain misrecognition: they treated a chaotic situation (total outage, unclear cause, high urgency) with a complicated-domain playbook (analyze thoroughly, then respond). **When the building is on fire, you extinguish or evacuate first; the architectural review can wait.**
+For **complicated** performance degradation, use relevant experts and measurements to test explanations. Agree on review points while user impact persists; a deadline is a reason to reassess the plan, not evidence that an untested fix is safe.
+
+For potentially **complex** behavior, such as checkout complaints that do not match aggregate metrics, consider bounded observations or probes that distinguish competing explanations. A canary with additional tracing is one possible illustration, provided its exposure, resource costs, data handling, and stop conditions are acceptable. Do not treat a suspected pattern as an established cause.
+
+For a situation interpreted as **chaotic**, the framework emphasizes seeking stability and then observing what changes. In operations, a rollback, failover, or traffic reduction is only a candidate action: each needs appropriate authority, prerequisites, and risk assessment. Neither red dashboards nor urgency alone selects the domain or the action.
+
+These examples apply the framework for teaching. They are not incidents reported by Kurtz and Snowden, and their proposed actions are not guaranteed remedies.
 
 ### 2.4 Domain Transitions
 
-Situations can shift between domains as stabilization progresses, and recognizing those transitions prevents the common failure mode of applying yesterday's correct strategy to today's changed context.
+Situations can shift between domains. This diagram illustrates one possible learning path, not a required sequence; restoring availability does not itself prove a move into a particular domain.
 
 ```mermaid
 graph LR
-    subgraph Healthy Progression
+    subgraph One Possible Progression
         direction LR
-        H_Chaotic["CHAOTIC<br/>(Site down!)"] -->|Stabilize| H_Complex["COMPLEX<br/>(Working, let's experiment)"]
+        H_Chaotic["CHAOTIC<br/>(Seeking stability)"] -->|Stabilize and reassess| H_Complex["COMPLEX<br/>(Bound probes and learn)"]
         H_Complex -->|Find patterns| H_Complicated["COMPLICATED<br/>(Analyze data)"]
         H_Complicated -->|Codify| H_Clear["CLEAR<br/>(New playbook)"]
     end
@@ -234,24 +234,24 @@ graph LR
 
 ### 2.5 Operating Cynefin Under Incident Pressure
 
-During incidents, domain classification is a leadership skill as much as a technical one. Teams under stress gravitate toward familiar habits: senior engineers want to analyze, managers want a single owner, executives want a confident sentence for status page updates. Cynefin gives you language to resist those defaults when they do not fit the situation. The goal is not to win a framework debate on the bridge call; the goal is to pick a response pattern that matches how much certainty you actually have.
+Use domain language to explain a working approach without turning the incident bridge into a classification debate. The following suggestions are operational applications of the framework, not empirical claims about how all teams behave.
 
-In the Clear domain, speed and standardization win. Disk cleanup, certificate renewal, and known dependency version bumps should not spawn novel investigation every time. The danger is complacency: a playbook written three years ago may assume architecture that no longer exists. Schedule periodic playbook drills, not because the task is hard, but because the environment changed while the document stayed still.
+For Clear work, check that the established procedure still fits the environment. A familiar task name, such as certificate renewal, does not establish that its dependencies and preconditions are unchanged. Rehearsing procedures can help expose stale assumptions.
 
-In the Complicated domain, expertise and measurement win, but time bounds matter. Analysis that continues for an hour while user impact persists is often a sign that you have slipped from complicated toward complex or chaotic without updating your strategy. A practical rule many teams adopt is to alternate between twenty-minute investigation windows and explicit decision points: what will we try next if this window does not produce an actionable hypothesis?
+For Complicated work, ask what evidence the relevant expert needs and when the team will reassess progress. Choose review intervals appropriate to the impact and available options; elapsed time alone neither changes the domain nor establishes a universal twenty-minute rule.
 
-In the Complex domain, experiments must be safe-to-fail. That phrase is overloaded in industry slides, so make it concrete. A safe-to-fail probe changes one variable, has a reversible or bounded blast radius, produces observable learning even when it "fails," and is documented so the next responder is not guessing what you tried. Canary traffic with extra tracing, shadow reads against a new dependency, or temporarily routing internal users through an alternate path are probes. "Restart everything in production and see" is not a probe; it is a high-risk gamble that destroys learning context.
+For Complex work, make the proposed learning and exposure explicit before a probe: what observation would distinguish explanations, who or what can be affected, and when will you stop? Changing one variable may help interpret a particular experiment, but it is not a definition of every complex-domain probe. Record observations as well as the intervention; a result can challenge the hypothesis without identifying a complete cause.
 
-In the Chaotic domain, the first obligation is stabilization, not understanding. Stabilization actions include rollback, failover, feature disablement, traffic shedding, and capacity isolation. These actions may feel crude. They are supposed to. Chaotic domains reward coarse moves that reduce the number of simultaneous unknowns. Once user-visible function returns, you almost always transition into Complex or Complicated work: now you can run probes, compare timelines, and rebuild a narrative with fewer moving parts.
+For Chaotic work, seek an intervention that can establish enough stability to observe and reassess. The framework does not remove operational constraints or guarantee that a coarse intervention improves matters. After acting, check effects and reconsider the approach instead of assuming a fixed progression through domains.
 
 ### 2.6 Communicating Uncertainty to Stakeholders
 
-Complex systems create a communication trap: leadership asks for certainty because certainty is comforting, and engineers provide narrow technical facts because those are the only statements they can defend. The gap between "we do not know yet" and "the database is slow" is where incidents go politically wrong. Practice translating domains into business language. Clear and Complicated updates can include expected time-to-recover ranges when the fix path is known. Complex updates should emphasize what you are learning, what you ruled out, and what bounded experiment runs next. Chaotic updates should state what stabilization action is in flight and when the next customer-facing checkpoint will occur.
+Communicate what is observed, what remains uncertain, and what happens next. Give a recovery estimate only when evidence supports it, and state its assumptions. If a bounded probe or stabilization action is underway, report its purpose and the next checkpoint without presenting the working hypothesis as a confirmed cause.
 
-A useful template for complex incidents is: **impact**, **stabilization status**, **working hypotheses**, **next safe experiment**, **decision time**. That template prevents the two worst failure modes: false confidence early, and endless "still investigating" language with no decision clock.
+A suggested update template is: **impact**, **stabilization status**, **working hypotheses**, **next action and its limits**, **decision time**. Use it to make uncertainty and responsibility visible; it cannot guarantee a good outcome.
 
 
-**Common stuck states** appear in almost every long-running organization. Teams can remain in complicated mode forever by insisting they "need more data" without time limits or decision clocks. Leaders can force complex incidents into complicated RCA templates that demand a single root cause when several contributing factors remain visible only in hindsight. Incident bridges can remain chaotic because each stabilization attempt fixes one symptom while another dependency fails, which means triage must explicitly prioritize customer impact over completeness.
+**Reflection:** Which observation would make your team change its current approach? If no answer comes to mind, revisit the hypothesis, the proposed action, and the evidence you are collecting. A domain label should invite that discussion rather than end it.
 
 ---
 


### PR DESCRIPTION
The complexity lesson assigned conflicting Cynefin practice labels and treated unknown outage causes as a reason to restart systems. It now distinguishes historical and later framework terminology, qualifies predictions and domain assignments, and presents operational examples as conditional teaching applications.

A hypothetical rollback exercise asks learners to inspect prerequisites before choosing an action, with its reasoning in an initially closed disclosure. The accepted outage opener and weather paragraphs remain unchanged. Cook, resilience, edge-of-chaos and Ukrainian parity remain separate work.

Refs #2403, #2272. Accepted source map: #2409.

Validation at `8c8d5ee1735875173e90fcde2df7ee18e1a203b5`: 176 pipeline tests passed (3.010s); primary-launched Astro build passed (2169 pages,43.99s); diff check and rendered text/source-link/closed-answer checks passed. Deterministic comparison confirms the opening through Part1 and Part3 onward are unchanged. One file,43 additions and43 deletions. No Python changes; Ruff not applicable. Generated test artifact restored; no build artifacts staged. Primary remains clean main.

Independent Google prose review passed (94s), following separately accepted source review. It relied on the accepted evidence note rather than re-inspecting the original journal images; review coverage and this limit are recorded in the PR comment. CI and deployment/live verification remain pending. Issue #2403 remains open after this packet.
