### PR TITLE
fix(404): enable hosted error page and honest recovery links (#2387)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -88,7 +88,7 @@ export default defineConfig({
     starlight({
       title: 'KubeDojo',
       tagline: 'Free, comprehensive cloud native education',
-      disable404Route: true,
+      disable404Route: false,
       // GoatCounter — privacy-friendly analytics (no cookies). Injected into the
       // <head> of every page via the default Starlight Head (kept by our custom
       // src/components/Head.astro override, which renders <Default>). The loader is

--- a/src/content/docs/404.mdx
+++ b/src/content/docs/404.mdx
@@ -9,9 +9,9 @@ hero:
       link: /
       icon: right-arrow
       variant: primary
-    - text: Search the Curriculum
-      link: /#_top
-      icon: magnifier
+    - text: Explore Fundamentals
+      link: /prerequisites/
+      icon: right-arrow
       variant: minimal
 pagefind: false
 sidebar:

--- a/src/content/docs/uk/404.mdx
+++ b/src/content/docs/uk/404.mdx
@@ -9,9 +9,9 @@ hero:
       link: /uk/
       icon: right-arrow
       variant: primary
-    - text: Пошук по навчальній програмі
-      link: /uk/#_top
-      icon: magnifier
+    - text: Переглянути основи
+      link: /uk/prerequisites/
+      icon: right-arrow
       variant: minimal
 pagefind: false
 sidebar:
@@ -30,27 +30,27 @@ import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
   <LinkCard
     title="Передумови"
     description="З нуля до терміналу, Linux, Cloud Native 101, основи Kubernetes"
-    href="/prerequisites/"
+    href="/uk/prerequisites/"
   />
   <LinkCard
     title="Хмара"
     description="AWS, GCP, Azure Essentials, поглиблене вивчення EKS/GKE/AKS"
-    href="/cloud/"
+    href="/uk/cloud/"
   />
   <LinkCard
     title="Сертифікації"
     description="CKA, CKAD, CKS, KCNA, KCSA та сертифікації інструментів"
-    href="/k8s/"
+    href="/uk/k8s/"
   />
   <LinkCard
     title="Платформна інженерія"
     description="Основи, дисципліни та інструментарій"
-    href="/platform/"
+    href="/uk/platform/"
   />
   <LinkCard
     title="On-Premises"
     description="Bare-metal Kubernetes, мережі, сховища, операції"
-    href="/on-premises/"
+    href="/uk/on-premises/"
   />
 </CardGrid>
 


### PR DESCRIPTION
Missing URLs currently lack the intended hosted error page, and its recovery action promises search but links to a homepage fragment. Enable the static 404 document and replace that action with a correctly labeled Fundamentals link. The existing Ukrainian error page also keeps its recovery cards in the Ukrainian curriculum.

Refs #2387, #2300, #2293; epic #2272. Three files, 12 additions / 12 deletions.

Validation at `1199fdf5f7fd687f61aa8211a38225836499bd3b`: all 176 pipeline tests passed; primary-launched Astro build passed (2,169 pages); diff check passed; isolated Chrome verified real HTTP404 responses for unknown EN/UK routes, mouse and Tab/Enter recovery, language selection to `/uk/404/`, and localized mouse/keyboard recovery to `/uk/prerequisites/`. Independent Google review passed.

GitHub Pages uses the root error document for unknown paths, including UK paths. Its existing language selector offers the localized recovery page; no automatic redirect is added. Deployed unknown-route smoke remains required after CI and merge. This small existing-page fix does not claim whole-page Ukrainian fidelity acceptance.
