### PR TITLE
fix(rubric): align standalone scorer with eight dimensions (#2419)

### DIFF
--- a/scripts/score_module.py
+++ b/scripts/score_module.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
 """Score a module against the KubeDojo quality rubric.
 
+Canonical rubric: docs/quality-rubric.md + .claude/rules/module-quality.md
+8 dimensions (D1-D8, including Practitioner Depth), each scored 1-5.
+
 Usage:
-    python scripts/score_module.py 4 5 4 4 5 4 4
-    python scripts/score_module.py 4 5 4 4 5 4 4 --json
-    echo "4 5 4 4 5 4 4" | python scripts/score_module.py -
+    .venv/bin/python scripts/score_module.py 4 5 4 4 5 4 4 4
+    .venv/bin/python scripts/score_module.py 4 5 4 4 5 4 4 4 --json
+    echo "4 5 4 4 5 4 4 4" | .venv/bin/python scripts/score_module.py -
 
 Dimensions (in order):
     D1: Learning Outcomes
@@ -14,11 +17,18 @@ Dimensions (in order):
     D5: Assessment Alignment
     D6: Cognitive Load Management
     D7: Engagement & Motivation
+    D8: Practitioner Depth (complexity-scaled)
 
 Rules:
     - Every dimension must be >= 4 (a 3 anywhere = FAIL)
-    - Sum must be >= 29 out of 35
+    - Sum must be >= 33 out of 40
     - Both conditions must pass
+
+Rating bands derive from the dimension count n (per-dimension range 1-5):
+    Pass:         4*n+1 .. 5*n   (33-40 for n=8)
+    Needs polish: 3*n+1 .. 4*n   (25-32)
+    Needs work:   2*n+1 .. 3*n   (17-24)
+    Rewrite:      n     .. 2*n   (8-16)
 """
 
 import json
@@ -32,28 +42,39 @@ DIMENSIONS = [
     "Assessment Alignment",
     "Cognitive Load Management",
     "Engagement & Motivation",
+    "Practitioner Depth",
 ]
 
+N_DIMS = len(DIMENSIONS)
+SCORE_MIN = 1
+SCORE_MAX = 5
+FLOOR = 4
+MAX_SUM = SCORE_MAX * N_DIMS
+PASS_SUM = FLOOR * N_DIMS + 1
+
+# Bands derived from the dimension count, not hard-coded totals.
 RATINGS = [
-    (29, 35, "Pass"),
-    (22, 28, "Needs polish"),
-    (15, 21, "Needs work"),
-    (7, 14, "Rewrite"),
+    (4 * N_DIMS + 1, 5 * N_DIMS, "Pass"),
+    (3 * N_DIMS + 1, 4 * N_DIMS, "Needs polish"),
+    (2 * N_DIMS + 1, 3 * N_DIMS, "Needs work"),
+    (N_DIMS, 2 * N_DIMS, "Rewrite"),
 ]
 
 
 def score(values: list[int]) -> dict:
-    if len(values) != 7:
-        raise ValueError(f"Expected 7 scores, got {len(values)}")
+    if len(values) != N_DIMS:
+        raise ValueError(f"Expected {N_DIMS} scores, got {len(values)}")
 
     for i, v in enumerate(values):
-        if not 1 <= v <= 5:
-            raise ValueError(f"D{i+1} ({DIMENSIONS[i]}): score {v} out of range 1-5")
+        if not SCORE_MIN <= v <= SCORE_MAX:
+            raise ValueError(
+                f"D{i+1} ({DIMENSIONS[i]}): score {v} out of range {SCORE_MIN}-{SCORE_MAX}"
+            )
 
     total = sum(values)
     minimum = min(values)
-    floor_pass = minimum >= 4
-    sum_pass = total >= 29
+    floor_pass = minimum >= FLOOR
+    sum_pass = total >= PASS_SUM
 
     # Find rating tier by sum
     rating = "Unknown"
@@ -66,12 +87,12 @@ def score(values: list[int]) -> dict:
     passes = floor_pass and sum_pass
 
     # Find weak dimensions
-    weak = [(DIMENSIONS[i], v) for i, v in enumerate(values) if v < 4]
+    weak = [(DIMENSIONS[i], v) for i, v in enumerate(values) if v < FLOOR]
 
     return {
         "scores": {DIMENSIONS[i]: v for i, v in enumerate(values)},
         "sum": total,
-        "max": 35,
+        "max": MAX_SUM,
         "min_score": minimum,
         "floor_pass": floor_pass,
         "sum_pass": sum_pass,
@@ -104,22 +125,22 @@ def main():
     # Pretty output
     print()
     for dim, val in result["scores"].items():
-        marker = " " if val >= 4 else " <-- BELOW FLOOR"
+        marker = " " if val >= FLOOR else " <-- BELOW FLOOR"
         print(f"  D{list(result['scores'].keys()).index(dim)+1}: {val}/5  {dim}{marker}")
 
     print(f"\n  Sum: {result['sum']}/{result['max']}")
     print(f"  Min: {result['min_score']}")
-    print(f"  Floor (all >= 4): {'PASS' if result['floor_pass'] else 'FAIL'}")
-    print(f"  Sum (>= 29):      {'PASS' if result['sum_pass'] else 'FAIL'}")
+    print(f"  Floor (all >= {FLOOR}): {'PASS' if result['floor_pass'] else 'FAIL'}")
+    print(f"  Sum (>= {PASS_SUM}):      {'PASS' if result['sum_pass'] else 'FAIL'}")
 
     if result["passes"]:
-        print(f"\n  RESULT: PASS ({result['sum']}/35)")
+        print(f"\n  RESULT: PASS ({result['sum']}/{result['max']})")
     else:
-        print(f"\n  RESULT: FAIL")
+        print("\n  RESULT: FAIL")
         if result["weak_dimensions"]:
             print(f"  Fix: {', '.join(f'{d} ({v})' for d, v in result['weak_dimensions'])}")
         if not result["sum_pass"]:
-            print(f"  Need {29 - result['sum']} more points to reach 29")
+            print(f"  Need {PASS_SUM - result['sum']} more points to reach {PASS_SUM}")
 
     print()
     sys.exit(0 if result["passes"] else 1)

--- a/scripts/tests/test_score_module.py
+++ b/scripts/tests/test_score_module.py
@@ -1,0 +1,133 @@
+"""Tests for scripts/score_module.py (issue #2419).
+
+Pins the canonical 8-dimension rubric contract (D1-D8 incl. Practitioner
+Depth): 33/40 pass sum, per-dimension floor of 4, rejection of stale 7-score
+and invalid 9-score input, out-of-range scores, CLI stdin/JSON. Literals
+(33/40, band edges) are asserted directly, not recomputed from the module's
+constants — tests pin the contract, not the implementation.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "score_module.py"
+VENV_PYTHON = REPO_ROOT / ".venv" / "bin" / "python"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("score_module", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sm = _load()
+
+ALL_FOUR = [4, 4, 4, 4, 4, 4, 4, 4]  # sum 32 — below the 33 pass line
+BARE_PASS = [4, 4, 4, 4, 4, 4, 4, 5]  # sum 33 — lowest passing sum
+
+
+def run_cli(*args: str, stdin: str | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run([str(VENV_PYTHON), str(SCRIPT), *args],
+                          input=stdin, capture_output=True, text=True, check=False)
+
+
+class TestPassContract:
+    def test_sum_32_with_clean_floor_fails(self):
+        result = sm.score(ALL_FOUR)
+        assert result["sum"] == 32
+        assert result["floor_pass"] is True and result["sum_pass"] is False
+        assert result["passes"] is False
+
+    def test_sum_33_passes(self):
+        result = sm.score(BARE_PASS)
+        assert result["sum"] == 33 and result["max"] == 40
+        assert result["passes"] is True and result["rating"] == "Pass"
+
+    def test_high_sum_with_d8_below_floor_fails(self):
+        # Sum 38 clears the bar; D8 = 3 must sink it via the floor.
+        result = sm.score([5, 5, 5, 5, 5, 5, 5, 3])
+        assert result["sum_pass"] is True and result["floor_pass"] is False
+        assert result["passes"] is False
+        assert ("Practitioner Depth", 3) in result["weak_dimensions"]
+
+    def test_floor_fail_on_any_single_dimension(self):
+        for i in range(8):
+            values = [5] * 8
+            values[i] = 3
+            assert sm.score(values)["passes"] is False, f"D{i+1} below floor must fail"
+
+    def test_result_keys_stable(self):
+        result = sm.score(BARE_PASS)
+        assert set(result) == {"scores", "sum", "max", "min_score", "floor_pass",
+                               "sum_pass", "passes", "rating", "weak_dimensions"}
+        assert list(result["scores"].values()) == BARE_PASS
+        assert len(result["scores"]) == 8
+
+
+class TestRatingBands:
+    @pytest.mark.parametrize(
+        "total,expected",
+        [(40, "Pass"), (33, "Pass"), (32, "Needs polish"), (25, "Needs polish"),
+         (24, "Needs work"), (17, "Needs work"), (16, "Rewrite"), (8, "Rewrite")],
+    )
+    def test_band_edges(self, total, expected):
+        values = [1] * 8
+        remaining = total - 8
+        for i in range(8):
+            add = min(4, remaining)
+            values[i] += add
+            remaining -= add
+        assert remaining == 0 and sum(values) == total
+        assert expected in sm.score(values)["rating"]  # fails wrap as FAIL(<band> ...)
+
+
+class TestInputValidation:
+    def test_wrong_score_counts_rejected(self):
+        with pytest.raises(ValueError, match="Expected 8 scores, got 7"):
+            sm.score([4, 5, 4, 4, 5, 4, 4])  # stale 7-dim input
+        with pytest.raises(ValueError, match="Expected 8 scores, got 9"):
+            sm.score([4, 5, 4, 4, 5, 4, 4, 4, 4])
+
+    @pytest.mark.parametrize("bad", [0, 6, -1, 99])
+    def test_out_of_range_rejected(self, bad):
+        values = [4] * 8
+        values[3] = bad
+        with pytest.raises(ValueError, match="out of range 1-5"):
+            sm.score(values)
+
+
+class TestCLI:
+    def test_argv_boundaries(self):
+        proc = run_cli(*[str(v) for v in BARE_PASS])
+        assert proc.returncode == 0 and "RESULT: PASS (33/40)" in proc.stdout
+        proc = run_cli(*[str(v) for v in ALL_FOUR])
+        assert proc.returncode == 1 and "RESULT: FAIL" in proc.stdout
+        assert "Need 1 more points to reach 33" in proc.stdout
+
+    def test_stdin_json_pass_and_fail(self):
+        proc = run_cli("-", "--json", stdin="4 4 4 4 4 4 4 5\n")
+        assert proc.returncode == 0
+        payload = json.loads(proc.stdout)
+        assert payload["passes"] is True and payload["sum"] == 33 and payload["max"] == 40
+        assert "Practitioner Depth" in payload["scores"]
+
+        proc = run_cli("-", "--json", stdin="5 5 5 5 5 5 5 3\n")
+        assert proc.returncode == 1
+        payload = json.loads(proc.stdout)
+        assert payload["passes"] is False and payload["floor_pass"] is False
+        assert payload["weak_dimensions"] == [["Practitioner Depth", 3]]
+
+    def test_cli_rejects_stale_seven_scores(self):
+        proc = run_cli("4", "5", "4", "4", "5", "4", "4")
+        assert proc.returncode == 1
+        assert "Expected 8 scores, got 7" in proc.stderr


### PR DESCRIPTION
The standalone scorer still required seven scores and a 29/35 pass, while the canonical rubric requires eight dimensions, including Practitioner Depth, and 33/40 with every dimension at least 4. Align the scorer with that contract and reject stale seven-score inputs.

Adds boundary, floor, invalid-input, output-contract, and CLI/stdin tests. Keeps the existing rating-band formula generalized to eight dimensions. Runtime pipelines and corpus scores are unchanged. Documentation reconciliation follows separately; this PR addresses only the code portion of #2419 (parent #2274, epic #2272).

Validation: lead ran 21 focused tests, Ruff, all 176 pipeline tests, and git diff --check successfully. Independent Google review passed at exact head 43722cc2044d89b9ec03225b6bfc68e75ac51123. Two files, 198 aggregate changed lines. No published content or Astro changes.
