### PR TITLE
docs(rubric): reconcile scoring and runtime contracts (#2419)

### DIFF
--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1,6 +1,6 @@
 # Module Quality Pipeline
 
-The pipeline processes each module through all 7 quality dimensions to reach a score of 29/35. It uses Gemini for writing/translating, Claude (Opus) for evaluation/review, and deterministic Python checks as quality gates.
+This document describes the v1 workflow and its numeric rubric. The manual rubric has 8 dimensions, a passing sum of 33/40, and a floor of 4 in every dimension; see [the quality rubric](quality-rubric.md). Current v1 execution uses binary review/check gates, retaining the numeric check for legacy score-bearing state. The workflow and provider examples below are historical descriptions, not current routing instructions.
 
 For the `4/5` and `5/5` upgrade program, **citations are a hard precondition**:
 - every war story must have a citation
@@ -41,18 +41,18 @@ Existing module → AUDIT+PLAN → WRITE → REVIEW → CHECK → CITE → SCORE
 | Step | Who | What | Cost |
 |------|-----|------|------|
 | **GAP-CHECK** | Python | Detect scaffolding gaps across a track (run once per track) | Free |
-| **AUDIT+PLAN** | Claude Opus | Score all 7 dimensions, generate improvement plan | ~$0.10/module |
+| **AUDIT+PLAN** | Claude Opus | Score all 8 dimensions, generate improvement plan | ~$0.10/module |
 | **WRITE** | Gemini Pro | Draft improvements based on the plan (full file output) | ~$0.05/module |
 | **REVIEW** | Claude Opus | Strict rubric review — approve or reject with feedback | ~$0.10/module |
 | **CHECK** | Python | Deterministic quality gates (structure, content, Ukrainian) | Free |
 | **CITE** | Python + reviewer | Verify `## Sources`, war-story citations, and evidence hygiene | Free |
-| **SCORE** | Python | `score_module.py` — 29/35 + every dimension >= 4 | Free |
+| **SCORE** | Python | v1 completion gate: clean binary review, or legacy scores meeting 33/40 with every dimension >= 4 | Free |
 
 If REVIEW rejects, the pipeline loops back to WRITE with the feedback (max 2 retries). If CITE or SCORE fails, the module is also rejected back into manual improvement. If it still fails, the module is flagged for manual intervention.
 
 ## Scoring System
 
-7 dimensions, each scored 1-5 (max 35):
+8 dimensions, each scored 1-5 (max 40):
 
 | # | Dimension | What a 4 looks like |
 |---|-----------|---------------------|
@@ -63,19 +63,31 @@ If REVIEW rejects, the pipeline loops back to WRITE with the feedback (max 2 ret
 | D5 | Assessment Alignment | Tests analysis not recall, explains WHY |
 | D6 | Cognitive Load Management | Good chunking, diagrams with text, worked examples |
 | D7 | Engagement & Motivation | Conversational tone, strong hook, good analogies |
+| D8 | Practitioner Depth | Complexity-scaled: patterns, anti-patterns, decision guidance for higher tiers |
+
+This numeric rubric is distinct from the binary deterministic gates in the
+CHECK/CITE steps: those gates pass or fail outright per track, while the
+rubric assigns a 1-5 score per dimension. A module must satisfy both.
 
 ### Pass criteria (BOTH required)
 
 1. **Every dimension >= 4** — a 3 anywhere is a fail, no matter the sum
-2. **Sum >= 29** — all 4s (28) isn't enough; must excel in at least one dimension
+2. **Sum >= 33** — all 4s (32) isn't enough; must excel in at least one dimension
 
 ```bash
 # Score a module manually
-python scripts/score_module.py 4 5 4 4 5 4 4          # PASS (30/35)
-python scripts/score_module.py 3 5 5 5 5 5 5          # FAIL (floor violated)
-python scripts/score_module.py 4 4 4 4 4 4 4          # FAIL (28 < 29)
-python scripts/score_module.py 4 5 4 4 5 4 4 --json   # machine-readable output
+.venv/bin/python scripts/score_module.py 4 4 4 4 4 4 4 5          # PASS (33/40)
+.venv/bin/python scripts/score_module.py 3 5 5 5 5 5 5 5          # FAIL (floor violated)
+.venv/bin/python scripts/score_module.py 4 4 4 4 4 4 4 4          # FAIL (32 < 33)
+.venv/bin/python scripts/score_module.py 4 5 4 4 5 4 4 4 --json   # machine-readable output
 ```
+
+`score_module.py` is a standalone manual scorer; v1 defines its path but does
+not invoke it. v4 reads a scalar score and gaps through
+`local_api.build_quality_scores`, a separate contract from this eight-score
+vector. These documentation changes do not rescore existing modules or change
+runtime gates. See `scripts/v1_pipeline.py` (SCORE phase) and
+`scripts/pipeline_v4.py` (`_rescore_module`) for those runtime contracts.
 
 ## Gap Detection
 
@@ -159,7 +171,7 @@ Pipeline state is stored in `.pipeline/state.yaml` (gitignored). Each module tra
 modules:
   cloud/aws-essentials/module-1.1-iam:
     phase: done          # pending → audit → write → review → check → score → done
-    scores: [5, 5, 5, 5, 4, 4, 5]
+    scores: [4, 4, 4, 4, 4, 4, 4, 5]
     sum: 33
     passes: true
     last_run: "2026-04-03T21:00:00+00:00"
@@ -180,9 +192,11 @@ State file uses file locking (`fcntl`) to prevent corruption with concurrent wor
 
 ## Auto-Commit
 
-When a module passes (29/35 + floor 4), the pipeline automatically:
-1. `git add` the improved file
-2. `git commit -m "chore(quality): v1 pipeline pass [module-key] (score/35)"`
+When v1's SCORE phase passes, it stages the improved file and any associated
+knowledge card or audit record, then attempts a commit. The commit message
+records either `all binary checks passed` or `score/40 (legacy rubric)`, plus
+the reviewer and any pending-independent-review marker. This automatic commit
+is not evidence that independent review or deployment has completed.
 
 This creates a clean git history with one commit per improved module.
 
@@ -237,7 +251,7 @@ python scripts/dispatch.py logs -n 20 --full
 | File | Purpose |
 |------|---------|
 | `scripts/v1_pipeline.py` | Main pipeline orchestrator + CLI |
-| `scripts/score_module.py` | Scoring tool (29/35 + floor 4) |
+| `scripts/score_module.py` | Scoring tool (33/40 + floor 4) |
 | `scripts/dispatch.py` | LLM dispatch (Gemini/Claude) with rate limiting |
 | `scripts/checks/structural.py` | Deterministic structure/content checks |
 | `scripts/checks/ukrainian.py` | Russicism detection + Russian char scan |
@@ -245,4 +259,4 @@ python scripts/dispatch.py logs -n 20 --full
 | `.pipeline/state.yaml` | Per-module state (gitignored) |
 | `.pipeline/audit-report.json` | Latest audit-all results (gitignored) |
 | `.mcp.json` | MCP server config for RAG tools |
-| `docs/quality-rubric.md` | Full 7-dimension rubric with scoring criteria |
+| `docs/quality-rubric.md` | Full 8-dimension rubric with scoring criteria |

--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -12,7 +12,7 @@ Minimum requirements:
 - each upgraded module must include a `## Sources` section
 - uncited modules may be improved, but they are still **not review-passed**
 
-This gate applies before the 7-dimension score is considered valid.
+This gate applies before the 8-dimension score is considered valid.
 
 ---
 
@@ -51,7 +51,7 @@ follow-up, not silently re-tiered. Locked via #2141 / #2146 / #2181 / #2187 / #2
 
 ---
 
-## Module Rubric (7 Dimensions, 1-5 Scale)
+## Module Rubric (8 Dimensions, 1-5 Scale)
 
 ### Dimension 1: Learning Outcomes
 
@@ -284,25 +284,35 @@ Copy this template when auditing a module:
 
 ## Score Interpretation
 
-Scoring uses **sum of all 7 dimensions** (max 35) with a **per-dimension floor**.
+Scoring uses **sum of all 8 dimensions** (max 40) with a **per-dimension floor**.
 
 | Sum | Rating | Action |
 |-----|--------|--------|
-| **29-35** | Pass | Ship it. Must excel in at least one dimension. |
-| **22-28** | Needs polish | Close — fix the weakest dimensions. |
-| **15-21** | Needs work | Significant gaps across multiple dimensions. |
-| **7-14** | Rewrite | Fundamentally broken. Start over. |
+| **33-40** | Pass | Ship it. Must excel in at least one dimension. |
+| **25-32** | Needs polish | Close — fix the weakest dimensions. |
+| **17-24** | Needs work | Significant gaps across multiple dimensions. |
+| **8-16** | Rewrite | Fundamentally broken. Start over. |
+
+This numeric rubric is separate from the binary per-track deterministic gates
+(structural, citation, Ukrainian checks): those gates pass or fail outright,
+while the rubric scores a module 1-5 per dimension. Both must be satisfied
+independently.
 
 ### Scoring Tool
 
 ```bash
-python scripts/score_module.py 4 5 4 4 5 4 4          # interactive
-python scripts/score_module.py 4 5 4 4 5 4 4 --json   # machine-readable
-echo "4 5 4 4 5 4 4" | python scripts/score_module.py -  # stdin
-python scripts/check_citations.py src/content/docs/ai/foundations/module-1.1-what-is-ai.md
+.venv/bin/python scripts/score_module.py 4 5 4 4 5 4 4 4          # interactive
+.venv/bin/python scripts/score_module.py 4 5 4 4 5 4 4 4 --json   # machine-readable
+echo "4 5 4 4 5 4 4 4" | .venv/bin/python scripts/score_module.py -  # stdin
+.venv/bin/python scripts/check_citations.py src/content/docs/ai/foundations/module-1.1-what-is-ai.md
 ```
 
-Dimension order: D1 Outcomes, D2 Scaffolding, D3 Active Learning, D4 Real-World, D5 Assessment, D6 Cognitive Load, D7 Engagement.
+Dimension order: D1 Outcomes, D2 Scaffolding, D3 Active Learning, D4 Real-World, D5 Assessment, D6 Cognitive Load, D7 Engagement, D8 Practitioner Depth.
+
+`score_module.py` is a standalone manual scorer for one module at a time. It
+is not currently invoked by the runtime pipelines (v1 defines the path but
+does not call it; v4 reads scalar scores and gaps via `local_api.build_quality_scores`), and nothing here
+implies a corpus-wide rescore.
 
 ---
 
@@ -318,7 +328,7 @@ A module passes the quality bar when **both** conditions are met:
 
 1. **Every dimension >= 4** — a score of 3 or below in ANY dimension is an automatic fail, regardless of sum. Every dimension matters equally. You cannot compensate for weak real-world connection with strong quizzes.
 
-2. **Sum >= 29 out of 35** — all 4s (sum=28) is not enough. At least one dimension must be at 5, meaning the module excels somewhere, not just meets the bar everywhere.
+2. **Sum >= 33 out of 40** — all 4s (sum=32) is not enough. At least one dimension must be at 5, meaning the module excels somewhere, not just meets the bar everywhere.
 
-A module that scores 3-5-5-5-5-5-5 (sum=33) **fails** — the floor is violated.
-A module that scores 4-4-4-4-4-4-4 (sum=28) **fails** — it needs to excel somewhere.
+A module that scores 3-5-5-5-5-5-5-5 (sum=38) **fails** — the floor is violated.
+A module that scores 4-4-4-4-4-4-4-4 (sum=32) **fails** — it needs to excel somewhere.


### PR DESCRIPTION
Reconcile the rubric and pipeline documentation with the eight-dimension scorer merged in #2422: 33/40, every dimension at least 4, and matching executable examples. Distinguish manual scoring from v1 binary/legacy completion gates and v4 scalar-score lookup, so the docs do not imply the standalone scorer runs in those pipelines.

Refs #2419, parent #2274, epic #2272. Agent instruction synchronization remains a separate follow-up; no corpus rescore or runtime behavior changes.

Validation: all seven documented scorer invocations produced intended exit codes; all 176 pipeline tests passed; git diff --check clean. Independent Google review PASS at dae732c64d2a2f05151ab0276396a2ac85436de7. Two internal documentation files, 84 aggregate changed lines. No published Astro content changed.
