### PR TITLE
docs(rubric): align writer and reviewer instructions (#2419)

### DIFF
--- a/.claude/hooks/post-compact.sh
+++ b/.claude/hooks/post-compact.sh
@@ -32,7 +32,7 @@ fi
 CONTEXT="$CONTEXT
 KEY REMINDERS:
   - .venv/bin/python only (hook enforces this)
-  - Quality: 29/35 sum + every dimension >= 4
+  - Quality: 33/40 sum + every dimension >= 4 (D1-D8)
   - Workflow: Gemini writes, Claude reviews strictly
   - Pipeline: .venv/bin/python scripts/v1_pipeline.py status
   - UK sync: .venv/bin/python scripts/uk_sync.py detect

--- a/.claude/skills/cross-family-reviewer/SKILL.md
+++ b/.claude/skills/cross-family-reviewer/SKILL.md
@@ -10,7 +10,7 @@ Run a rigorous PR review on KubeDojo code or content. **Different model family t
 
 > **Routing source-of-truth precedence**: `docs/review-protocol.md` defines the cross-family *principle* but its concrete pairings (Claude → Codex etc.) predate Decision Card C (2026-05-24). The active routing table below + [`STATUS.md`](../../../STATUS.md) "Active policies" supersede the stale defaults in `review-protocol.md` until that doc is refreshed.
 
-This skill describes the **review contract**. For pedagogical content scoring against the 7-dim rubric, layer in [[module-quality-reviewer]].
+This skill describes the **review contract**. For pedagogical content scoring against the 8-dim rubric (D1-D8), layer in [[module-quality-reviewer]].
 
 ## Routing table (Decision Card C, 2026-05-24; gemini-cli retired ~2026-06-15 → the Google seat is agy)
 
@@ -29,7 +29,7 @@ This skill describes the **review contract**. For pedagogical content scoring ag
 
 1. **Pull the PR locally** (or read the diff via `gh pr diff <N>`).
 2. **Read changed files in full**, not just the hunk. A diff hides surrounding-context bugs.
-3. **For curriculum content**: also run [[module-quality-reviewer]] (7-dim rubric).
+3. **For curriculum content**: also run [[module-quality-reviewer]] (8-dim rubric).
 4. **For code**: run the relevant linter + tests (`.venv/bin/ruff check`, `npx tsc --noEmit`, `npx eslint`, `.venv/bin/pytest`, `npm test`).
 5. **For workflows** (`.github/workflows/**`): `uvx zizmor --offline --strict-collection .github/` ([[.claude/rules/github-actions-security]]).
 6. **For modules**: `.venv/bin/python scripts/quality/verify_module.py <path>` for density gates.
@@ -108,7 +108,7 @@ For contested NEEDS_CHANGES (author defends, reviewer blocks, repeat), trigger `
 
 ## References
 
-- [[module-quality-reviewer]] — pedagogical 7-dim rubric for content reviews.
+- [[module-quality-reviewer]] — pedagogical 8-dim rubric for content reviews.
 - [[curriculum-writer]] — what the author was contracted to deliver.
 - [[dispatch-router]] — picking the right reviewer agent.
 - [`docs/review-protocol.md`](../../../docs/review-protocol.md) — cross-family review contract.

--- a/.claude/skills/curriculum-orchestrator/SKILL.md
+++ b/.claude/skills/curriculum-orchestrator/SKILL.md
@@ -112,7 +112,7 @@ Per user policy refinement: every shipped module must carry a composer-2.5 cross
 - Never act on a file or directory without understanding its purpose.
 - Never modify a pipeline without reading design docs first.
 - Density gates are MINIMUMS, not targets (median_wpp ≥ 28, mean_wpp ≥ 30, short-para-rate ≤ 20%). Expand content; do not lower the gate ([[feedback_388_verifier_first_pilot_then_volume]]).
-- Verifier ≠ pedagogical quality. A module that passes the verifier can still fail the 7-dimension rubric ([[feedback_teaching_not_listicles]]).
+- Verifier ≠ pedagogical quality. A module that passes the verifier can still fail the 8-dimension rubric ([[feedback_teaching_not_listicles]]).
 - "Heuristic-green" ≠ "reviewed by composer-2.5". Two different axes on the `/quality` dashboard.
 - Never switch branches in the main project dir; all branch work in `.worktrees/`.
 - Don't add Jenkins modules — cover GHA + GitLab CI + ArgoCD instead ([[feedback_skip_jenkins_prefer_modern_cicd]]).

--- a/.claude/skills/curriculum-writer/SKILL.md
+++ b/.claude/skills/curriculum-writer/SKILL.md
@@ -12,7 +12,7 @@ Author skill for new KubeDojo curriculum modules. Ensures consistent structure, 
 - Creating new curriculum modules
 - Expanding existing module content
 - Writing theory sections, exercises, or quizzes
-- Rewriting modules failing the verifier (`median_wpp < 28` etc.) or the 7-dimension rubric
+- Rewriting modules failing the verifier (`median_wpp < 28` etc.) or the 8-dimension rubric
 
 ## Author lanes (who writes what — 2026-05-24 snapshot)
 
@@ -27,7 +27,7 @@ Author skill for new KubeDojo curriculum modules. Ensures consistent structure, 
 | Drafter (needs Claude expansion) | agy (gemini-3.1-pro-high) | When deeper structure scoped but final-form latency cheap | Outputs 350-400 lines, expand to 700-900+ |
 | Source-fidelity expansion | claude opus (post-2026-06-15 inline) OR codex (pre, danger mode) | Strict-source rewrites | [[feedback_codex_default_prose_expander]] |
 
-**Important**: every author lane is bound by the same density gates and 7-dim rubric below. The agent identity changes the dispatch wrapper, not the content contract.
+**Important**: every author lane is bound by the same density gates and 8-dim rubric below. The agent identity changes the dispatch wrapper, not the content contract.
 
 ## Author contract (every lane)
 
@@ -47,7 +47,7 @@ Every authored/rewritten module MUST satisfy ALL of:
 9. **No personal framing**: no interview/job/role narrative ([[feedback_no_personal_framing]]).
 10. **Pedagogy over listicles**: modules must TEACH, not dump facts ([[feedback_teaching_not_listicles]]).
 
-The 7-dimension rubric (Learning Outcomes, Scaffolding, Active Learning, Real-World Connection, Assessment Alignment, Cognitive Load, Engagement) is the reviewer's contract — see [[module-quality-reviewer]]. Author for ≥3.5 average with no dimension at 1.
+The 8-dimension rubric (Learning Outcomes, Scaffolding, Active Learning, Real-World Connection, Assessment Alignment, Cognitive Load, Engagement, Practitioner Depth — complexity-scaled) is the reviewer's contract — see [[module-quality-reviewer]] and `docs/quality-rubric.md`. Author for sum ≥ 33/40 with every dimension ≥ 4.
 
 ## Track-Specific Guidelines
 
@@ -469,7 +469,7 @@ Same shape as codex via `.venv/bin/python scripts/dispatch_smart.py draft --agen
 
 ## References
 
-- [[module-quality-reviewer]] — the 7-dimension rubric your authored module is graded against.
+- [[module-quality-reviewer]] — the 8-dimension rubric your authored module is graded against.
 - [[cross-family-reviewer]] — post-author review protocol.
 - [[dispatch-router]] — agent routing decisions.
 - [[k8s-cert-expert]] — domain expertise for k8s/cert content.

--- a/.claude/skills/module-quality-reviewer/SKILL.md
+++ b/.claude/skills/module-quality-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: module-quality-reviewer
-description: Review KubeDojo modules against the 7-dim pedagogical rubric. For ANY agent acting as reviewer (codex, composer-2.5, agy, claude). Use when reviewing, scoring, or checking modules. Triggers on "review module", "check quality", "score module".
+description: Review KubeDojo modules against the 8-dimension (D1-D8) pedagogical rubric. For ANY agent acting as reviewer (codex, composer-2.5, agy, claude). Use when reviewing, scoring, or checking modules. Triggers on "review module", "check quality", "score module".
 last_calibrated: 2026-05-24
 ---
 
@@ -24,7 +24,7 @@ Every PR must be reviewed by a different model family than the author per [`docs
 
 1. **Read the module fully** — line-by-line, not skim ([[code-editing-safety §3]]).
 2. **Run the verifier first**: `.venv/bin/python scripts/quality/verify_module.py <path>`. Density gates failing (median_wpp < 28, mean_wpp < 30, short-para > 20%) = immediate NEEDS_CHANGES, no rubric needed yet.
-3. **Score against ALL 7 rubric dimensions** (1-5 each).
+3. **Score against ALL 8 rubric dimensions** (1-5 each).
 4. **Be STRICT** — a 4 means genuinely good, a 5 is exceptional.
 5. **Flag specific issues with line numbers** — vague critique is reviewer-malpractice.
 6. **Verify all external facts**. Burden of proof on keeping: if a citation `supports` the claim → keep; partial/no/fetch-fail/ambiguous → flag for removal ([[feedback_citation_verify_or_remove]]).
@@ -41,6 +41,7 @@ Every PR must be reviewed by a different model family than the author per [`docs
 | **Assessment Alignment** | Do quiz questions test understanding (scenarios) or recall (what is X?)? |
 | **Cognitive Load** | Well-chunked? Diagrams integrated? Or information dump? |
 | **Engagement** | Memorable tone? Would you recommend this to a colleague? Or dry/robotic? |
+| **Practitioner Depth** (complexity-scaled) | Apply D8 in `docs/quality-rubric.md` for the module's complexity marker: purpose and honest tradeoffs for `[QUICK]`, patterns and decision guidance for `[MEDIUM]`, deeper failure analysis and architectural reasoning for advanced tiers. |
 
 ## Structure Checklist
 
@@ -60,10 +61,10 @@ Do not penalize a module solely for omitting a story or analogy. When used, veri
 
 ## Passing Criteria
 
-- Average score >= 3.5/5
-- No single dimension scores 1
-- Active Learning >= 3
-- Assessment Alignment >= 3
+Per the repository-root `docs/quality-rubric.md` (D1-D8), a module passes only when **both** hold:
+
+- **Sum >= 33 out of 40** (8 dimensions, 1-5 each)
+- **Every dimension >= 4** — a 3 anywhere is an automatic fail, regardless of sum
 
 ## Output Format
 
@@ -83,7 +84,8 @@ Do not penalize a module solely for omitting a story or analogy. When used, veri
 | Assessment Alignment | /5 | |
 | Cognitive Load | /5 | |
 | Engagement | /5 | |
-| **Average** | **/5** | |
+| Practitioner Depth | /5 | (complexity-scaled) |
+| **Sum** | **/40** | pass: sum >= 33 AND every dimension >= 4 |
 
 ### Structure Checklist
 - [x] or [ ] for each required element
@@ -98,6 +100,8 @@ Do not penalize a module solely for omitting a story or analogy. When used, veri
 ```
 
 ## Reference Modules (Gold Standard)
+
+> The listed five-point scores do not establish acceptance under the current eight-dimension contract. Verify current evidence before treating these modules as passing references.
 
 - **Platform: What is Systems Thinking?** (4.6/5) — narrative voice, inline exercises, scenario-based assessment
 - **On-Prem: The Case for On-Prem** (4.4/5) — balanced perspective, deliberate quiz traps, TCO exercise

--- a/agents_extensions/claude/skills/curriculum-orchestrator/SKILL.md
+++ b/agents_extensions/claude/skills/curriculum-orchestrator/SKILL.md
@@ -112,7 +112,7 @@ Per user policy refinement: every shipped module must carry a composer-2.5 cross
 - Never act on a file or directory without understanding its purpose.
 - Never modify a pipeline without reading design docs first.
 - Density gates are MINIMUMS, not targets (median_wpp ≥ 28, mean_wpp ≥ 30, short-para-rate ≤ 20%). Expand content; do not lower the gate ([[feedback_388_verifier_first_pilot_then_volume]]).
-- Verifier ≠ pedagogical quality. A module that passes the verifier can still fail the 7-dimension rubric ([[feedback_teaching_not_listicles]]).
+- Verifier ≠ pedagogical quality. A module that passes the verifier can still fail the 8-dimension rubric ([[feedback_teaching_not_listicles]]).
 - "Heuristic-green" ≠ "reviewed by composer-2.5". Two different axes on the `/quality` dashboard.
 - Never switch branches in the main project dir; all branch work in `.worktrees/`.
 - Don't add Jenkins modules — cover GHA + GitLab CI + ArgoCD instead ([[feedback_skip_jenkins_prefer_modern_cicd]]).

--- a/agents_extensions/shared/skills/cross-family-reviewer/SKILL.md
+++ b/agents_extensions/shared/skills/cross-family-reviewer/SKILL.md
@@ -10,7 +10,7 @@ Run a rigorous PR review on KubeDojo code or content. **Different model family t
 
 > **Routing source-of-truth precedence**: `docs/review-protocol.md` defines the cross-family *principle* but its concrete pairings (Claude → Codex etc.) predate Decision Card C (2026-05-24). The active routing table below + [`STATUS.md`](../../../STATUS.md) "Active policies" supersede the stale defaults in `review-protocol.md` until that doc is refreshed.
 
-This skill describes the **review contract**. For pedagogical content scoring against the 7-dim rubric, layer in [[module-quality-reviewer]].
+This skill describes the **review contract**. For pedagogical content scoring against the 8-dim rubric (D1-D8), layer in [[module-quality-reviewer]].
 
 ## Routing table (Decision Card C, 2026-05-24; gemini-cli retired ~2026-06-15 → the Google seat is agy)
 
@@ -29,7 +29,7 @@ This skill describes the **review contract**. For pedagogical content scoring ag
 
 1. **Pull the PR locally** (or read the diff via `gh pr diff <N>`).
 2. **Read changed files in full**, not just the hunk. A diff hides surrounding-context bugs.
-3. **For curriculum content**: also run [[module-quality-reviewer]] (7-dim rubric).
+3. **For curriculum content**: also run [[module-quality-reviewer]] (8-dim rubric).
 4. **For code**: run the relevant linter + tests (`.venv/bin/ruff check`, `npx tsc --noEmit`, `npx eslint`, `.venv/bin/pytest`, `npm test`).
 5. **For workflows** (`.github/workflows/**`): `uvx zizmor --offline --strict-collection .github/` ([[.claude/rules/github-actions-security]]).
 6. **For modules**: `.venv/bin/python scripts/quality/verify_module.py <path>` for density gates.
@@ -108,7 +108,7 @@ For contested NEEDS_CHANGES (author defends, reviewer blocks, repeat), trigger `
 
 ## References
 
-- [[module-quality-reviewer]] — pedagogical 7-dim rubric for content reviews.
+- [[module-quality-reviewer]] — pedagogical 8-dim rubric for content reviews.
 - [[curriculum-writer]] — what the author was contracted to deliver.
 - [[dispatch-router]] — picking the right reviewer agent.
 - [`docs/review-protocol.md`](../../../docs/review-protocol.md) — cross-family review contract.

--- a/agents_extensions/shared/skills/curriculum-writer/SKILL.md
+++ b/agents_extensions/shared/skills/curriculum-writer/SKILL.md
@@ -12,7 +12,7 @@ Author skill for new KubeDojo curriculum modules. Ensures consistent structure, 
 - Creating new curriculum modules
 - Expanding existing module content
 - Writing theory sections, exercises, or quizzes
-- Rewriting modules failing the verifier (`median_wpp < 28` etc.) or the 7-dimension rubric
+- Rewriting modules failing the verifier (`median_wpp < 28` etc.) or the 8-dimension rubric
 
 ## Author lanes (who writes what — 2026-05-24 snapshot)
 
@@ -27,7 +27,7 @@ Author skill for new KubeDojo curriculum modules. Ensures consistent structure, 
 | Drafter (needs Claude expansion) | agy (gemini-3.1-pro-high) | When deeper structure scoped but final-form latency cheap | Outputs 350-400 lines, expand to 700-900+ |
 | Source-fidelity expansion | claude opus (post-2026-06-15 inline) OR codex (pre, danger mode) | Strict-source rewrites | [[feedback_codex_default_prose_expander]] |
 
-**Important**: every author lane is bound by the same density gates and 7-dim rubric below. The agent identity changes the dispatch wrapper, not the content contract.
+**Important**: every author lane is bound by the same density gates and 8-dim rubric below. The agent identity changes the dispatch wrapper, not the content contract.
 
 ## Author contract (every lane)
 
@@ -47,7 +47,7 @@ Every authored/rewritten module MUST satisfy ALL of:
 9. **No personal framing**: no interview/job/role narrative ([[feedback_no_personal_framing]]).
 10. **Pedagogy over listicles**: modules must TEACH, not dump facts ([[feedback_teaching_not_listicles]]).
 
-The 7-dimension rubric (Learning Outcomes, Scaffolding, Active Learning, Real-World Connection, Assessment Alignment, Cognitive Load, Engagement) is the reviewer's contract — see [[module-quality-reviewer]]. Author for ≥3.5 average with no dimension at 1.
+The 8-dimension rubric (Learning Outcomes, Scaffolding, Active Learning, Real-World Connection, Assessment Alignment, Cognitive Load, Engagement, Practitioner Depth — complexity-scaled) is the reviewer's contract — see [[module-quality-reviewer]] and `docs/quality-rubric.md`. Author for sum ≥ 33/40 with every dimension ≥ 4.
 
 ## Track-Specific Guidelines
 
@@ -469,7 +469,7 @@ Same shape as codex via `.venv/bin/python scripts/dispatch_smart.py draft --agen
 
 ## References
 
-- [[module-quality-reviewer]] — the 7-dimension rubric your authored module is graded against.
+- [[module-quality-reviewer]] — the 8-dimension rubric your authored module is graded against.
 - [[cross-family-reviewer]] — post-author review protocol.
 - [[dispatch-router]] — agent routing decisions.
 - [[k8s-cert-expert]] — domain expertise for k8s/cert content.

--- a/agents_extensions/shared/skills/module-quality-reviewer/SKILL.md
+++ b/agents_extensions/shared/skills/module-quality-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: module-quality-reviewer
-description: Review KubeDojo modules against the 7-dim pedagogical rubric. For ANY agent acting as reviewer (codex, composer-2.5, agy, claude). Use when reviewing, scoring, or checking modules. Triggers on "review module", "check quality", "score module".
+description: Review KubeDojo modules against the 8-dimension (D1-D8) pedagogical rubric. For ANY agent acting as reviewer (codex, composer-2.5, agy, claude). Use when reviewing, scoring, or checking modules. Triggers on "review module", "check quality", "score module".
 last_calibrated: 2026-05-24
 ---
 
@@ -24,7 +24,7 @@ Every PR must be reviewed by a different model family than the author per [`docs
 
 1. **Read the module fully** — line-by-line, not skim ([[code-editing-safety §3]]).
 2. **Run the verifier first**: `.venv/bin/python scripts/quality/verify_module.py <path>`. Density gates failing (median_wpp < 28, mean_wpp < 30, short-para > 20%) = immediate NEEDS_CHANGES, no rubric needed yet.
-3. **Score against ALL 7 rubric dimensions** (1-5 each).
+3. **Score against ALL 8 rubric dimensions** (1-5 each).
 4. **Be STRICT** — a 4 means genuinely good, a 5 is exceptional.
 5. **Flag specific issues with line numbers** — vague critique is reviewer-malpractice.
 6. **Verify all external facts**. Burden of proof on keeping: if a citation `supports` the claim → keep; partial/no/fetch-fail/ambiguous → flag for removal ([[feedback_citation_verify_or_remove]]).
@@ -41,6 +41,7 @@ Every PR must be reviewed by a different model family than the author per [`docs
 | **Assessment Alignment** | Do quiz questions test understanding (scenarios) or recall (what is X?)? |
 | **Cognitive Load** | Well-chunked? Diagrams integrated? Or information dump? |
 | **Engagement** | Memorable tone? Would you recommend this to a colleague? Or dry/robotic? |
+| **Practitioner Depth** (complexity-scaled) | Apply D8 in `docs/quality-rubric.md` for the module's complexity marker: purpose and honest tradeoffs for `[QUICK]`, patterns and decision guidance for `[MEDIUM]`, deeper failure analysis and architectural reasoning for advanced tiers. |
 
 ## Structure Checklist
 
@@ -60,10 +61,10 @@ Do not penalize a module solely for omitting a story or analogy. When used, veri
 
 ## Passing Criteria
 
-- Average score >= 3.5/5
-- No single dimension scores 1
-- Active Learning >= 3
-- Assessment Alignment >= 3
+Per the repository-root `docs/quality-rubric.md` (D1-D8), a module passes only when **both** hold:
+
+- **Sum >= 33 out of 40** (8 dimensions, 1-5 each)
+- **Every dimension >= 4** — a 3 anywhere is an automatic fail, regardless of sum
 
 ## Output Format
 
@@ -83,7 +84,8 @@ Do not penalize a module solely for omitting a story or analogy. When used, veri
 | Assessment Alignment | /5 | |
 | Cognitive Load | /5 | |
 | Engagement | /5 | |
-| **Average** | **/5** | |
+| Practitioner Depth | /5 | (complexity-scaled) |
+| **Sum** | **/40** | pass: sum >= 33 AND every dimension >= 4 |
 
 ### Structure Checklist
 - [x] or [ ] for each required element
@@ -98,6 +100,8 @@ Do not penalize a module solely for omitting a story or analogy. When used, veri
 ```
 
 ## Reference Modules (Gold Standard)
+
+> The listed five-point scores do not establish acceptance under the current eight-dimension contract. Verify current evidence before treating these modules as passing references.
 
 - **Platform: What is Systems Thinking?** (4.6/5) — narrative voice, inline exercises, scenario-based assessment
 - **On-Prem: The Case for On-Prem** (4.4/5) — balanced perspective, deliberate quiz traps, TCO exercise

--- a/docs/citation-upgrade-plan.md
+++ b/docs/citation-upgrade-plan.md
@@ -22,7 +22,7 @@ For upgrade work, a module is **not review-passed** until it satisfies all of th
 3. important factual claims are traceable to cited sources
 4. the formal rubric score still passes:
    - every dimension `>= 4`
-   - total `>= 29/35`
+   - total `>= 33/40` across all eight dimensions in `docs/quality-rubric.md`
 
 ## What Must Be Cited
 


### PR DESCRIPTION
Writer and reviewer skills still allowed seven dimensions and a 3.5 average, contradicting the rubric and scorer. Align the canonical skill sources, deployed Claude copies, compaction reminder, and citation plan with D1–D8, sum >=33/40, and every dimension >=4. Add complexity-scaled Practitioner Depth to review/output tables; old reference scores no longer imply current acceptance.

Refs #2419, #2274, #2272. Follows merged #2422 and #2423. No corpus rescoring, runtime gate changes, or new claims of learner outcomes. The Git-ignored primary .agents reviewer requires a separate local update before #2419 closes.

Validation: all176 pipeline tests, extension sync, bash syntax, and diff checks pass. Independent Google review PASS at 9eeed60486ca1bc9d865b93a9cf5adf153f2ca4f. General skill validator rejects unchanged last_calibrated metadata both before and after; that pre-existing schema limitation is preserved. Ten files,72 aggregate changed lines.
