### PR TITLE
fix(linux): bound mount namespace lab ownership and cleanup (#2418)

### DIFF
--- a/docs/content-upgrade/research/linux-mount-lab-evidence.md
+++ b/docs/content-upgrade/research/linux-mount-lab-evidence.md
@@ -1,0 +1,15 @@
+# Mount namespace lab evidence — #2418
+
+Scope: the mount worked example and Part 4 of the English namespaces module. Network-name ownership, other lab parts, and Ukrainian fidelity remain separate work.
+
+The lead read the bodies of [unshare(1)](https://man7.org/linux/man-pages/man1/unshare.1.html), [mount_namespaces(7)](https://man7.org/linux/man-pages/man7/mount_namespaces.7.html), and [findmnt(8)](https://man7.org/linux/man-pages/man8/findmnt.8.html). Relevant contracts: explicit private propagation; namespace lifetime and persistence; successful full mount-table enumeration. `findmnt` exit 1 can indicate an error, so it is not sufficient evidence of absence. Installed GNU `mktemp --help` and `rmdir --help` were also read to confirm directory creation and empty-directory cleanup behavior.
+
+Independent Fable source/design review accepted the tested Bash interior, with the invocation caveat resolved by an explicit `bash` here-document. This is source/design acceptance, not prose acceptance. The reviewed manuals describe newer releases than the installed utilities; command compatibility below is observed on the stated environment.
+
+On 2026-09-05, the lead ran the candidate in a dedicated kind node (`kindest/node:v1.35.0`) on OrbStack, as UID 0. Installed versions: util-linux `unshare` and `findmnt` 2.38.1; kernel `7.0.14-orbstack-00380-ga7e0a2dc9535`. The final lesson block was extracted and executed at 17:15:40 UTC. Its interior SHA256 is `9fade2f36c60bec19327679c363e5f9d77d9034d96a2f06f5435b68b14d37201`.
+
+Observed cases: normal exit 0; invalid tmpfs mount option exit 32; child self-TERM exit 143; parent self-TERM after child exit 143; non-empty cleanup refusal exit 1 with the injected file preserved. A separate pre-existing `/tmp/kd-mnt-lab` sentinel remained unchanged while a fresh suffixed directory was used. Every test-owned directory and sentinel was removed after inspection. Exit numbers are observations, not a portable error-code specification.
+
+Normal output showed distinct parent/child namespace identifiers, `tmpfs` with `private` propagation inside the child, and no matching mount or file in the parent after the child exited. There was no explicit unmount before the parent check. This is sequential observation, not simultaneous inspection of both namespaces.
+
+Limits: no `sudo` binary in the node; no sudo-policy test, non-root exercise, concurrent terminal Ctrl-C test, SIGKILL-cleanup guarantee, or general claim about other Linux environments. No background process or persistent namespace was created. The cleanup trap can report failure rather than remove a non-empty directory. Numeric rubric scores or these bounded executions do not establish whole-module correctness.

--- a/src/content/docs/linux/foundations/container-primitives/module-2.1-namespaces.md
+++ b/src/content/docs/linux/foundations/container-primitives/module-2.1-namespaces.md
@@ -292,29 +292,7 @@ flowchart LR
     end
 ```
 
-The worked example below creates a mount namespace and mounts a temporary filesystem under `/tmp/ns-mount-lab`. The temporary mount exists only inside the namespace unless mount propagation settings intentionally share it. The file you create is real while the namespace exists, but the host mount table does not gain the same mount point.
-
-```bash
-sudo unshare --mount bash
-```
-
-Inside the new shell, run these commands. The `findmnt` output shows that `/tmp/ns-mount-lab` is a mount point in this namespace. The file write proves that the mounted tmpfs is usable.
-
-```bash
-mkdir -p /tmp/ns-mount-lab
-mount -t tmpfs tmpfs /tmp/ns-mount-lab
-echo "visible only through this mount namespace" > /tmp/ns-mount-lab/message.txt
-findmnt /tmp/ns-mount-lab
-cat /tmp/ns-mount-lab/message.txt
-exit
-```
-
-Back on the host, inspect the same path. Depending on whether the directory existed before and how your system handles cleanup, the directory may exist, but the tmpfs mount and its file should not be visible from the host namespace. The important observation is the mount table difference, not the directory name alone.
-
-```bash
-findmnt /tmp/ns-mount-lab || true
-cat /tmp/ns-mount-lab/message.txt
-```
+The [mount exercise in Part 4](#part-4-create-a-mount-namespace) makes this distinction observable: a child mounts a tmpfs at a newly created directory, writes a file through that mount, and exits. The parent then checks its own mount table and filesystem view. Predict what remains: the directory, the mount, or the file? A directory in the underlying filesystem is different from a mount attached to that path in one namespace.
 
 Mount namespaces interact heavily with security. Accidentally bind-mounting sensitive host paths into a container can defeat filesystem isolation even when the container has its own mount namespace. The namespace controls the view; the mounts placed into that view determine what data is exposed. A private view containing `/var/run/docker.sock` is still dangerous because the socket grants control over the container runtime.
 
@@ -799,34 +777,64 @@ ip netns list
 
 ### Part 4: Create a Mount Namespace
 
-Create a mount namespace and mount a temporary filesystem. This demonstrates that a process can see a mount that the host shell does not see in the same way.
+Use a **root Bash session on a disposable Linux lab machine** with util-linux and GNU coreutils installed. The block below was exercised as root in a kind node with util-linux 2.38.1; it does not test your machine's `sudo` policy. Here, “parent” means that Linux shell's mount namespace, not the Mac hosting a Linux VM.
+
+Before running it, predict why removing an empty directory should succeed even though the child wrote a file at that path. The block creates its own directory with `mktemp -d`, rather than adopting a fixed name. Cleanup uses `rmdir`, which refuses to remove a non-empty directory; see the installed `mktemp --help` and `rmdir --help`.
+
+Paste the complete block. `bash` is explicit because the script uses Bash syntax. `set -eu` stops on failed commands or unset variables inside this lab shell. The exit trap attempts to remove only the directory created by this run.
 
 ```bash
-sudo unshare --mount bash
+bash <<'LAB'
+set -eu
+for tool in unshare mount findmnt mktemp rmdir readlink; do
+    command -v "$tool" >/dev/null
+done
+lab_dir=$(mktemp -d /tmp/kd-mnt-lab.XXXXXX)
+printf 'Owned directory: %s\n' "$lab_dir"
+cleanup() {
+    status=$?
+    trap - EXIT
+    if ! rmdir -- "$lab_dir"; then
+        printf 'Cleanup refused; inspect this exact directory: %s\n' "$lab_dir" >&2
+        exit 1
+    fi
+    exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+printf 'Parent namespace: '; readlink /proc/self/ns/mnt
+unshare --mount --propagation private bash -eu -s -- "$lab_dir" <<'CHILD'
+lab_dir=$1
+printf 'Child namespace: '; readlink /proc/self/ns/mnt
+mount -t tmpfs -o size=1m tmpfs "$lab_dir"
+printf 'namespace mount data\n' > "$lab_dir/data.txt"
+findmnt --mountpoint "$lab_dir" -o TARGET,FSTYPE,PROPAGATION
+cat "$lab_dir/data.txt"
+CHILD
+parent_mounts=$(findmnt --kernel --noheadings --raw --output TARGET)
+while IFS= read -r target; do
+    if [ "$target" = "$lab_dir" ]; then
+        printf 'FAIL: unexpected parent mount\n' >&2
+        exit 1
+    fi
+done <<< "$parent_mounts"
+test ! -e "$lab_dir/data.txt"
+printf 'PASS: parent has neither the mount nor its file\n'
+LAB
 ```
 
-Inside the namespace, create and inspect the mount. Read the file through that mount table.
+Compare the two namespace identifiers and the child's `tmpfs`/`private` output. The final message checks the parent's view after the child exits; it is not a simultaneous observation from two shells. The directory survives until the exit trap removes it, while the file was written into the child's tmpfs. [Private propagation prevents mount events from propagating to other namespaces](https://man7.org/linux/man-pages/man7/mount_namespaces.7.html); [unshare has selected it by default since util-linux 2.27](https://man7.org/linux/man-pages/man1/unshare.1.html). The flag makes that choice explicit.
 
-```bash
-mkdir -p /tmp/kd-mnt-lab
-mount -t tmpfs tmpfs /tmp/kd-mnt-lab
-echo "namespace mount data" > /tmp/kd-mnt-lab/data.txt
-findmnt /tmp/kd-mnt-lab
-cat /tmp/kd-mnt-lab/data.txt
-exit
-```
+Why read the whole parent mount table? [`findmnt` returns 1 for errors as well as no match](https://man7.org/linux/man-pages/man8/findmnt.8.html). Treating every nonzero result as proof of absence could hide a broken check. Here the table read must succeed before the script searches its output.
 
-Back on the host, check whether the mount exists. The expected result is that the tmpfs mount is not present in your original mount namespace.
-
-```bash
-findmnt /tmp/kd-mnt-lab || true
-cat /tmp/kd-mnt-lab/data.txt
-```
+If setup fails, the exit trap still attempts cleanup and preserves the failure status unless cleanup itself fails. If cleanup refuses, inspect the exact printed path; do not replace `rmdir` with recursive deletion. Do not start background processes or persist this namespace: its lifetime can extend beyond the script if another process or reference holds it. SIGKILL cannot run the shell's trap, so an abrupt termination may leave the owned directory for manual inspection. The checks above do not certify arbitrary interruption or privilege configurations.
 
 #### Success Criteria for Part 4
 
 - [ ] You created a mount namespace and mounted a tmpfs inside it.
 - [ ] You observed that mount visibility depends on the mount namespace.
+- [ ] The owned directory was removed, or cleanup reported a failure that you investigated without deleting unrelated data.
 - [ ] You can explain why same-pod containers need shared volumes for shared files.
 
 ### Part 5: Create UTS and IPC Namespaces
@@ -889,6 +897,8 @@ Scenario D: A minimal image has no network tools, but you need to inspect its ro
 - [Linux pid_namespaces documentation, man7.org](https://man7.org/linux/man-pages/man7/pid_namespaces.7.html)
 - [Linux network_namespaces documentation, man7.org](https://man7.org/linux/man-pages/man7/network_namespaces.7.html)
 - [Linux mount_namespaces documentation, man7.org](https://man7.org/linux/man-pages/man7/mount_namespaces.7.html)
+- [util-linux unshare: namespace lifetime and explicit propagation](https://man7.org/linux/man-pages/man1/unshare.1.html)
+- [util-linux findmnt: mount-table queries and exit status](https://man7.org/linux/man-pages/man8/findmnt.8.html)
 - [Linux user_namespaces documentation, man7.org](https://man7.org/linux/man-pages/man7/user_namespaces.7.html)
 - [Linux ipc_namespaces documentation, man7.org](https://man7.org/linux/man-pages/man7/ipc_namespaces.7.html)
 - [Linux uts_namespaces documentation, man7.org](https://man7.org/linux/man-pages/man7/uts_namespaces.7.html)


### PR DESCRIPTION
The namespace module reused fixed temporary directories, hid parent mount-check failures, and left cleanup ambiguous. Replace the duplicate mount examples with one explicit root-Bash exercise that creates a fresh directory, mounts a bounded tmpfs in a private child namespace, checks the parent's view, and removes only its owned empty directory. A prediction prompt connects the directory, mount, and file observations.

Refs #2418 and #2279; epic #2272. Network-name ownership, other lab sections, and Ukrainian fidelity remain open. The evidence note records source review and the limits of the actual Linux tests.

Validation: exact published block executed in dedicated kind root bash (util-linux2.38.1); normal, mount failure, child TERM, parent TERM after child exit, cleanup refusal, and existing-path sentinel cases produced expected outcomes. All176 pipeline tests passed. Primary-root Astro build passed (2169 pages); rendered block, anchor, sources and old-command removal verified. Independent Fable source/design and separate Google prose review PASS; final prose review at 211d07c81cbc9987c5f05849116540e9261f28c7.

Two files,109 aggregate changed lines. No sudo-policy, concurrent terminal interruption, other-environment, or whole-module acceptance claim. CI and deployment/live verification pending.
