### PR TITLE
feat(quality): prove custom Astro pages from rendered HTML (#2346)

### DIFF
--- a/scripts/quality/custom-astro-page-proof.mjs
+++ b/scripts/quality/custom-astro-page-proof.mjs
@@ -1,0 +1,64 @@
+import { buildDocumentRouteSet } from './document-route-set.mjs';
+
+export class UnsupportedCustomAstroPage extends TypeError {}
+
+const fail = (message) => { throw new UnsupportedCustomAstroPage(message); };
+
+function attr(tag, name) {
+  const quoted = tag.match(new RegExp(`(?:^|\\s)${name}\\s*=\\s*("([^"]*)"|'([^']*)')`, 'i'));
+  return quoted ? (quoted[2] ?? quoted[3]) : null;
+}
+
+function canonicalHref(html) {
+  if (typeof html !== 'string' || !html) fail('rendered HTML must be non-empty text');
+  const hrefs = [];
+  for (const match of html.matchAll(/<link\b[^>]*>/gi)) {
+    const rel = attr(match[0], 'rel');
+    if (!rel || !rel.toLowerCase().split(/\s+/).includes('canonical')) continue;
+    const href = attr(match[0], 'href');
+    if (href == null) fail('canonical link is missing href');
+    hrefs.push(href);
+  }
+  if (hrefs.length !== 1) fail('rendered HTML must contain exactly one canonical link');
+  return hrefs[0];
+}
+
+function optionalSource(value) {
+  if (value == null) return null;
+  if (typeof value !== 'string' || !value) fail('page.source must be non-empty text or null');
+  if (/[\u0000-\u001f\u007f]/.test(value) || value.startsWith('/') || value.includes('\\') || value.split('/').some((part) => !part || part === '.' || part === '..')) {
+    fail('page.source must be a safe relative path');
+  }
+  if (!value.startsWith('src/pages/') || !value.endsWith('.astro')) fail('page.source must be a custom Astro page');
+  return value;
+}
+
+/** Prove custom Astro pages from same-build rendered HTML. Routes are never inferred from source filenames. */
+export function proveCustomAstroPages(manifest, pages) {
+  const routeSet = buildDocumentRouteSet(manifest);
+  if (!Array.isArray(pages)) fail('rendered pages must be an array');
+  const { origin } = routeSet;
+  const { base, trailingSlash } = routeSet.config;
+  const root = base.endsWith('/') ? base.slice(0, -1) : base;
+  const targetPaths = new Set();
+  const proven = [];
+  for (const page of pages) {
+    if (!page || typeof page !== 'object' || Array.isArray(page)) fail('rendered page must be an object');
+    const source = optionalSource(page.source);
+    const href = canonicalHref(page.html);
+    let url;
+    try { url = new URL(href); } catch { fail('canonical href must be a URL'); }
+    if (url.href !== href || url.origin !== origin || url.username || url.password || url.search || url.hash) {
+      fail('canonical href must be a same-origin serialized URL without credentials, query, or fragment');
+    }
+    const pathname = url.pathname;
+    if (trailingSlash === 'always' && !pathname.endsWith('/')) fail('canonical pathname must use trailingSlash always');
+    if (trailingSlash === 'never' && pathname !== '/' && pathname.endsWith('/')) fail('canonical pathname must use trailingSlash never');
+    if (base !== '/' && pathname !== root && !pathname.startsWith(`${root}/`)) fail('canonical pathname must lie under config.base');
+    if (routeSet.targetPaths.has(pathname)) fail(`custom page collides with document route: ${pathname}`);
+    if (targetPaths.has(pathname)) fail(`duplicate custom page pathname: ${pathname}`);
+    targetPaths.add(pathname);
+    proven.push({ url: href, pathname, source });
+  }
+  return { origin, config: routeSet.config, pages: proven, targetPaths };
+}

--- a/scripts/quality/custom-astro-page-proof.test.mjs
+++ b/scripts/quality/custom-astro-page-proof.test.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { proveCustomAstroPages } from './custom-astro-page-proof.mjs';
+
+const hash = (digit = 'a') => digit.repeat(64);
+const doc = (overrides = {}) => ({ id: 'guide/one', url: 'https://site.test/docs/guide/one/', pathname: '/docs/guide/one/', source: 'guide/one.md', sourceSha256: hash(), isFallback: false, locale: null, lang: null, ...overrides });
+const manifest = (routes = [doc()], overrides = {}) => ({ schemaVersion: 1, scope: 'starlight-document-routes', config: { site: 'https://site.test/contained/', base: '/docs/', trailingSlash: 'always', buildFormat: 'directory' }, routes, redirects: [], ...overrides });
+const html = (canonical, extra = '') => `<!doctype html><html><head><link rel="canonical" href="${canonical}" />${extra}</head></html>`;
+const rejects = (fn, pattern) => assert.throws(fn, { name: 'TypeError', message: pattern });
+
+test('proves EN and UK custom pages from rendered canonicals, not document fallbacks', () => {
+  const fallback = doc({ id: 'uk/guide/one', url: 'https://site.test/docs/uk/guide/one/', pathname: '/docs/uk/guide/one/', isFallback: true, locale: 'uk', lang: 'uk' });
+  const result = proveCustomAstroPages(manifest([doc(), fallback]), [
+    { html: html('https://site.test/docs/', '<link rel="shortcut icon" href="/favicon.svg" />'), source: 'src/pages/index.astro' },
+    { html: html('https://site.test/docs/uk/'), source: 'src/pages/uk/index.astro' },
+  ]);
+  assert.deepEqual([...result.targetPaths], ['/docs/', '/docs/uk/']);
+  assert.equal(result.pages[0].source, 'src/pages/index.astro');
+  assert.equal(result.pages[1].pathname, '/docs/uk/');
+  assert.equal(result.targetPaths.has('/docs/guide/one/'), false);
+  assert.equal(result.targetPaths.has('/docs/uk/guide/one/'), false);
+});
+
+test('derives the route from the canonical and ignores claimed pathnames or filenames', () => {
+  const sneaky = proveCustomAstroPages(manifest(), [{ html: html('https://site.test/docs/uk/'), pathname: '/docs/', source: 'src/pages/index.astro' }]);
+  assert.deepEqual([...sneaky.targetPaths], ['/docs/uk/']);
+  rejects(() => proveCustomAstroPages(manifest(), [{ source: 'src/pages/index.astro' }]), /rendered HTML must be non-empty/);
+  rejects(() => proveCustomAstroPages(manifest(), [{ source: 'src/pages/index.astro', html: '<html></html>' }]), /exactly one canonical/);
+  rejects(() => proveCustomAstroPages(manifest(), [{ html: html('https://site.test/docs/'), source: 'src/content/docs/index.md' }]), /custom Astro page/);
+});
+
+test('accepts root-base EN/UK homepages and href-first canonical tags', () => {
+  const root = manifest([doc({ url: 'https://site.test/guide/one/', pathname: '/guide/one/' })], { config: { site: 'https://site.test/', base: '/', trailingSlash: 'always', buildFormat: 'directory' } });
+  const result = proveCustomAstroPages(root, [
+    { html: '<link href="https://site.test/" rel="canonical">' },
+    { html: html('https://site.test/uk/') },
+  ]);
+  assert.deepEqual([...result.targetPaths], ['/', '/uk/']);
+});
+
+test('rejects missing, multiple, colliding, or non-serialized canonicals', () => {
+  rejects(() => proveCustomAstroPages(manifest(), [{ html: html('https://other.test/docs/') }]), /same-origin/);
+  rejects(() => proveCustomAstroPages(manifest(), [{ html: `${html('https://site.test/docs/')}${html('https://site.test/docs/uk/')}` }]), /exactly one canonical/);
+  rejects(() => proveCustomAstroPages(manifest(), [{ html: html('https://site.test/docs/?q=1') }]), /query/);
+  rejects(() => proveCustomAstroPages(manifest(), [{ html: '<link href="https://site.test/docs/" rel="canonical"><link rel="canonical">' }]), /missing href/);
+  rejects(() => proveCustomAstroPages(manifest(), [{ html: html('https://site.test/docs/guide/one/') }]), /collides with document/);
+  rejects(() => proveCustomAstroPages(manifest(), [{ html: html('https://site.test/docs/') }, { html: html('https://site.test/docs/') }]), /duplicate custom/);
+  rejects(() => proveCustomAstroPages(manifest(), [{ html: html('https://site.test/docs/\u2713/') }]), /serialized URL/);
+});
+
+test('rejects unsupported config, pages outside base, and treats redirects as non-targets', () => {
+  rejects(() => proveCustomAstroPages(manifest([doc()], { schemaVersion: 2 }), [{ html: html('https://site.test/docs/') }]), /schema or scope/);
+  rejects(() => proveCustomAstroPages(manifest(), [{ html: html('https://site.test/') }]), /lie under config.base/);
+  rejects(() => proveCustomAstroPages(manifest(), [{ html: html('https://site.test/docs/uk') }]), /trailingSlash always/);
+  rejects(() => proveCustomAstroPages(manifest(), [{ html: html('https://site.test/docs/'), source: '../pages/index.astro' }]), /safe relative/);
+  const redirected = proveCustomAstroPages(manifest([doc()], { redirects: [{ source: '/docs/old/', target: '/docs/guide/one/', status: 301 }] }), [{ html: html('https://site.test/docs/') }]);
+  assert.equal(redirected.targetPaths.has('/docs/old/'), false);
+  assert.equal(redirected.targetPaths.has('/docs/'), true);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Starlight document manifest does not include custom Astro pages. Links to `/` and `/uk/` would otherwise look missing once the route gate consumes that manifest.

This packet proves those pages from same-build rendered HTML: the route is the page's single canonical URL. Source filenames, claimed pathnames, and redirect records cannot invent a target. Ukrainian homepage HTML is a first-class custom page, not an English fallback.

Refs #2346. This is not Markdown link consumption, redirect-chain resolution, CI wiring, or replacement of the legacy gates. #2346 stays open.

## Scope

- `scripts/quality/custom-astro-page-proof.mjs`
- `scripts/quality/custom-astro-page-proof.test.mjs`

Two files, 123 added lines. No published content or Astro config changes.

## Acceptance

- EN and UK homepages are proven from rendered canonical tags
- `src/pages/index.astro` without HTML does not invent `/`
- A claimed pathname cannot override the canonical
- Document fallbacks and redirect sources stay out of the custom target set
- Colliding document routes, missing/multiple canonicals, query/fragment, and cross-origin hrefs fail closed

## Validation

- `node --test scripts/quality/custom-astro-page-proof.test.mjs` — 5/5 passed
- Existing document-route-set, document-source-validation, and route-resolver Node tests passed
- `.venv/bin/python scripts/test_pipeline.py` — 176 tests, 0 failures (4.728s)
- `git diff --check` clean
- No Python or `src/content/docs/` changes, so Ruff and Astro build were not required
- Primary remains on `main`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7371b35-559f-4dad-90bc-2140a5243b22?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7371b35-559f-4dad-90bc-2140a5243b22&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

