### PR TITLE
docs(platform): refresh OTel Collector landscape to v0.160.0 (#2469)

### DIFF
--- a/src/content/docs/platform/toolkits/observability-intelligence/observability/module-1.12-otel-collector-production.md
+++ b/src/content/docs/platform/toolkits/observability-intelligence/observability/module-1.12-otel-collector-production.md
@@ -37,11 +37,11 @@ The module is intentionally not a runnable operator lab. You will see realistic 
 
 This is also why the module keeps cost visible from the beginning. Observability platforms often fail socially before they fail technically: the platform team adds more detail because incidents are painful, finance pushes back because the bill grows, security asks for redaction after data has already spread, and application teams bypass shared policy because the default path feels too restrictive. A production Collector design gives those groups a common control surface. Sampling, routing, batching, and attribute policy become explicit platform decisions instead of scattered application defaults.
 
-> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+> **Landscape snapshot — as of 2026-09. This changes fast; verify against vendor docs before relying on specifics.**
 >
 > OpenTelemetry is a CNCF Graduated project. CNCF announced graduation on May 21, 2026 and described OTel as having the second-highest project velocity in CNCF after Kubernetes. That maturity applies to the project as a whole; the Collector still requires per-component review when you build a production distribution.
 >
-> The Collector is versioned separately from the specification and from many language SDKs. As of this snapshot, the core Collector release is v1.60.0/v0.154.0, published on June 8, 2026, and the contrib distribution is v0.154.0, published on June 9, 2026. The paired versioning is intentional: stable core modules can be in the v1.x line while the broader collector distribution and contrib components remain in the v0.1xx line.
+> The Collector is versioned separately from the specification and from many language SDKs. As of this snapshot, the core Collector release is v1.66.0/v0.160.0, published on September 2, 2026, and the contrib distribution is v0.160.0, published on September 2, 2026. The paired versioning is intentional: stable core modules can be in the v1.x line while the broader collector distribution and contrib components remain in the v0.1xx line.
 >
 > Component stability is mixed. The OpenTelemetry status page says core collector components have mixed stability levels, and each receiver, processor, exporter, connector, and extension documents its own alpha, beta, stable, deprecated, or unmaintained status in its README. Production reviews should therefore check the exact components you enable, not just the Collector binary version.
 
@@ -551,8 +551,8 @@ Continue to the [GitOps & Deployments toolkit](../../cicd-delivery/gitops-deploy
 - [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) - General Collector role and architecture.
 - [CNCF OpenTelemetry graduation announcement](https://www.cncf.io/announcements/2026/05/21/cloud-native-computing-foundation-announces-opentelemetrys-graduation-solidifying-status-as-the-de-facto-observability-standard/) - CNCF maturity and project activity snapshot.
 - [OpenTelemetry project status](https://opentelemetry.io/status/) - Collector mixed stability status and per-component stability guidance.
-- [OpenTelemetry Collector v1.60.0/v0.154.0 release](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.154.0) - Current core Collector release at this snapshot.
-- [OpenTelemetry Collector Contrib v0.154.0 release](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.154.0) - Current contrib distribution release at this snapshot.
+- [OpenTelemetry Collector v1.66.0/v0.160.0 release](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.160.0) - Current core Collector release at this snapshot.
+- [OpenTelemetry Collector Contrib v0.160.0 release](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.160.0) - Current contrib distribution release at this snapshot.
 - [OpenTelemetry Collector configuration](https://opentelemetry.io/docs/collector/configuration/) - Receivers, processors, exporters, connectors, and service pipelines.
 - [OpenTelemetry Collector agent deployment pattern](https://opentelemetry.io/docs/collector/deploy/agent/) - Agent collectors alongside applications or hosts.
 - [OpenTelemetry Collector gateway deployment pattern](https://opentelemetry.io/docs/collector/deploy/gateway/) - Gateway collectors, load balancing, and tail-sampling topology guidance.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Parent: #2294 (X03). Closes #2469.

## What

Currency-only refresh of `src/content/docs/platform/toolkits/observability-intelligence/observability/module-1.12-otel-collector-production.md`.

The June 2026 Landscape snapshot still named core **v1.60.0/v0.154.0** and contrib **v0.154.0** as current. Verified against GitHub releases on 2026-09-09:

| Distro | Previous pin | Current release | Published |
|---|---|---|---|
| Core (`opentelemetry-collector`) | v1.60.0/v0.154.0 (2026-06-08) | **v1.66.0/v0.160.0** | 2026-09-02 |
| Contrib (`opentelemetry-collector-contrib`) | v0.154.0 (2026-06-09) | **v0.160.0** | 2026-09-02 |
| Collector releases | — | **v0.160.0** | 2026-09-02 |

Sources:

- https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.160.0 (`v1.66.0/v0.160.0`)
- https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.160.0
- https://github.com/open-telemetry/opentelemetry-collector-releases/releases/tag/v0.160.0

## Changes

- Landscape snapshot date: `2026-06` → `2026-09`
- Core/contrib version claims + publish dates
- Sources “current release” links/labels for core and contrib
- Paired versioning note kept (still accurate: stable core `v1.x` / distribution `v0.1xx`)

## Out of scope

- No pedagogy, labs, or processor rewrite
- No Harbor/Cilium modules (#2467)
- No UK twin (path does not exist)

## Diff

1 file, 4 lines changed. Currency only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3efa6c7e-461a-4f0f-81a6-a881f5e6c550?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3efa6c7e-461a-4f0f-81a6-a881f5e6c550&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

