### PR TITLE
feat(cka): verify private certificate backups (#2478)

### DIFF
--- a/scripts/cka_certificate_state.sh
+++ b/scripts/cka_certificate_state.sh
@@ -84,15 +84,36 @@ cka_cert_state_close() {
 }
 
 cka_cert_state_read() {
+  local state revision
   [[ $# == 1 ]] || return 1
   cka_cert_state_directory /var/lib/cka-certificate-transaction || return 1
   cka_cert_state_file /var/lib/cka-certificate-transaction/state.json || return 1
-  jq -ces --argjson expected "$1" '
+  state=$(jq -ces --argjson expected "$1" '
+    def hash: type=="string" and test("^[a-f0-9]{64}$");
+    def files: type=="object" and keys==["apiserver.crt","apiserver.key","kube-apiserver.yaml"];
     if length==1 then .[0] else error("Expected one state") end |
-    select(type=="object" and keys==["identity","recovery","revision","schema"]) |
-    select(.schema==1 and .revision==0 and .identity==$expected) |
-    select(.recovery=={direction:"forward",stage:"created"})
-  ' /var/lib/cka-certificate-transaction/state.json
+    select(type=="object" and .schema==1 and .identity==$expected) |
+    select(if .revision==0 then
+      keys==["identity","recovery","revision","schema"] and
+      .recovery=={direction:"forward",stage:"created"}
+    else
+      keys==["baseline","identity","recovery","revision","schema"] and
+      ((.revision==1 and .recovery=={direction:"forward",stage:"backup_requested"}) or
+       (.revision==2 and .recovery=={direction:"forward",stage:"backup_verified"})) and
+      (.baseline | type=="object" and keys==["fingerprint","hashes","metadata","public_key"] and
+        (.fingerprint | hash) and (.public_key | hash) and
+        (.hashes | files and all(.[]; hash)) and
+        (.metadata | files and all(.[];
+          type=="object" and keys==["gid","mode","uid"] and .uid==0 and
+          (.gid | type=="number" and .>=0 and floor==.) and
+          (.mode=="600" or .mode=="644")) and .["apiserver.key"].mode=="600"))
+    end)
+  ' /var/lib/cka-certificate-transaction/state.json) || return 1
+  revision=$(jq -r .revision <<< "$state") || return 1
+  if [[ $revision == 2 ]]; then
+    cka_cert_state_backup_verify "$state" || return 1
+  fi
+  printf '%s\n' "$state"
 }
 
 cka_cert_state_init() {
@@ -137,4 +158,99 @@ cka_cert_state_status() {
   cka_cert_state_artifacts "$expected" || return 1
   state=$(cka_cert_state_read "$expected") || return 1
   jq -ce '{schema,identity,revision,recovery}' <<< "$state"
+}
+
+# Key bytes travel only between file descriptors; hashes remain private state.
+cka_cert_state_backup_evidence() {
+  local path mode name file digest metadata fingerprint public_key result='{"hashes":{},"metadata":{}}'
+  [[ $# == 1 && ( $1 == live || $1 == backup ) ]] || return 1
+  declare -F cka_cert_obs_fingerprint cka_cert_obs_pair >/dev/null || return 1
+  if [[ $1 == live ]]; then
+    for path in /etc /etc/kubernetes /etc/kubernetes/pki /etc/kubernetes/manifests; do
+      [[ -d $path && ! -L $path && $(stat -c %u -- "$path") == 0 ]] || return 1
+      mode=$(stat -c %a -- "$path") || return 1
+      (( (8#$mode & 0022) == 0 )) || return 1
+    done
+  else
+    cka_cert_state_directory /var/lib/cka-certificate-transaction || return 1
+  fi
+  for name in apiserver.crt apiserver.key kube-apiserver.yaml; do
+    file="/var/lib/cka-certificate-transaction/$name"
+    if [[ $1 == live ]]; then
+      file="/etc/kubernetes/pki/$name"
+      [[ $name != kube-apiserver.yaml ]] || file=/etc/kubernetes/manifests/kube-apiserver.yaml
+      [[ -f $file && ! -L $file && $(stat -c '%u:%h' -- "$file") == 0:1 ]] || return 1
+      mode=$(stat -c %a -- "$file") || return 1
+      [[ $mode == 600 || ( $mode == 644 && $name != apiserver.key ) ]] || return 1
+    else
+      cka_cert_state_file "$file" || return 1
+    fi
+    digest=$(sha256sum -- "$file") || return 1
+    metadata=$(stat -c '{"uid":%u,"gid":%g,"mode":"%a"}' -- "$file") || return 1
+    result=$(jq -c --arg name "$name" --arg digest "${digest%% *}" --argjson metadata "$metadata" \
+      '.hashes[$name]=$digest | .metadata[$name]=$metadata' <<< "$result") || return 1
+  done
+  path=/var/lib/cka-certificate-transaction
+  [[ $1 != live ]] || path=/etc/kubernetes/pki
+  fingerprint=$(cka_cert_obs_fingerprint "$path/apiserver.crt") || return 1
+  fingerprint=${fingerprint#*=}
+  fingerprint=${fingerprint//:/}
+  public_key=$(cka_cert_obs_pair "$path/apiserver.crt" "$path/apiserver.key") || return 1
+  public_key=${public_key##* }
+  [[ ${fingerprint,,} =~ ^[a-f0-9]{64}$ && $public_key =~ ^[a-f0-9]{64}$ ]] || return 1
+  jq -c --arg fingerprint "${fingerprint,,}" --arg public_key "$public_key" \
+    '. + {fingerprint:$fingerprint,public_key:$public_key}' <<< "$result"
+}
+
+cka_cert_state_backup_verify() {
+  local evidence
+  [[ $# == 1 ]] || return 1
+  evidence=$(cka_cert_state_backup_evidence backup) || return 1
+  jq -e --argjson evidence "$evidence" \
+    '(.baseline | del(.metadata))==($evidence | del(.metadata))' <<< "$1" >/dev/null
+}
+
+# No retry/adoption API: a partial copy remains backup_requested for reconciliation.
+cka_cert_state_backup() {
+  local expected state baseline current stage revision temporary name source target
+  [[ $# == 1 ]] || return 1
+  cka_cert_state_environment && cka_cert_state_locked || return 1
+  expected=$(cka_cert_state_expected "$1") || return 1
+  cka_cert_state_artifacts "$expected" || return 1
+  state=$(cka_cert_state_read "$expected") || return 1
+  [[ $(jq -r .revision <<< "$state") == 0 ]] || return 1
+  baseline=$(cka_cert_state_backup_evidence live) || return 1
+  for name in apiserver.crt apiserver.key kube-apiserver.yaml; do
+    target="/var/lib/cka-certificate-transaction/$name"
+    [[ ! -e $target && ! -L $target ]] || return 1
+  done
+  revision=0
+  for stage in backup_requested backup_verified; do
+    cka_cert_state_environment && cka_cert_state_locked || return 1
+    cka_cert_state_artifacts "$expected" || return 1
+    current=$(cka_cert_state_read "$expected") || return 1
+    [[ $current == "$state" ]] || return 1
+    revision=$((revision + 1))
+    state=$(jq -c --argjson baseline "$baseline" --arg stage "$stage" --argjson revision "$revision" \
+      '.baseline=$baseline | .revision=$revision | .recovery.stage=$stage' <<< "$state") || return 1
+    temporary=$(mktemp /var/lib/cka-certificate-transaction/state.XXXXXXXX) || return 1
+    cka_cert_state_file "$temporary" || return 1
+    printf '%s\n' "$state" > "$temporary" || return 1
+    sync -f "$temporary" || return 1
+    mv -T -- "$temporary" /var/lib/cka-certificate-transaction/state.json || return 1
+    sync -f /var/lib/cka-certificate-transaction || return 1
+    [[ $stage != backup_verified ]] || return 0
+    for name in apiserver.crt apiserver.key kube-apiserver.yaml; do
+      source="/etc/kubernetes/pki/$name"
+      [[ $name != kube-apiserver.yaml ]] || source=/etc/kubernetes/manifests/kube-apiserver.yaml
+      target="/var/lib/cka-certificate-transaction/$name"
+      (umask 077; set -o noclobber; cat -- "$source" > "$target") || return 1
+      cka_cert_state_file "$target" && cmp -s -- "$source" "$target" || return 1
+      sync -f "$target" || return 1
+    done
+    sync -f /var/lib/cka-certificate-transaction || return 1
+    current=$(cka_cert_state_backup_evidence live) || return 1
+    [[ $current == "$baseline" ]] || return 1
+    cka_cert_state_backup_verify "$state" || return 1
+  done
 }

--- a/scripts/tests/test_cka_certificate_state.py
+++ b/scripts/tests/test_cka_certificate_state.py
@@ -7,6 +7,46 @@ from pathlib import Path
 
 
 class TestCertificateStateSource(unittest.TestCase):
+    def test_backup_state_schema_with_injected_filesystem(self):
+        library = Path(__file__).resolve().parents[1] / "cka_certificate_state.sh"
+        names = ("apiserver.crt", "apiserver.key", "kube-apiserver.yaml")
+        baseline = {"fingerprint": "a" * 64, "public_key": "b" * 64,
+                    "hashes": dict.fromkeys(names, "c" * 64),
+                    "metadata": {name: {"uid": 0, "gid": 0, "mode": "600"} for name in names}}
+        valid = [{"schema": 1, "identity": {}, "revision": revision,
+                  "recovery": {"direction": "forward", "stage": stage}, "baseline": baseline}
+                 for revision, stage in ((1, "backup_requested"), (2, "backup_verified"))]
+        invalid = [dict(valid[0], revision=2), dict(valid[1], revision=1),
+                   dict(valid[0], schema=2), dict(valid[0], extra=True), dict(valid[0], baseline={})]
+        for field, bad in (("fingerprint", "invalid"), ("public_key", None), ("hashes", {})):
+            invalid.append(dict(valid[0], baseline=dict(baseline, **{field: bad})))
+        for field, bad in (("uid", 1), ("gid", -1), ("gid", 0.5), ("mode", "644")):
+            broken = json.loads(json.dumps(valid[0]))
+            broken["baseline"]["metadata"]["apiserver.key"][field] = bad
+            invalid.append(broken)
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory) / "state.json"
+            cases = [(v, "accepted", "") for v in valid] + [(v, "refused", "") for v in invalid]
+            cases.append((valid[1], "refused", "fail-revision"))
+            for value, expected, fault in cases:
+                with self.subTest(value=value):
+                    fixture.write_text(json.dumps(value))
+                    result = subprocess.run(["bash", "-c", r'''
+source "$1"; fixture=$2; fault=$3
+cka_cert_state_directory() { return 0; }
+cka_cert_state_file() { return 0; }
+cka_cert_state_backup_verify() { return 0; }
+jq() {
+  [[ $1 != -r || $2 != .revision || $fault != fail-revision ]] || return 1
+  if [[ ${!#} == /var/lib/cka-certificate-transaction/state.json ]]; then
+    command jq "${@:1:$#-1}" "$fixture"
+  else command jq "$@"; fi
+}
+if cka_cert_state_read '{}' >/dev/null; then printf accepted; else printf refused; fi
+''', "--", str(library), str(fixture), fault], capture_output=True, text=True, check=False)
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertEqual(result.stdout, expected)
+
     def test_explicit_identity_schema_under_conditional_caller(self):
         library = Path(__file__).resolve().parents[1] / "cka_certificate_state.sh"
         identity = {"transaction_id": "a" * 32, "fixture_cluster": "cert-fixture-" + "b" * 32,


### PR DESCRIPTION
Progresses #2478 by preserving and verifying node-private originals before a later renewal transaction. The state helper now persists `backup_requested` before copying the API-server certificate, key and manifest, and promotes to `backup_verified` only after byte comparisons, file synchronization and cryptographic checks. Reopen verifies retained bytes against the recorded baseline without depending on live originals. Public status excludes private baseline metadata.

Partial copies remain incomplete and cannot be silently retried or promoted. Revision-extraction failure explicitly refuses the operation. There is no renewal, restoration or manifest-movement entry point.

Validation:
- Four separate fresh Kubernetes v1.35.0 fixtures: positive backup/reopen, injected copy failure, injected backup-file sync failure and injected request-state sync failure passed. The latter prevented copying; partial-copy cases retained `backup_requested`.
- Injected retained-byte changes, unsafe permissions, hardlink and symlink cases were refused. Source key bytes stayed inside the node.
- Each run preserved the public API-server certificate/four manifest fingerprints, passed authenticated inspection and removed its fixture with the baseline preserved. Teardown is not rollback evidence.
- Source-inertness, 18 explicit identity cases and 15 schema/failure cases passed. Schema tests explicitly mock filesystem/integrity checks and are separate from actual fixture evidence.
- Bash syntax, Ruff, whitespace and all 176 pipeline tests passed. Independent pre-execution and correction reviews passed; exact-head final review follows as a comment.

Two files; 161 added and 5 deleted lines (166 aggregate). No generated artifacts. Local Astro build is not applicable to this scripts-only change. Surviving-child coordination, complete renewal/rollback and host activation remain future gates.
