### PR TITLE
feat(cka): add private certificate process records (#2478)

### DIFF
--- a/scripts/cka_certificate_process.sh
+++ b/scripts/cka_certificate_process.sh
@@ -1,0 +1,138 @@
+# Internal Linux Bash process identity and private record custody primitives.
+# Sourcing defines functions only. No launch, signalling or recovery admission.
+# Callers explicitly source the state and observation helpers.
+
+# Parse after the LAST closing comm delimiter; spaces/parentheses in comm are valid.
+# A vanished or malformed /proc entry is uncertainty, not proof of absence.
+cka_cert_process_stat() {
+  local line tail
+  local -a fields
+  [[ $# == 1 && $1 =~ ^[1-9][0-9]*$ ]] || return 1
+  IFS= read -r line < "/proc/$1/stat" || return 1
+  [[ $line == "$1 ("* && $line == *") "* ]] || return 1
+  tail=${line##*) }
+  read -r -a fields <<< "$tail" || return 1
+  [[ ${#fields[@]} -ge 50 && ${fields[0]} =~ ^[RSDZTtXxKWPI]$ &&
+     ${fields[1]} =~ ^[0-9]+$ && ${fields[2]} =~ ^[0-9]+$ &&
+     ${fields[3]} =~ ^[0-9]+$ && ${fields[19]} =~ ^[0-9]+$ ]] || return 1
+  CKA_CERT_PROC_STATE=${fields[0]}
+  CKA_CERT_PROC_PPID=${fields[1]}
+  CKA_CERT_PROC_PGID=${fields[2]}
+  CKA_CERT_PROC_SID=${fields[3]}
+  CKA_CERT_PROC_START=${fields[19]}
+}
+
+# Builtins only while enumerating: do not manufacture transient scanner children.
+# Zombies have released descriptors; any live reused SID conservatively blocks.
+cka_cert_process_snapshot() {
+  local path pid
+  [[ $# == 2 && $1 =~ ^[1-9][0-9]*$ && $2 =~ ^[0-9]+$ ]] || return 1
+  CKA_CERT_PROCESS_OTHERS=0
+  for path in /proc/[0-9]*/stat; do
+    pid=${path#/proc/}
+    pid=${pid%/stat}
+    cka_cert_process_stat "$pid" || return 1
+    [[ $CKA_CERT_PROC_SID == "$1" ]] || continue
+    [[ $CKA_CERT_PROC_STATE != Z && $CKA_CERT_PROC_STATE != X && $CKA_CERT_PROC_STATE != x ]] || continue
+    [[ $CKA_CERT_PROC_PGID == "$1" ]] || return 1
+    [[ $pid == "$2" ]] || CKA_CERT_PROCESS_OTHERS=$((CKA_CERT_PROCESS_OTHERS + 1))
+  done
+}
+
+cka_cert_process_check() {
+  local expected state
+  [[ $# == 2 && $2 =~ ^[a-f0-9]{32}$ ]] || return 1
+  declare -F cka_cert_state_expected cka_cert_state_read cka_cert_state_artifacts \
+    cka_cert_state_environment cka_cert_state_locked cka_cert_state_file >/dev/null || return 1
+  cka_cert_state_environment || return 1
+  expected=$(cka_cert_state_expected "$1") || return 1
+  cka_cert_state_artifacts "$expected" || return 1
+  state=$(cka_cert_state_read "$expected") || return 1
+  jq -e '.revision==2 and .recovery=={direction:"forward",stage:"backup_verified"}' \
+    <<< "$state" >/dev/null || return 1
+}
+
+# Validate both record kinds before either reading or creating a temporary file.
+cka_cert_process_payload() {
+  local expected
+  [[ $# == 4 && $2 =~ ^[a-f0-9]{32}$ && ( $3 == process || $3 == cancel ) ]] || return 1
+  expected=$(cka_cert_state_expected "$1") || return 1
+  jq -ces --argjson identity "$expected" --arg operation "$2" --arg kind "$3" '
+    def integer: type=="number" and floor==.;
+    def pid: integer and .>0;
+    def ticks: type=="string" and test("^[0-9]+$");
+    if length==1 then .[0] else error("Expected one record") end |
+    if $kind=="cancel" then
+      select(.=={schema:1,identity:$identity,operation_id:$operation,request:"cancel"})
+    else
+      select(type=="object" and
+        keys==["child_exit","coordinator","identity","operation_id","schema","stage","supervisor","timeout_seconds"]) |
+      select(.schema==1 and .identity==$identity and .operation_id==$operation) |
+      select(.timeout_seconds | integer and .>=1 and .<=3600) |
+      select(.coordinator | type=="object" and keys==["pid","start_time"] and
+        (.pid | pid) and (.start_time | ticks)) |
+      select(if .stage=="launch_requested" then .supervisor==null and .child_exit==null else
+        (.supervisor | type=="object" and keys==["pgid","pid","sid","start_time"] and
+          (.pid | pid) and .pid==.pgid and .pid==.sid and (.start_time | ticks)) and
+        (if .stage=="supervision_complete" then (.child_exit | integer and .>=0 and .<=255) else
+          (.stage=="running" or .stage=="term_requested" or .stage=="kill_requested") and .child_exit==null end)
+      end)
+    end
+  ' <<< "$4"
+}
+
+cka_cert_process_read() {
+  local payload
+  [[ $# == 2 ]] || return 1
+  cka_cert_state_environment || return 1
+  cka_cert_state_directory /var/lib/cka-certificate-transaction || return 1
+  cka_cert_state_file /var/lib/cka-certificate-transaction/process.json || return 1
+  payload=$(cat /var/lib/cka-certificate-transaction/process.json) || return 1
+  cka_cert_process_payload "$1" "$2" process "$payload"
+}
+
+# Callers own sequencing. Process writes require FD9; cancel writes need no lock.
+# Existing records must be private, valid and bound to this same operation.
+cka_cert_process_write() {
+  local temporary target payload existing
+  [[ $# == 4 && ( $3 == process || $3 == cancel ) ]] || return 1
+  cka_cert_process_check "$1" "$2" || return 1
+  [[ $3 != process ]] || cka_cert_state_locked || return 1
+  payload=$(cka_cert_process_payload "$1" "$2" "$3" "$4") || return 1
+  target="/var/lib/cka-certificate-transaction/$3.json"
+  if [[ -e $target || -L $target ]]; then
+    cka_cert_state_file "$target" || return 1
+    existing=$(cat -- "$target") || return 1
+    cka_cert_process_payload "$1" "$2" "$3" "$existing" >/dev/null || return 1
+  fi
+  temporary=$(mktemp /var/lib/cka-certificate-transaction/process-write.XXXXXXXX) || return 1
+  cka_cert_state_file "$temporary" || return 1
+  printf '%s\n' "$payload" > "$temporary" || return 1
+  sync -f "$temporary" || return 1
+  mv -T -- "$temporary" "$target" || return 1
+  sync -f /var/lib/cka-certificate-transaction || return 1
+}
+
+cka_cert_process_cancel_read() {
+  local payload
+  [[ $# == 2 && $2 =~ ^[a-f0-9]{32}$ ]] || return 1
+  cka_cert_state_expected "$1" >/dev/null || return 1
+  cka_cert_state_environment || return 1
+  cka_cert_state_directory /var/lib/cka-certificate-transaction || return 1
+  CKA_CERT_PROCESS_CANCEL=0
+  if [[ ! -e /var/lib/cka-certificate-transaction/cancel.json &&
+        ! -L /var/lib/cka-certificate-transaction/cancel.json ]]; then
+    return 0
+  fi
+  cka_cert_state_file /var/lib/cka-certificate-transaction/cancel.json || return 1
+  payload=$(cat /var/lib/cka-certificate-transaction/cancel.json) || return 1
+  cka_cert_process_payload "$1" "$2" cancel "$payload" >/dev/null || return 1
+  CKA_CERT_PROCESS_CANCEL=1
+}
+
+cka_cert_process_self() {
+  [[ $# == 2 && $BASHPID == "$1" ]] || return 1
+  cka_cert_process_stat "$1" || return 1
+  [[ $CKA_CERT_PROC_PGID == "$1" && $CKA_CERT_PROC_SID == "$1" &&
+     $CKA_CERT_PROC_START == "$2" ]]
+}

--- a/scripts/cka_certificate_state.sh
+++ b/scripts/cka_certificate_state.sh
@@ -36,7 +36,7 @@ cka_cert_state_expected() {
     select(.image_id | type=="string" and test("^sha256:[a-f0-9]{64}$")) |
     select(.system_namespace_uid | type=="string" and
       test("^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$")) |
-    select(.artifact_hashes | type=="object" and keys==["observe.sh","state.sh"] and
+    select(.artifact_hashes | type=="object" and keys==["observe.sh","process.sh","state.sh"] and
       all(.[]; hex))
   ' <<< "$1"
 }
@@ -45,7 +45,7 @@ cka_cert_state_artifacts() {
   local name actual expected
   [[ $# == 1 ]] || return 1
   cka_cert_state_directory /var/lib/cka-certificate-artifacts || return 1
-  for name in state.sh observe.sh; do
+  for name in state.sh observe.sh process.sh; do
     cka_cert_state_file "/var/lib/cka-certificate-artifacts/$name" || return 1
     actual=$(sha256sum -- "/var/lib/cka-certificate-artifacts/$name") || return 1
     expected=$(jq -er --arg name "$name" '.artifact_hashes[$name]' <<< "$1") || return 1

--- a/scripts/tests/test_cka_certificate_state.py
+++ b/scripts/tests/test_cka_certificate_state.py
@@ -7,6 +7,41 @@ from pathlib import Path
 
 
 class TestCertificateStateSource(unittest.TestCase):
+    def test_process_payload_rejects_malformed_and_foreign_records(self):
+        library = Path(__file__).resolve().parents[1] / "cka_certificate_process.sh"
+        operation = "a" * 32
+        coordinator = {"pid": 20, "start_time": "123"}
+        supervisor = {"pid": 21, "pgid": 21, "sid": 21, "start_time": "124"}
+        launch = {"schema": 1, "identity": {}, "operation_id": operation,
+                  "coordinator": coordinator, "supervisor": None, "child_exit": None,
+                  "stage": "launch_requested", "timeout_seconds": 60}
+        running = dict(launch, supervisor=supervisor, stage="running")
+        done = dict(running, stage="supervision_complete", child_exit=0)
+        cancel = {"schema": 1, "identity": {}, "operation_id": operation, "request": "cancel"}
+        cases = [(v, "process", True) for v in [launch, running, done]]
+        cases += [(cancel, "cancel", True), (dict(cancel, extra=True), "cancel", False)]
+        invalid = [dict(launch, supervisor=supervisor), dict(running, supervisor=None),
+                   dict(running, child_exit=0), dict(done, child_exit=None),
+                   dict(done, child_exit=256), dict(done, child_exit=0.5),
+                   dict(running, supervisor=dict(supervisor, pgid=22)),
+                   dict(running, coordinator=dict(coordinator, start_time=123)),
+                   dict(running, operation_id="b" * 32), dict(running, identity={"foreign": 1}),
+                   dict(running, timeout_seconds=0), dict(running, timeout_seconds=3601),
+                   dict(running, stage="invented"), dict(running, extra=True), [], None]
+        cases += [(v, "process", False) for v in invalid]
+        for value, kind, accepted in cases:
+            with self.subTest(value=value, kind=kind):
+                result = subprocess.run(["bash", "-c", r'''
+source "$1"
+cka_cert_state_expected() { printf '{}'; }
+if cka_cert_process_payload '{}' "$2" "$3" "$4" >/dev/null; then
+  printf accepted
+else printf refused; fi
+''', "--", str(library), operation, kind, json.dumps(value)],
+                    capture_output=True, text=True, check=False)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout, "accepted" if accepted else "refused")
+
     def test_backup_state_schema_with_injected_filesystem(self):
         library = Path(__file__).resolve().parents[1] / "cka_certificate_state.sh"
         names = ("apiserver.crt", "apiserver.key", "kube-apiserver.yaml")
@@ -52,7 +87,7 @@ if cka_cert_state_read '{}' >/dev/null; then printf accepted; else printf refuse
         identity = {"transaction_id": "a" * 32, "fixture_cluster": "cert-fixture-" + "b" * 32,
                     "docker_container_id": "c" * 64, "image_id": "sha256:" + "d" * 64,
                     "system_namespace_uid": "12345678-1234-1234-1234-123456789abc",
-                    "artifact_hashes": {"state.sh": "e" * 64, "observe.sh": "f" * 64}}
+                    "artifact_hashes": {"state.sh": "e" * 64, "observe.sh": "f" * 64, "process.sh": "a" * 64}}
         invalid = [{}, [], None, dict(identity, extra=True)]
         invalid += [{k: v for k, v in identity.items() if k != key} for key in identity]
         invalid += [dict(identity, **{key: None}) for key in identity]
@@ -76,11 +111,13 @@ umask 027
 exec 9> sentinel
 before=$(set +o); mask=$(umask); location=$PWD
 source "$1" || exit 1
+source "$2" || exit 1
 [[ "$before" == "$(set +o)" && "$mask" == "$(umask)" && "$location" == "$PWD" ]] || exit 2
 printf preserved >&9 || exit 3
 [[ $(cat sentinel) == preserved ]] || exit 4
 [[ $(find . -type f | wc -l) -eq 1 ]] || exit 5
-''', "--", str(library)], cwd=directory, capture_output=True, text=True, check=False)
+''', "--", str(library), str(library.with_name("cka_certificate_process.sh"))],
+                cwd=directory, capture_output=True, text=True, check=False)
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(result.stdout, "")
 


### PR DESCRIPTION
The isolated certificate experiment needs process identities and private cancellation records before command supervision can be implemented safely. This packet adds source-inert Linux Bash primitives for `/proc` identity/snapshot checks and strict process/cancel record custody. Invalid payloads are rejected before temporary-file creation; foreign operations cannot overwrite existing records. Process writes require the node lock, while cancellation records can be written without it.

Refs #2478, parent #2280, epic #2272. This is packet 1 of the independently reviewed process split. Command launch, supervision, signals, recovery admission, certificate renewal and rollback remain open in #2478. No learner mutation recipe is published.

Validation at `393a19fb0160cbb064cc8d36870c7867e72d99b1`:

- Four focused unit tests pass, including malformed/foreign records and inert sourcing; Python lint, Bash syntax and diff checks pass.
- Full curriculum pipeline: 176 tests pass. Generated test audit files are excluded.
- Fresh owned Kubernetes fixture: process identity/self checks, snapshot without scanner children, private record persistence/readback, malformed and foreign-operation rejection, insecure-mode rejection, lock enforcement and cancellation-record checks pass.
- Public certificate and static-pod manifests remain unchanged; private-key equality is checked inside the node without exporting key contents. Authenticated fixture inspection passes. The owned fixture is deleted and the pre-existing cluster list is preserved.

The fixture demonstrates record custody and identity primitives only. It does not establish command containment, cancellation completion, renewal, rollback or learner outcomes. Final independent-family review is posted separately.

Scope: 3 files, +179/-4 = 183 aggregate lines. Pure shell/Python helpers; Astro build is not applicable.
