### PR TITLE
fix(cka): validate process decisions and bound snapshots (#2478)

### DIFF
--- a/scripts/cka_certificate_process.sh
+++ b/scripts/cka_certificate_process.sh
@@ -22,13 +22,26 @@ cka_cert_process_stat() {
   CKA_CERT_PROC_START=${fields[19]}
 }
 
+# Shared node clock in centiseconds, unlike shell-relative SECONDS.
+# /proc/uptime reports elapsed boot time including suspend (proc_uptime(5)).
+cka_cert_process_now() {
+  local uptime idle extra
+  [[ $# == 0 ]] || return 1
+  read -r uptime idle extra < /proc/uptime || return 1
+  [[ $uptime =~ ^[0-9]{1,12}\.[0-9]{2}$ && $idle =~ ^[0-9]+\.[0-9]{2}$ && -z $extra ]] || return 1
+  CKA_CERT_PROCESS_NOW=$((10#${uptime%.*} * 100 + 10#${uptime#*.}))
+}
+
+# Pass an absolute deadline in node-clock centiseconds; callers share one budget.
 # Builtins only while enumerating: do not manufacture transient scanner children.
 # Zombies have released descriptors; any live reused SID conservatively blocks.
 cka_cert_process_snapshot() {
   local path pid
-  [[ $# == 2 && $1 =~ ^[1-9][0-9]*$ && $2 =~ ^[0-9]+$ ]] || return 1
+  [[ $# == 3 && $1 =~ ^[1-9][0-9]*$ && $2 =~ ^[0-9]+$ && $3 =~ ^[0-9]{1,15}$ ]] || return 1
   CKA_CERT_PROCESS_OTHERS=0
   for path in /proc/[0-9]*/stat; do
+    cka_cert_process_now || return 1
+    (( CKA_CERT_PROCESS_NOW < 10#$3 )) || return 124
     pid=${path#/proc/}
     pid=${pid%/stat}
     cka_cert_process_stat "$pid" || return 1
@@ -37,6 +50,8 @@ cka_cert_process_snapshot() {
     [[ $CKA_CERT_PROC_PGID == "$1" ]] || return 1
     [[ $pid == "$2" ]] || CKA_CERT_PROCESS_OTHERS=$((CKA_CERT_PROCESS_OTHERS + 1))
   done
+  cka_cert_process_now || return 1
+  (( CKA_CERT_PROCESS_NOW < 10#$3 )) || return 124
 }
 
 cka_cert_process_check() {
@@ -61,22 +76,44 @@ cka_cert_process_payload() {
     def integer: type=="number" and floor==.;
     def pid: integer and .>0;
     def ticks: type=="string" and test("^[0-9]+$");
+    def leader: type=="object" and keys==["pgid","pid","sid","start_time"] and
+      (.pid | pid) and .pid==.pgid and .pid==.sid and (.start_time | ticks);
+    def command: type=="object" and keys==["child_pid","exit_code","started"] and
+      (if .started==true then (.child_pid | pid) and (.exit_code | integer and .>=0 and .<=255)
+       else (.started==null or .started==false) and .child_pid==null and .exit_code==null end);
     if length==1 then .[0] else error("Expected one record") end |
     if $kind=="cancel" then
       select(.=={schema:1,identity:$identity,operation_id:$operation,request:"cancel"})
     else
-      select(type=="object" and
-        keys==["child_exit","coordinator","identity","operation_id","schema","stage","supervisor","timeout_seconds"]) |
-      select(.schema==1 and .identity==$identity and .operation_id==$operation) |
+      select(type=="object" and keys==["cancel_ack","cause","command","coordinator",
+        "identity","launch_disposition","operation_id","schema","stage","supervisor","timeout_seconds"]) |
+      select(.schema==2 and .identity==$identity and .operation_id==$operation) |
       select(.timeout_seconds | integer and .>=1 and .<=3600) |
+      select(.cancel_ack | type=="boolean") |
+      select(.cause=="none" or .cause=="cancel" or .cause=="timeout" or .cause=="signal" or .cause=="unknown") |
       select(.coordinator | type=="object" and keys==["pid","start_time"] and
         (.pid | pid) and (.start_time | ticks)) |
-      select(if .stage=="launch_requested" then .supervisor==null and .child_exit==null else
-        (.supervisor | type=="object" and keys==["pgid","pid","sid","start_time"] and
-          (.pid | pid) and .pid==.pgid and .pid==.sid and (.start_time | ticks)) and
-        (if .stage=="supervision_complete" then (.child_exit | integer and .>=0 and .<=255) else
-          (.stage=="running" or .stage=="term_requested" or .stage=="kill_requested") and .child_exit==null end)
-      end)
+      select(.command | command) |
+      select(if .stage=="launch_requested" then
+        .supervisor==null and .launch_disposition=="not_committed" and .command.started==null and .cause=="none"
+      elif .stage=="launch_committed" then
+        .supervisor==null and .launch_disposition=="supervisor_committed" and .command.started==null and .cause=="none"
+      elif .stage=="cancelled_before_launch" then
+        (.supervisor==null or (.supervisor | leader)) and .launch_disposition=="not_started" and
+        .command.started==false and .cancel_ack==true and .cause=="cancel"
+      else
+        (.supervisor | leader) and
+        (if .stage=="supervisor_ready" then
+          .launch_disposition=="supervisor_committed" and .command.started==null and .cause=="none"
+        else .launch_disposition=="command_committed" and .command.started!=false and
+          (if .stage=="command_launch_committed" then .command.started==null and .cause=="none"
+           elif .stage=="term_requested" or .stage=="kill_requested" then .cause!="none" and .cause!="unknown"
+           elif .stage=="supervision_complete" then .command.started==true and .cause!="unknown"
+           elif .stage=="supervision_unresolved" then .cause!="none"
+           else false end)
+        end)
+      end) |
+      select(if .cancel_ack then .cause!="none" else .cause!="cancel" end)
     end
   ' <<< "$4"
 }

--- a/scripts/tests/test_cka_certificate_state.py
+++ b/scripts/tests/test_cka_certificate_state.py
@@ -7,27 +7,83 @@ from pathlib import Path
 
 
 class TestCertificateStateSource(unittest.TestCase):
+    def test_process_clock_with_injected_read(self):
+        library = Path(__file__).resolve().parents[1] / "cka_certificate_process.sh"
+        # Redirect only the proc clock input so the injected read works on macOS too.
+        code = library.read_text().replace("< /proc/uptime", "< /dev/null")
+        cases = [("00.08 0.00", "8"), ("08.09 100.01", "809"),
+                 ("999999999999.99 0.00", "99999999999999")]
+        cases += [(sample, "refused") for sample in (
+            "", "read-failure", "1 0.00", "-1.00 0.00", "1.1 0.00", "1.001 0.00",
+            "1.00 0.0", "1.00 -0.01", "1.00 0.00 extra", "1000000000000.00 0.00")]
+        for sample, expected in cases:
+            with self.subTest(sample=sample):
+                result = subprocess.run(["bash", "-c", code + r'''
+sample=$1
+read() { [[ $sample != read-failure ]] && builtin read "$@" <<< "$sample"; }
+if cka_cert_process_now; then printf '%s' "$CKA_CERT_PROCESS_NOW"; else printf refused; fi
+''', "--", sample], capture_output=True, text=True, check=False)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout, expected)
+
+    def test_process_snapshot_refuses_expired_or_failed_clock_before_stat(self):
+        library = Path(__file__).resolve().parents[1] / "cka_certificate_process.sh"
+        for fault, expected in (("expired", "124"), ("failed", "1")):
+            with self.subTest(fault=fault):
+                result = subprocess.run(["bash", "-c", r'''
+source "$1"; fault=$2
+cka_cert_process_now() { [[ $fault != failed ]] || return 1; CKA_CERT_PROCESS_NOW=200; }
+cka_cert_process_stat() { printf unexpected-stat; return 1; }
+if cka_cert_process_snapshot 999 0 200; then printf 0; else printf '%s' "$?"; fi
+''', "--", str(library), fault], capture_output=True, text=True, check=False)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout, expected)
+
     def test_process_payload_rejects_malformed_and_foreign_records(self):
         library = Path(__file__).resolve().parents[1] / "cka_certificate_process.sh"
         operation = "a" * 32
         coordinator = {"pid": 20, "start_time": "123"}
         supervisor = {"pid": 21, "pgid": 21, "sid": 21, "start_time": "124"}
-        launch = {"schema": 1, "identity": {}, "operation_id": operation,
-                  "coordinator": coordinator, "supervisor": None, "child_exit": None,
-                  "stage": "launch_requested", "timeout_seconds": 60}
-        running = dict(launch, supervisor=supervisor, stage="running")
-        done = dict(running, stage="supervision_complete", child_exit=0)
+        unknown = {"started": None, "child_pid": None, "exit_code": None}
+        exited = {"started": True, "child_pid": 22, "exit_code": 0}
+        launch = {"schema": 2, "identity": {}, "operation_id": operation,
+                  "coordinator": coordinator, "supervisor": None, "command": unknown,
+                  "stage": "launch_requested", "timeout_seconds": 60,
+                  "launch_disposition": "not_committed", "cancel_ack": False, "cause": "none"}
+        committed = dict(launch, stage="launch_committed", launch_disposition="supervisor_committed")
+        ready = dict(committed, supervisor=supervisor, stage="supervisor_ready")
+        running = dict(ready, stage="command_launch_committed", launch_disposition="command_committed")
+        stopped = dict(launch, stage="cancelled_before_launch", launch_disposition="not_started",
+                       cancel_ack=True, cause="cancel", command=dict(unknown, started=False))
+        term = dict(running, stage="term_requested", cause="timeout")
+        done = dict(running, stage="supervision_complete", command=exited)
         cancel = {"schema": 1, "identity": {}, "operation_id": operation, "request": "cancel"}
-        cases = [(v, "process", True) for v in [launch, running, done]]
+        valid = [launch, committed, ready, running, stopped, dict(stopped, supervisor=supervisor),
+                 term, dict(term, stage="kill_requested"), done,
+                 dict(done, cancel_ack=True, cause="cancel", command=dict(exited, exit_code=42)),
+                 dict(running, stage="supervision_unresolved", cause="unknown")]
+        valid += [dict(launch, timeout_seconds=n) for n in (1, 3600)]
+        valid += [dict(done, command=dict(exited, exit_code=255)), dict(term, cause="signal")]
+        cases = [(v, "process", True) for v in valid]
         cases += [(cancel, "cancel", True), (dict(cancel, extra=True), "cancel", False)]
-        invalid = [dict(launch, supervisor=supervisor), dict(running, supervisor=None),
-                   dict(running, child_exit=0), dict(done, child_exit=None),
-                   dict(done, child_exit=256), dict(done, child_exit=0.5),
+        invalid = [dict(launch, schema=1), dict(launch, supervisor=supervisor),
+                   dict(committed, supervisor=supervisor), dict(ready, supervisor=None),
+                   dict(running, command=exited), dict(done, command=unknown),
+                   dict(stopped, command=exited), dict(stopped, cancel_ack=False),
+                   dict(term, cause="none"), dict(launch, cause="cancel"), dict(launch, cancel_ack=True),
+                   dict(running, launch_disposition="supervisor_committed"),
                    dict(running, supervisor=dict(supervisor, pgid=22)),
                    dict(running, coordinator=dict(coordinator, start_time=123)),
                    dict(running, operation_id="b" * 32), dict(running, identity={"foreign": 1}),
-                   dict(running, timeout_seconds=0), dict(running, timeout_seconds=3601),
-                   dict(running, stage="invented"), dict(running, extra=True), [], None]
+                   dict(running, stage="invented"), dict(running, cause="invented"),
+                   dict(running, cancel_ack=1), dict(running, extra=True), [], None]
+        invalid += [dict(launch, timeout_seconds=n) for n in (0, 3601, 1.5, "60", True)]
+        invalid += [dict(done, command=dict(exited, exit_code=n)) for n in (-1, 256, 0.5, None, True)]
+        invalid += [dict(done, command=dict(exited, child_pid=n)) for n in (0, -1, "22", True)]
+        invalid += [dict(launch, **{key: None}) for key in ("command", "coordinator", "launch_disposition")]
+        invalid += [dict(v, cause="unknown") for v in (ready, running, term, dict(term, stage="kill_requested"), done)]
+        invalid += [dict(v, command=dict(unknown, started=False)) for v in
+                    (term, done, dict(running, stage="supervision_unresolved", cause="unknown"))]
         cases += [(v, "process", False) for v in invalid]
         for value, kind, accepted in cases:
             with self.subTest(value=value, kind=kind):


### PR DESCRIPTION
Process records previously could not distinguish launch permission, acknowledged cancellation before launch, and observed command exit. Process enumeration also lacked an absolute deadline. This packet adds schema-2 stage/field validation and a shared node-clock deadline, with expired or uncertain snapshots refusing success.

Part of #2478, following the reviewed seven-packet split. This source-inert library change does not enable supervision, signalling, certificate renewal, or recovery admission. Schema-1 process records are deliberately rejected. Record validation checks combinations, not monotonic transitions or the truth of caller-supplied evidence.

Validation: six focused tests pass; 176 pipeline tests pass; Ruff, Bash syntax and whitespace checks pass. No site build is needed for these shell/Python test changes. The generated pipeline test review was preserved privately and excluded from the commit.

An independently reviewed harness passed on a freshly owned disposable Linux fixture at this exact head. It verified the child clock within parent readings, deadline expiry returning 124, old-arity refusal, actual bounded process snapshot, private record reads/writes, and malformed/foreign/unlocked-write refusal. Public certificate and manifest hashes matched before/after; authenticated fixture inspection passed; owned fixture deletion and preservation of the baseline cluster list were verified. Private receipt: `.agent/cka-certificate-process-runs/92c9cb652c394056b30d8506199f5780/receipt.json`. This proves the listed checks, not process termination or recovery. Independent final review will be posted before merge.

Diff: 2 files, 114 additions and 21 deletions (135 aggregate lines).
