### PR TITLE
feat(cka): preserve exclusive command exit receipts (#2478)

### DIFF
--- a/scripts/cka_certificate_process.sh
+++ b/scripts/cka_certificate_process.sh
@@ -1,6 +1,7 @@
 # Internal Linux Bash process identity and private record custody primitives.
 # Sourcing defines functions only. No launch, signalling or recovery admission.
 # Callers explicitly source the state and observation helpers.
+# Receipt publication additionally requires GNU ln and unlink.
 
 # Parse after the LAST closing comm delimiter; spaces/parentheses in comm are valid.
 # A vanished or malformed /proc entry is uncertainty, not proof of absence.
@@ -172,4 +173,68 @@ cka_cert_process_self() {
   cka_cert_process_stat "$1" || return 1
   [[ $CKA_CERT_PROC_PGID == "$1" && $CKA_CERT_PROC_SID == "$1" &&
      $CKA_CERT_PROC_START == "$2" ]]
+}
+
+# Expected identities must come from the later live supervisor/runner handshake.
+cka_cert_supervisor_receipt_payload() {
+  local expected
+  [[ $# == 5 && $2 =~ ^[a-f0-9]{32}$ ]] || return 1
+  expected=$(cka_cert_state_expected "$1") || return 1
+  jq -ces --argjson identity "$expected" --arg operation "$2" \
+    --argjson supervisor "$3" --argjson runner "$4" '
+    def integer: type=="number" and floor==.;
+    def pid: integer and .>0;
+    def ticks: type=="string" and test("^[0-9]+$");
+    def runner: type=="object" and keys==["pid","start_time"] and
+      (.pid | pid) and (.start_time | ticks);
+    def leader: type=="object" and keys==["pgid","pid","sid","start_time"] and
+      (.pid | pid) and .pid==.pgid and .pid==.sid and (.start_time | ticks);
+    if length==1 then .[0] else error("Expected one command receipt") end |
+    select(($supervisor | leader) and ($runner | runner)) |
+    select(type=="object" and keys==["child_pid","exit_code","identity","operation_id","runner","schema","supervisor"]) |
+    select(.schema==1 and .identity==$identity and .operation_id==$operation and
+      .supervisor==$supervisor and .runner==$runner and (.child_pid | pid)) |
+    select(.exit_code | integer and .>=0 and .<=255)
+  ' <<< "$5"
+}
+
+cka_cert_supervisor_receipt_read() {
+  local payload
+  [[ $# == 4 ]] || return 1
+  cka_cert_process_check "$1" "$2" || return 1
+  cka_cert_state_file /var/lib/cka-certificate-transaction/command.json || return 1
+  payload=$(cat /var/lib/cka-certificate-transaction/command.json) || return 1
+  cka_cert_supervisor_receipt_payload "$1" "$2" "$3" "$4" "$payload"
+}
+
+# Invoke directly in the admitted runner, not in a timeout-created Bash child.
+# This proves writer identity/custody only; the runner must supply real wait evidence.
+cka_cert_supervisor_receipt_write() {
+  local payload temporary runner_pid runner_start supervisor_pid supervisor_start
+  [[ $# == 5 ]] || return 1
+  payload=$(cka_cert_supervisor_receipt_payload "$1" "$2" "$3" "$4" "$5") || return 1
+  cka_cert_process_check "$1" "$2" && cka_cert_state_locked || return 1
+  runner_pid=$(jq -er .pid <<< "$4") || return 1
+  runner_start=$(jq -er .start_time <<< "$4") || return 1
+  supervisor_pid=$(jq -er .pid <<< "$3") || return 1
+  supervisor_start=$(jq -er .start_time <<< "$3") || return 1
+  [[ $BASHPID == "$runner_pid" ]] || return 1
+  cka_cert_process_stat "$supervisor_pid" || return 1
+  [[ $CKA_CERT_PROC_START == "$supervisor_start" && $CKA_CERT_PROC_PGID == "$supervisor_pid" &&
+     $CKA_CERT_PROC_SID == "$supervisor_pid" ]] || return 1
+  cka_cert_process_stat "$BASHPID" || return 1
+  [[ $CKA_CERT_PROC_START == "$runner_start" && $CKA_CERT_PROC_PPID == "$supervisor_pid" &&
+     $CKA_CERT_PROC_PGID == "$supervisor_pid" && $CKA_CERT_PROC_SID == "$supervisor_pid" ]] || return 1
+  [[ ! -e /var/lib/cka-certificate-transaction/command.json &&
+     ! -L /var/lib/cka-certificate-transaction/command.json ]] || return 1
+  temporary=$(mktemp /var/lib/cka-certificate-transaction/command.XXXXXXXX) || return 1
+  cka_cert_state_file "$temporary" || return 1
+  printf '%s\n' "$payload" > "$temporary" || return 1
+  sync -f "$temporary" || return 1
+  # Exclusive link creation also refuses a destination appearing after the check.
+  ln -T -- "$temporary" /var/lib/cka-certificate-transaction/command.json || return 1
+  # A crash before this unlink leaves two links and therefore a refused receipt.
+  unlink -- "$temporary" || return 1
+  sync -f /var/lib/cka-certificate-transaction || return 1
+  cka_cert_supervisor_receipt_read "$1" "$2" "$3" "$4" >/dev/null
 }

--- a/scripts/tests/test_cka_command_receipt.py
+++ b/scripts/tests/test_cka_command_receipt.py
@@ -1,0 +1,91 @@
+"""Receipt schema and prevalidation; live custody is verified separately."""
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+
+class TestCommandReceipt(unittest.TestCase):
+    def setUp(self):
+        self.identity = {"fixture": "expected"}
+        self.operation = "a" * 32
+        self.supervisor = {"pid": 21, "pgid": 21, "sid": 21, "start_time": "123"}
+        self.runner = {"pid": 22, "start_time": "124"}
+        self.receipt = {"schema": 1, "identity": self.identity, "operation_id": self.operation,
+                        "supervisor": self.supervisor, "runner": self.runner,
+                        "child_pid": 23, "exit_code": 0}
+
+    def check_receipt(self, value, accepted, method="payload", raw=False, custody=False, count=5, **expected):
+        library = Path(__file__).resolve().parents[1] / "cka_certificate_process.sh"
+        arguments = [json.dumps(expected.get("identity", self.identity)),
+                     expected.get("operation", self.operation),
+                     json.dumps(expected.get("supervisor", self.supervisor)),
+                     json.dumps(expected.get("runner", self.runner)),
+                     value if raw else json.dumps(value)]
+        result = subprocess.run(["bash", "-c", r'''
+source "$1"; method=$2; shift 2
+cka_cert_state_expected() { printf '%s\n' "$1"; }
+cka_cert_process_check() { printf REACHED_CUSTODY >&2; return 1; }
+mktemp() { printf REACHED_MKTEMP >&2; return 1; }
+if "cka_cert_supervisor_receipt_$method" "$@" >/dev/null; then
+  printf accepted
+else printf refused; fi
+''', "--", str(library), method, *arguments[:count]], capture_output=True, text=True, check=False)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "accepted" if accepted else "refused")
+        self.assertNotIn("REACHED_MKTEMP", result.stderr)
+        if custody:
+            self.assertIn("REACHED_CUSTODY", result.stderr)
+        else:
+            self.assertNotIn("REACHED_CUSTODY", result.stderr)
+
+    def test_valid_exit_boundaries_and_writer_validation_control(self):
+        for status in (0, 42, 255):
+            with self.subTest(status=status):
+                self.check_receipt(dict(self.receipt, exit_code=status), True)
+        # A valid payload reaches our refusing custody stub; no filesystem call occurs.
+        self.check_receipt(self.receipt, False, method="write", custody=True)
+        self.check_receipt(self.receipt, False, method="read")  # Read rejects five arguments.
+        self.check_receipt(self.receipt, False, method="read", count=4, custody=True)
+        for method in ("payload", "write"):
+            self.check_receipt(self.receipt, False, method=method, count=4)
+
+    def test_invalid_payloads_refuse_before_writer_custody_or_mktemp(self):
+        invalid = [None, [], {}, dict(self.receipt, extra=True), dict(self.receipt, schema=2),
+                   dict(self.receipt, identity={"foreign": 1}), dict(self.receipt, operation_id="b" * 32),
+                   dict(self.receipt, supervisor=None), dict(self.receipt, runner=None)]
+        invalid += [{k: v for k, v in self.receipt.items() if k != key} for key in self.receipt]
+        invalid += [dict(self.receipt, exit_code=v) for v in (-1, 256, 0.5, "0", None, True)]
+        invalid += [dict(self.receipt, child_pid=v) for v in (0, -1, 1.5, "23", None, True)]
+        for value in invalid:
+            for method in ("payload", "write"):
+                with self.subTest(value=value, method=method):
+                    self.check_receipt(value, False, method=method)
+        for value in ("{", json.dumps(self.receipt) + "\n" + json.dumps(self.receipt)):
+            for method in ("payload", "write"):
+                with self.subTest(raw=value, method=method):
+                    self.check_receipt(value, False, method=method, raw=True)
+
+    def test_independently_supplied_expected_identities(self):
+        mismatches = [{"identity": {"foreign": 1}}, {"operation": "bad"}, {"operation": "b" * 32},
+                      {"supervisor": dict(self.supervisor, start_time="999")},
+                      {"runner": dict(self.runner, pid=99)}, {"runner": dict(self.runner, start_time="999")}]
+        for expected in mismatches:
+            for method in ("payload", "write"):
+                with self.subTest(expected=expected, method=method):
+                    self.check_receipt(self.receipt, False, method=method, **expected)
+        for field, original in (("supervisor", self.supervisor), ("runner", self.runner)):
+            malformed = [None, [], dict(original, extra=True), dict(original, pid=True),
+                         dict(original, start_time=123), dict(original, start_time="-1")]
+            malformed += [{k: v for k, v in original.items() if k != key} for key in original]
+            if field == "supervisor":
+                malformed += [dict(original, pgid=99), dict(original, sid=99)]
+            for value in malformed:
+                for method in ("payload", "write"):
+                    with self.subTest(field=field, value=value, method=method):
+                        self.check_receipt(dict(self.receipt, **{field: value}), False,
+                                           method=method, **{field: value})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add private command-receipt custody primitives for #2478. The writer validates the full record before creating a temporary file, binds it to independently supplied supervisor/runner identities, and checks that the executing runner matches those identities. Exclusive publication refuses an existing or concurrently created destination. Failures after publication preserve the receipt; an interrupted two-link publication is refused by readers.

This source-inert packet implements storage and validation only. Synthetic exit values are used for custody tests. The later runner must obtain real wait evidence, and the supervisor must capture the runner identity during a live handshake before releasing execution. Direct writer execution and bounded utility calls must be integrated before complete supervision is enabled. No signalling, certificate renewal or recovery admission is enabled here.

Validation: 9 focused tests and 176 pipeline tests pass; Ruff, Bash syntax and whitespace checks pass. Generated pipeline test output was preserved privately and excluded. No Astro source/config changed, so no local site build is required.

An actual owned-Linux run at this exact head passed positive publication controls, invalid/foreign payload refusal, wrong runner/supervisor start-time refusal, different-process and missing-FD9 refusal, existing file/symlink/directory preservation, publication races, pre/post publication fault handling, and exactly one winner from concurrent publishers. Certificate/manifest hashes matched before/after, authenticated fixture inspection passed, the owned fixture was deleted and the baseline cluster list was preserved. Private receipt: `.agent/cka-command-receipt-runs/e01ab0820d8c4596b8aeefea38953778/receipt.json`.

The first harness run failed because it captured Bash subshell PIDs inside command substitutions. That run is retained as failed evidence. The harness was corrected to capture IDs before substitution and require a successful publication before refusal tests; independent re-review passed before the successful fresh run. Production code did not change between runs. Independent final review will be posted before merge.

Diff: 2 files, 156 additions; no deletions or generated artifacts.
