### PR TITLE
feat(cka): bound helper calls by a shared deadline (#2478)

### DIFF
--- a/scripts/cka_certificate_process.sh
+++ b/scripts/cka_certificate_process.sh
@@ -238,3 +238,64 @@ cka_cert_supervisor_receipt_write() {
   sync -f /var/lib/cka-certificate-transaction || return 1
   cka_cert_supervisor_receipt_read "$1" "$2" "$3" "$4" >/dev/null
 }
+
+# Shared deadline helpers; source-inert. Deadline is absolute node centiseconds.
+# A late/timeout result is unknown, never proof that descendants are absent.
+cka_cert_deadline_budget() {
+  local remaining soft
+  [[ $# == 1 && $1 =~ ^[0-9]{1,15}$ ]] || return 1
+  cka_cert_process_now || return 1
+  remaining=$((10#$1 - CKA_CERT_PROCESS_NOW))
+  # Reserve 25cs TERM-to-KILL grace and 5cs return margin inside this budget.
+  (( remaining > 30 )) || return 124
+  soft=$((remaining - 30))
+  printf -v CKA_CERT_DEADLINE_SOFT '%d.%02ds' "$((soft / 100))" "$((soft % 100))"
+}
+
+# Use only for receipt/read utilities; never for authoritative decision publication.
+# Decision publishers need a separate FD8+FD9-retaining protocol.
+cka_cert_run_utility() {
+  local deadline result duration
+  [[ $# -ge 3 && $2 == -- ]] || return 1
+  deadline=$1; shift 2
+  case $1 in jq|stat|cat|sha256sum|sync|ln|unlink|mktemp|flock|cmp|openssl) ;; *) return 1 ;; esac
+  cka_cert_deadline_budget "$deadline" || return $?
+  duration=$CKA_CERT_DEADLINE_SOFT
+  if (exec 8>&-; exec timeout --foreground --kill-after=0.25s "$duration" "$@"); then
+    result=0
+  else result=$?; fi
+  cka_cert_process_now || return 1
+  (( CKA_CERT_PROCESS_NOW < 10#$deadline )) || return 124
+  return "$result"
+}
+
+# Fixed read-only function allowlist; no receipt writes or process decisions.
+# Caller must have validated the private staged artifact set before dispatch.
+cka_cert_run_read_helper() {
+  local deadline duration result
+  [[ $# -ge 2 ]] || return 1
+  deadline=$1; shift
+  case $1 in
+    cka_cert_process_check|cka_cert_process_read|cka_cert_process_payload|\
+    cka_cert_state_expected|cka_cert_state_descriptor|cka_cert_state_file|\
+    cka_cert_supervisor_receipt_payload|cka_cert_supervisor_receipt_read) ;;
+    *) return 1 ;;
+  esac
+  cka_cert_deadline_budget "$deadline" || return $?
+  duration=$CKA_CERT_DEADLINE_SOFT
+  if (exec 8>&-; exec timeout --foreground --kill-after=0.25s "$duration" \
+    env -u BASH_ENV -u ENV bash --noprofile --norc -p -c '
+      unset CKA_CERT_CONTROL_OWNS_FD
+      source /var/lib/cka-certificate-artifacts/observe.sh || exit 1
+      source /var/lib/cka-certificate-artifacts/state.sh || exit 1
+      source /var/lib/cka-certificate-artifacts/process.sh || exit 1
+      if [[ -L /proc/$BASHPID/fd/9 ]]; then
+        CKA_CERT_STATE_OWNS_FD=1
+        cka_cert_state_descriptor || exit 1
+      fi
+      "$@"
+    ' cka-certificate-read-helper "$@"); then result=0; else result=$?; fi
+  cka_cert_process_now || return 1
+  (( CKA_CERT_PROCESS_NOW < 10#$deadline )) || return 124
+  return "$result"
+}

--- a/scripts/tests/test_cka_deadline_helper.py
+++ b/scripts/tests/test_cka_deadline_helper.py
@@ -1,0 +1,96 @@
+"""Dispatch tests with a fake timeout; no GNU-timeout or Linux custody proof."""
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class TestDeadlineHelper(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.directory = Path(temporary.name)
+        self.log = self.directory / "calls"
+        fake = self.directory / "timeout"
+        fake.write_text('''#!/bin/bash
+printf 'CALL\\0' >> "$TIMEOUT_LOG"
+printf '%s\\0' "$@" >> "$TIMEOUT_LOG"
+if [[ $FD_PROBE == 1 ]]; then
+  if (printf leaked >&8) 2>/dev/null; then printf FD8_LEAK; fi
+  printf child9 >&9 || exit 98
+fi
+exit "$FAKE_STATUS"
+''')
+        fake.chmod(0o700)
+
+    def invoke(self, command, clocks="0 1", status=0, probe=False):
+        library = Path(__file__).resolve().parents[1] / "cka_certificate_process.sh"
+        self.log.write_bytes(b"")
+        environment = dict(os.environ, PATH=str(self.directory) + os.pathsep + os.environ["PATH"],
+                           TIMEOUT_LOG=str(self.log), FAKE_STATUS=str(status), FD_PROBE=str(int(probe)),
+                           CLOCK_VALUES=clocks, FD8_FILE=str(self.directory / "fd8"),
+                           FD9_FILE=str(self.directory / "fd9"))
+        result = subprocess.run(["bash", "-c", r'''
+source "$1"; shift
+read -ra clock_values <<< "$CLOCK_VALUES"; clock_i=0
+cka_cert_process_now() {
+  local value=${clock_values[$clock_i]:-fail}; clock_i=$((clock_i + 1))
+  [[ $value != fail ]] || return 1
+  CKA_CERT_PROCESS_NOW=$value
+}
+chain() { cka_cert_run_utility "$@" || return $?; cka_cert_run_utility "$@"; }
+if [[ $FD_PROBE == 1 ]]; then exec 8>"$FD8_FILE" 9>"$FD9_FILE"; fi
+if "$@"; then result=0; else result=$?; fi
+if [[ $FD_PROBE == 1 ]]; then printf parent8 >&8; printf parent9 >&9; fi
+printf '%s|%s' "$result" "${CKA_CERT_DEADLINE_SOFT:-unset}"
+''', "--", str(library), *command], env=environment, capture_output=True, text=True, check=False)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stderr, "")
+        calls = [] if not self.log.exists() else [
+            [argument.decode() for argument in call.split(b"\0")[:-1]]
+            for call in self.log.read_bytes().split(b"CALL\0")[1:]]
+        return result.stdout, calls
+
+    def test_budget_validation_and_grace_boundaries(self):
+        cases = [("100", "69", "0|0.01s"), ("100", "70", "124|unset"),
+                 ("100", "100", "124|unset"), ("100", "101", "124|unset"),
+                 ("00100", "0", "0|0.70s"), ("250", "100", "0|1.20s"),
+                 ("999999999999999", "0", "0|9999999999999.69s"), ("100", "fail", "1|unset")]
+        cases += [(value, "0", "1|unset") for value in ("", "-1", "1.0", "bad", "1" * 16)]
+        for deadline, clock, expected in cases:
+            with self.subTest(deadline=deadline, clock=clock):
+                self.assertEqual(self.invoke(["cka_cert_deadline_budget", deadline], clock), (expected, []))
+
+    def test_expired_and_forbidden_dispatch_never_launches(self):
+        cases = [(["cka_cert_run_utility", "30", "--", "cat"], "124|unset"),
+                 (["cka_cert_run_utility", "100", "--", "bash"], "1|unset"),
+                 (["cka_cert_run_utility", "100", "missing-separator", "cat"], "1|unset")]
+        cases += [(["cka_cert_run_read_helper", "100", function], "1|unset") for function in
+                  ("cka_cert_process_write", "cka_cert_supervisor_receipt_write", "cka_cert_state_backup")]
+        for command, expected in cases:
+            with self.subTest(command=command):
+                self.assertEqual(self.invoke(command), (expected, []))
+
+    def test_late_zero_original_status_and_dispatch_arguments(self):
+        for status, after, expected in ((0, 99, 0), (0, 100, 124), (37, 99, 37), (124, 99, 124), (0, "fail", 1)):
+            with self.subTest(status=status, after=after):
+                output, calls = self.invoke(["cka_cert_run_utility", "100", "--", "cat", "two words"], f"0 {after}", status)
+                self.assertEqual(output, f"{expected}|0.70s")
+                self.assertEqual(calls, [["--foreground", "--kill-after=0.25s", "0.70s", "cat", "two words"]])
+        output, calls = self.invoke(["cka_cert_run_read_helper", "100", "cka_cert_process_read", "identity", "operation"])
+        self.assertEqual(output, "0|0.70s")
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[-1][:4], ["--foreground", "--kill-after=0.25s", "0.70s", "env"])
+        self.assertEqual(calls[-1][-3:], ["cka_cert_process_read", "identity", "operation"])
+
+    def test_shared_deadline_and_descriptor_inheritance(self):
+        output, calls = self.invoke(["chain", "100", "--", "cat"], "0 50 50 75", probe=True)
+        self.assertEqual(output, "0|0.20s")
+        self.assertEqual([call[2] for call in calls], ["0.70s", "0.20s"])
+        self.assertEqual((self.directory / "fd8").read_text(), "parent8")
+        self.assertEqual((self.directory / "fd9").read_text(), "child9child9parent9")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add shared-deadline helper calls for #2478. Callers pass one absolute node-clock deadline; the helper reserves TERM/KILL grace inside the remaining budget, refuses insufficient budgets and rejects late results even when the child exits zero. Utility and read-only helper allowlists close inherited FD8 while retaining FD9.

This source-inert packet does not activate control custody, decision publication, the runner/supervisor, certificate renewal or recovery admission. Timeout is not proof that descendants stopped. Utility callers must not use the generic helper for authoritative decisions; those require the separately reviewed FD8/FD9-retaining publication protocol. Complete direct receipt-writer deadline integration remains pending.

Validation: 13 focused tests and 176 pipeline tests pass; Ruff, Bash syntax and whitespace checks pass. Unit tests use a fake timeout and mocked clock. Generated pipeline output was preserved privately and excluded. No Astro source/config changed, so no local site build is required.

An actual owned-Linux run at this exact head passed utility/read-helper execution, no-launch and dispatch refusal, real descriptor inheritance, clean helper bootstrap, GNU timeout TERM/KILL handling and shared-deadline chaining. A surviving timed-out helper descendant retained FD9 and blocked fresh transaction custody while FD8 was released; after it exited, fresh FD9 custody succeeded. This is observed behavior for the tested chain, not a guarantee of hard scheduling bounds or general descendant termination. Private receipt: `.agent/cka-deadline-helper-runs/922fcca68df047aa8a68837c386098ed/receipt.json`.

Public certificate/manifest hashes matched, authenticated fixture inspection passed, the owned fixture was deleted and the baseline cluster list was preserved. Independent final review will be posted before merge.

Diff: 2 files, 157 additions, no deletions.
