### PR TITLE
feat(cka): add bounded control descriptor custody (#2478)

### DIFF
--- a/scripts/cka_certificate_process.sh
+++ b/scripts/cka_certificate_process.sh
@@ -285,7 +285,7 @@ cka_cert_run_read_helper() {
   duration=$CKA_CERT_DEADLINE_SOFT
   if (exec 8>&-; exec timeout --foreground --kill-after=0.25s "$duration" \
     env -u BASH_ENV -u ENV bash --noprofile --norc -p -c '
-      unset CKA_CERT_CONTROL_OWNS_FD
+      unset CKA_CERT_CONTROL_OWNS_FD CKA_CERT_CONTROL_OWNER CKA_CERT_CONTROL_LOCKED
       source /var/lib/cka-certificate-artifacts/observe.sh || exit 1
       source /var/lib/cka-certificate-artifacts/state.sh || exit 1
       source /var/lib/cka-certificate-artifacts/process.sh || exit 1
@@ -298,4 +298,86 @@ cka_cert_run_read_helper() {
   cka_cert_process_now || return 1
   (( CKA_CERT_PROCESS_NOW < 10#$deadline )) || return 124
   return "$result"
+}
+
+# Permanent control-inode custody. FD8 is reserved; callers must not replace it manually.
+# Callers validate the private transaction directory; participating actors never replace the inode.
+# Initialize once before process.json or any child work; failure requires reconciliation.
+cka_cert_control_init() {
+  local deadline temporary
+  [[ $# == 3 && ${CKA_CERT_STATE_OWNS_FD:-0} == 1 ]] || return 1
+  deadline=$1
+  cka_cert_run_read_helper "$deadline" cka_cert_process_check "$2" "$3" || return $?
+  cka_cert_run_read_helper "$deadline" cka_cert_state_descriptor || return $?
+  cka_cert_run_utility "$deadline" -- flock -n 9 || return $?
+  [[ ! -e /var/lib/cka-certificate-transaction/process.json &&
+     ! -L /var/lib/cka-certificate-transaction/process.json &&
+     ! -e /var/lib/cka-certificate-transaction/control.lock &&
+     ! -L /var/lib/cka-certificate-transaction/control.lock ]] || return 1
+  temporary=$(cka_cert_run_utility "$deadline" -- mktemp /var/lib/cka-certificate-transaction/control.XXXXXXXX) || return $?
+  cka_cert_run_read_helper "$deadline" cka_cert_state_file "$temporary" || return $?
+  cka_cert_run_utility "$deadline" -- sync -f "$temporary" || return $?
+  cka_cert_run_utility "$deadline" -- ln -T -- "$temporary" /var/lib/cka-certificate-transaction/control.lock || return $?
+  cka_cert_run_utility "$deadline" -- unlink -- "$temporary" || return $?
+  cka_cert_run_utility "$deadline" -- sync -f /var/lib/cka-certificate-transaction || return $?
+  cka_cert_run_read_helper "$deadline" cka_cert_state_file /var/lib/cka-certificate-transaction/control.lock
+}
+
+cka_cert_control_descriptor() {
+  local descriptor inode path
+  [[ $# == 1 && ${CKA_CERT_CONTROL_OWNER:-} == "$BASHPID" && -L /proc/$BASHPID/fd/8 ]] || return 1
+  path=/proc/$BASHPID/fd/8
+  cka_cert_run_read_helper "$1" cka_cert_state_file /var/lib/cka-certificate-transaction/control.lock || return $?
+  descriptor=$(cka_cert_run_utility "$1" -- stat -Lc '%d:%i:%u:%a:%h' -- "$path") || return $?
+  inode=$(cka_cert_run_utility "$1" -- stat -c '%d:%i:%u:%a:%h' -- /var/lib/cka-certificate-transaction/control.lock) || return $?
+  [[ $descriptor == "$inode" && $inode == *:0:600:1 ]]
+}
+
+# The only acquisition wrapper retaining FD8; never accepts arbitrary commands.
+cka_cert_control_acquire() {
+  local deadline duration result
+  [[ $# == 1 && ${CKA_CERT_CONTROL_OWNER:-} == "$BASHPID" && -L /proc/$BASHPID/fd/8 ]] || return 1
+  deadline=$1
+  cka_cert_deadline_budget "$deadline" || return $?
+  duration=$CKA_CERT_DEADLINE_SOFT
+  if timeout --foreground --kill-after=0.25s "$duration" flock -n 8; then result=0; else result=$?; fi
+  cka_cert_process_now || return 1
+  (( CKA_CERT_PROCESS_NOW < 10#$deadline )) || return 124
+  return "$result"
+}
+
+cka_cert_control_close() {
+  [[ $# == 0 && ${CKA_CERT_CONTROL_OWNER:-} == "$BASHPID" ]] || return 1
+  exec 8>&- || return 1
+  unset CKA_CERT_CONTROL_OWNER CKA_CERT_CONTROL_LOCKED
+}
+
+cka_cert_control_open() {
+  [[ $# == 1 && -z ${CKA_CERT_CONTROL_OWNER:-} && ! -L /proc/$BASHPID/fd/8 ]] || return 1
+  cka_cert_run_read_helper "$1" cka_cert_state_file /var/lib/cka-certificate-transaction/control.lock || return $?
+  cka_cert_deadline_budget "$1" || return $?
+  # Read-only open cannot recreate a vanished inode; native Linux flock permits it.
+  exec 8< /var/lib/cka-certificate-transaction/control.lock || return 1
+  CKA_CERT_CONTROL_OWNER=$BASHPID
+  CKA_CERT_CONTROL_LOCKED=0
+  if cka_cert_control_descriptor "$1" && cka_cert_control_acquire "$1" && cka_cert_control_descriptor "$1"; then
+    CKA_CERT_CONTROL_LOCKED=1
+  else
+    local result=$?
+    cka_cert_control_close || return 1
+    return "$result"
+  fi
+}
+
+cka_cert_control_locked() {
+  [[ $# == 1 && ${CKA_CERT_CONTROL_LOCKED:-0} == 1 ]] || return 1
+  cka_cert_control_descriptor "$1"
+}
+
+# Child bootstrap only, before doing any other work or acquiring a fresh lock.
+cka_cert_control_child_drop() {
+  [[ $# == 0 && ${CKA_CERT_CONTROL_OWNER:-} =~ ^[1-9][0-9]*$ &&
+     $CKA_CERT_CONTROL_OWNER != "$BASHPID" ]] || return 1
+  exec 8>&- || return 1
+  unset CKA_CERT_CONTROL_OWNER CKA_CERT_CONTROL_LOCKED
 }

--- a/scripts/tests/test_cka_control_custody.py
+++ b/scripts/tests/test_cka_control_custody.py
@@ -1,0 +1,105 @@
+"""Portable Bash descriptor tests; injected statuses do not prove Linux inode/flock custody."""
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class TestControlCustody(unittest.TestCase):
+    def run_case(self, body, control="", inherited=""):
+        library = Path(__file__).resolve().parents[1] / "cka_certificate_process.sh"
+        # Darwin FD entries are not symlinks: adapt Linux's FD-existence -L to -e.
+        # Real FD duplication/closure is exercised; inode validation remains stubbed.
+        code = library.read_text().replace("/proc/$BASHPID/fd", "/dev/fd").replace(
+            "/var/lib/cka-certificate-transaction/control.lock", '"$CONTROL_FILE"').replace("-L /dev/fd/", "-e /dev/fd/")
+        stubs = r'''
+helper_calls=0; descriptor_calls=0
+cka_cert_run_read_helper() { helper_calls=$((helper_calls + 1)); return "${HELPER_RESULT:-0}"; }
+cka_cert_deadline_budget() { return "${BUDGET_RESULT:-0}"; }
+cka_cert_control_acquire() { return "${ACQUIRE_RESULT:-0}"; }
+cka_cert_control_descriptor() {
+  descriptor_calls=$((descriptor_calls + 1))
+  if (( descriptor_calls == 1 )); then return "${DESCRIPTOR_FIRST:-0}"; fi
+  return "${DESCRIPTOR_AFTER:-0}"
+}
+fd8_open() { ( : >&8 ) 2>/dev/null; }
+'''
+        with tempfile.TemporaryDirectory() as directory:
+            control_file = Path(directory) / "control"
+            inherited_file = Path(directory) / "inherited"
+            control_file.write_text("")
+            result = subprocess.run(["bash", "-c", 'CONTROL_FILE=$1; INHERITED_FILE=$2\n' +
+                                     code + stubs + body, "--", str(control_file), str(inherited_file)],
+                                    capture_output=True, text=True, check=False)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout, "")
+            self.assertEqual(result.stderr, "")
+            self.assertEqual(control_file.read_text(), control)
+            self.assertEqual(inherited_file.read_text() if inherited_file.exists() else "", inherited)
+
+    def test_owner_close_is_local_and_needs_no_remaining_budget(self):
+        self.run_case(r'''
+exec 8<>"$CONTROL_FILE"; CKA_CERT_CONTROL_OWNER=$BASHPID; CKA_CERT_CONTROL_LOCKED=1
+if cka_cert_control_close unexpected; then exit 10; fi
+fd8_open || exit 11
+BUDGET_RESULT=124; HELPER_RESULT=124
+cka_cert_control_close || exit 12
+if fd8_open; then exit 13; fi
+[[ -z ${CKA_CERT_CONTROL_OWNER+x} && -z ${CKA_CERT_CONTROL_LOCKED+x} && $helper_calls == 0 ]] || exit 14
+''')
+
+    def test_child_drop_retains_fd9_and_parent_state(self):
+        self.run_case(r'''
+exec 8<>"$CONTROL_FILE" 9>"$INHERITED_FILE"; CKA_CERT_CONTROL_OWNER=$BASHPID; CKA_CERT_CONTROL_LOCKED=1
+if cka_cert_control_child_drop; then exit 20; fi
+(
+  if cka_cert_control_close || cka_cert_control_open 100; then exit 21; fi
+  fd8_open || exit 22
+  cka_cert_control_child_drop || exit 23
+  if fd8_open; then exit 24; fi
+  [[ -z ${CKA_CERT_CONTROL_OWNER+x} && -z ${CKA_CERT_CONTROL_LOCKED+x} ]] || exit 25
+  printf child9 >&9
+) || exit 26
+[[ $CKA_CERT_CONTROL_OWNER == "$BASHPID" && $CKA_CERT_CONTROL_LOCKED == 1 ]] || exit 27
+printf parent8 >&8; printf parent9 >&9
+''', control="parent8", inherited="child9parent9")
+
+    def test_unowned_drop_and_occupied_or_stale_open_refuse(self):
+        self.run_case(r'''
+exec 8<>"$CONTROL_FILE"
+if cka_cert_control_child_drop; then exit 30; fi
+if cka_cert_control_close; then exit 34; fi
+if cka_cert_control_open 100; then exit 35; fi
+fd8_open || exit 31
+exec 8>&-; CKA_CERT_CONTROL_OWNER=999999
+if cka_cert_control_open 100; then exit 32; fi
+[[ $CKA_CERT_CONTROL_OWNER == 999999 && $helper_calls == 0 ]] || exit 33
+''')
+
+    def test_open_success_and_failure_cleanup_preserve_status(self):
+        for setting, expected in (("HELPER_RESULT=7", 7), ("BUDGET_RESULT=124", 124),
+                                  ("DESCRIPTOR_FIRST=55", 55), ("ACQUIRE_RESULT=37", 37),
+                                  ("DESCRIPTOR_AFTER=124", 124), ("ACQUIRE_RESULT=0", 0)):
+            with self.subTest(setting=setting):
+                self.run_case(setting + r'''
+if cka_cert_control_open 100; then status=0; else status=$?; fi
+''' + f'[[ $status == {expected} ]] || exit 40\n' + (r'''
+[[ $CKA_CERT_CONTROL_OWNER == "$BASHPID" && $CKA_CERT_CONTROL_LOCKED == 1 ]] || exit 41
+fd8_open || exit 42
+cka_cert_control_close || exit 43
+''' if expected == 0 else r'''
+if fd8_open; then exit 44; fi
+[[ -z ${CKA_CERT_CONTROL_OWNER+x} && -z ${CKA_CERT_CONTROL_LOCKED+x} ]] || exit 45
+'''))
+
+    def test_init_arity_and_missing_ownership_refuse_before_helpers(self):
+        self.run_case(r'''
+if cka_cert_control_init 100 identity operation; then exit 50; fi
+CKA_CERT_STATE_OWNS_FD=1
+if cka_cert_control_init 100 identity; then exit 51; fi
+[[ $helper_calls == 0 ]] || exit 52
+''')
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the permanent control inode and direct FD8 custody needed by the later certificate-process decision protocol. Acquisition opens the existing inode read-only, checks descriptor identity before and after bounded nonblocking flock, and closes only the caller's descriptor on failure or a late result. Child drop requires a recorded inherited owner; read-helper bootstrap clears inherited control ownership.

Part of #2478, packet 3b. This internal helper does not enable command launch, authoritative decision publication, signalling, certificate mutation, or recovery admission. Receipt deadline integration, late-publisher reconciliation, and the remaining lifecycle gates stay open.

Validation at `20123bd2a5a4b46cd474ba87dfb26e0c92b2c830`:

- 19 focused CKA tests and 176 pipeline tests passed; Ruff, Bash syntax and diff whitespace checks passed.
- Independent Gemini draft and exact pre-execution reviews passed. Final independent review follows as a comment.
- Nine fresh sequential Linux fixtures passed: normal custody/independent contention/child FD8 drop with FD9 retention, symlink, FIFO, mode, owner, multiple links, injected interrupted link publication, injected replacement after opening, and a finite surviving acquisition helper after timeout.
- The late case returned 124 with local FD8 closed; fresh independent probes for FD8 and FD9 remained blocked until the surviving helper exited. Runtime mutations were confined to owned fixture test artifacts.
- Every fixture passed authenticated inspection, preservation of the five explicitly hashed public certificate/manifest paths, verified deletion, and baseline cluster-name preservation. This is not a universal certificate-state integrity claim.
- Private runtime evidence: run `1eeee715cd764c038c312647eb6cb94d`; runtime SHA-256 `037a366858078c3ceb88c626425c6dbb166ed5113c176691b0ab68856c2e28ad`. All nine receipts match the reviewed artifact hashes.

Contract limits: trusted root-private transaction directory, reserved FD8, and participating actors never replace the permanent inode. Descriptor comparison detects replacement relative to the current acquisition, not a valid replacement installed before opening. Bash open does not provide O_NOFOLLOW/O_NONBLOCK; this is not protection against hostile concurrent root replacement or a hard OS scheduling deadline. Failed publication preserves residues for reconciliation. Closing a local descriptor does not prove that surviving descendants released custody.

Diff: 188 additions, 1 deletion, 2 files (189 aggregate lines). No generated artifacts or site content. Primary remains clean on main; no Astro build required for this script-only change.
