### PR TITLE
fix(cka): bound direct receipt writer and output capture (#2478)

### DIFF
--- a/scripts/cka_certificate_process.sh
+++ b/scripts/cka_certificate_process.sh
@@ -207,18 +207,60 @@ cka_cert_supervisor_receipt_read() {
   cka_cert_supervisor_receipt_payload "$1" "$2" "$3" "$4" "$payload"
 }
 
+cka_cert_capture_directory() {
+  [[ $# == 0 ]] && cka_cert_state_environment && cka_cert_state_directory /var/lib/cka-certificate-transaction
+}
+
+# Direct invocation only: never put this capture helper inside command substitution.
+# Fixed single-line text results; uncertain files remain private reconciliation artifacts.
+cka_cert_capture() {
+  local deadline mode path snapshot
+  unset CKA_CERT_CAPTURED
+  [[ $# -ge 3 ]] || return 1
+  deadline=$1; mode=$2; shift 2
+  case "$mode:$1" in read:cka_cert_supervisor_receipt_payload|utility:jq|utility:mktemp) ;; *) return 1 ;; esac
+  cka_cert_deadline_budget "$deadline" || return $?
+  cka_cert_run_read_helper "$deadline" cka_cert_capture_directory || return $?
+  path=/var/lib/cka-certificate-transaction/capture.$BASHPID.$RANDOM.$RANDOM
+  [[ ! -e $path && ! -L $path ]] || return 1
+  if (umask 077; set -C; exec 8>&-; {
+    case $mode in
+      read) cka_cert_run_read_helper "$deadline" "$@" ;;
+      utility) cka_cert_run_utility "$deadline" -- "$@" ;;
+    esac
+  } > "$path" 2>&1); then :; else return $?; fi
+  cka_cert_run_read_helper "$deadline" cka_cert_state_file "$path" || return $?
+  # These allowlisted results are single-line text; cap the direct builtin read.
+  if LC_ALL=C IFS= read -r -d '' -n 65537 snapshot < "$path"; then return 1; else [[ $? == 1 ]] || return 1; fi
+  [[ ${#snapshot} -le 65536 && $snapshot == *$'\n' ]] || return 1
+  snapshot=${snapshot%$'\n'}
+  [[ -n $snapshot && $snapshot != *$'\n'* ]] || return 1
+  cka_cert_deadline_budget "$deadline" || return $?
+  CKA_CERT_CAPTURED=$snapshot
+}
+
 # Invoke directly in the admitted runner, not in a timeout-created Bash child.
 # This proves writer identity/custody only; the runner must supply real wait evidence.
+# Deadline is mandatory and first; late receipts are preserved without acknowledgement.
 cka_cert_supervisor_receipt_write() {
-  local payload temporary runner_pid runner_start supervisor_pid supervisor_start
-  [[ $# == 5 ]] || return 1
-  payload=$(cka_cert_supervisor_receipt_payload "$1" "$2" "$3" "$4" "$5") || return 1
-  cka_cert_process_check "$1" "$2" && cka_cert_state_locked || return 1
-  runner_pid=$(jq -er .pid <<< "$4") || return 1
-  runner_start=$(jq -er .start_time <<< "$4") || return 1
-  supervisor_pid=$(jq -er .pid <<< "$3") || return 1
-  supervisor_start=$(jq -er .start_time <<< "$3") || return 1
+  local deadline payload temporary runner_pid runner_start supervisor_pid supervisor_start
+  [[ $# == 6 && ${CKA_CERT_STATE_OWNS_FD:-0} == 1 ]] || return 1
+  deadline=$1
+  cka_cert_capture "$deadline" read cka_cert_supervisor_receipt_payload "$2" "$3" "$4" "$5" "$6" || return $?
+  payload=$CKA_CERT_CAPTURED
+  cka_cert_run_read_helper "$deadline" cka_cert_process_check "$2" "$3" || return $?
+  cka_cert_run_read_helper "$deadline" cka_cert_state_descriptor || return $?
+  cka_cert_run_utility "$deadline" -- flock -n 9 || return $?
+  cka_cert_capture "$deadline" utility jq -er .pid <<< "$5" || return $?
+  runner_pid=$CKA_CERT_CAPTURED
+  cka_cert_capture "$deadline" utility jq -er .start_time <<< "$5" || return $?
+  runner_start=$CKA_CERT_CAPTURED
+  cka_cert_capture "$deadline" utility jq -er .pid <<< "$4" || return $?
+  supervisor_pid=$CKA_CERT_CAPTURED
+  cka_cert_capture "$deadline" utility jq -er .start_time <<< "$4" || return $?
+  supervisor_start=$CKA_CERT_CAPTURED
   [[ $BASHPID == "$runner_pid" ]] || return 1
+  cka_cert_deadline_budget "$deadline" || return $?
   cka_cert_process_stat "$supervisor_pid" || return 1
   [[ $CKA_CERT_PROC_START == "$supervisor_start" && $CKA_CERT_PROC_PGID == "$supervisor_pid" &&
      $CKA_CERT_PROC_SID == "$supervisor_pid" ]] || return 1
@@ -227,16 +269,16 @@ cka_cert_supervisor_receipt_write() {
      $CKA_CERT_PROC_PGID == "$supervisor_pid" && $CKA_CERT_PROC_SID == "$supervisor_pid" ]] || return 1
   [[ ! -e /var/lib/cka-certificate-transaction/command.json &&
      ! -L /var/lib/cka-certificate-transaction/command.json ]] || return 1
-  temporary=$(mktemp /var/lib/cka-certificate-transaction/command.XXXXXXXX) || return 1
-  cka_cert_state_file "$temporary" || return 1
+  cka_cert_capture "$deadline" utility mktemp /var/lib/cka-certificate-transaction/command.XXXXXXXX || return $?
+  temporary=$CKA_CERT_CAPTURED
+  cka_cert_run_read_helper "$deadline" cka_cert_state_file "$temporary" || return $?
+  cka_cert_deadline_budget "$deadline" || return $?
   printf '%s\n' "$payload" > "$temporary" || return 1
-  sync -f "$temporary" || return 1
-  # Exclusive link creation also refuses a destination appearing after the check.
-  ln -T -- "$temporary" /var/lib/cka-certificate-transaction/command.json || return 1
-  # A crash before this unlink leaves two links and therefore a refused receipt.
-  unlink -- "$temporary" || return 1
-  sync -f /var/lib/cka-certificate-transaction || return 1
-  cka_cert_supervisor_receipt_read "$1" "$2" "$3" "$4" >/dev/null
+  cka_cert_run_utility "$deadline" -- sync -f "$temporary" || return $?
+  cka_cert_run_utility "$deadline" -- ln -T -- "$temporary" /var/lib/cka-certificate-transaction/command.json || return $?
+  cka_cert_run_utility "$deadline" -- unlink -- "$temporary" || return $?
+  cka_cert_run_utility "$deadline" -- sync -f /var/lib/cka-certificate-transaction || return $?
+  cka_cert_run_read_helper "$deadline" cka_cert_supervisor_receipt_read "$2" "$3" "$4" "$5" >/dev/null
 }
 
 # Shared deadline helpers; source-inert. Deadline is absolute node centiseconds.
@@ -276,7 +318,7 @@ cka_cert_run_read_helper() {
   [[ $# -ge 2 ]] || return 1
   deadline=$1; shift
   case $1 in
-    cka_cert_process_check|cka_cert_process_read|cka_cert_process_payload|\
+    cka_cert_process_check|cka_cert_process_read|cka_cert_process_payload|cka_cert_capture_directory|\
     cka_cert_state_expected|cka_cert_state_descriptor|cka_cert_state_file|\
     cka_cert_supervisor_receipt_payload|cka_cert_supervisor_receipt_read) ;;
     *) return 1 ;;

--- a/scripts/tests/test_cka_command_receipt.py
+++ b/scripts/tests/test_cka_command_receipt.py
@@ -22,15 +22,19 @@ class TestCommandReceipt(unittest.TestCase):
                      json.dumps(expected.get("supervisor", self.supervisor)),
                      json.dumps(expected.get("runner", self.runner)),
                      value if raw else json.dumps(value)]
+        arguments = (["10000"] if method == "write" else []) + arguments[:count]
         result = subprocess.run(["bash", "-c", r'''
 source "$1"; method=$2; shift 2
+CKA_CERT_STATE_OWNS_FD=1
+cka_cert_run_read_helper() { [[ $1 == 10000 ]] || return 97; shift; "$@"; }
+cka_cert_capture() { [[ $1 == 10000 && $2 == read ]] || return 97; shift 2; CKA_CERT_CAPTURED=$("$@"); }
 cka_cert_state_expected() { printf '%s\n' "$1"; }
 cka_cert_process_check() { printf REACHED_CUSTODY >&2; return 1; }
 mktemp() { printf REACHED_MKTEMP >&2; return 1; }
 if "cka_cert_supervisor_receipt_$method" "$@" >/dev/null; then
   printf accepted
 else printf refused; fi
-''', "--", str(library), method, *arguments[:count]], capture_output=True, text=True, check=False)
+''', "--", str(library), method, *arguments], capture_output=True, text=True, check=False)
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout, "accepted" if accepted else "refused")
         self.assertNotIn("REACHED_MKTEMP", result.stderr)

--- a/scripts/tests/test_cka_receipt_deadline.py
+++ b/scripts/tests/test_cka_receipt_deadline.py
@@ -1,0 +1,111 @@
+"""Portable orchestration probes with injected identity; not Linux custody proof."""
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+class TestReceiptDeadline(unittest.TestCase):
+    def probe(self, failure="none", status=124):
+        source = Path(__file__).resolve().parents[1] / "cka_certificate_process.sh"
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            library = root / "writer.sh"
+            library.write_text(source.read_text().replace("/var/lib/cka-certificate-transaction", str(root)))
+            started = time.monotonic()
+            result = subprocess.run(["bash", "-c", r'''
+source "$1"; root=$2; failure=$3; failure_status=$4; sync_count=0
+CKA_CERT_STATE_OWNS_FD=1; writer=$BASHPID
+check() { [[ $1 == 10000 ]] || return 97; printf '%s\n' "$2" >> "$root/log"; }
+cka_cert_deadline_budget() { check "$1" budget; }
+cka_cert_process_stat() {
+  CKA_CERT_PROC_START=42; CKA_CERT_PROC_PGID=21; CKA_CERT_PROC_SID=21; CKA_CERT_PROC_PPID=21
+  [[ $1 == 21 || $1 == "$writer" ]] || return 96
+}
+cka_cert_run_read_helper() {
+  check "$1" "$2" || return $?; shift
+  [[ $failure != "$1" ]] || return "$failure_status"
+  case $1 in
+    cka_cert_supervisor_receipt_payload)
+      case $failure in
+        descendant) sleep 4 & return 124 ;;
+        oversized) printf '%65537s\n' x ;;
+        nul) printf 'before\0after\n' ;;
+        multiline) printf 'first\nsecond\n' ;;
+        *) printf '%s\n' "$6" ;;
+      esac ;;
+    cka_cert_supervisor_receipt_read) cat "$root/command.json" ;;
+  esac
+}
+cka_cert_run_utility() {
+  check "$1" "$3" || return $?; [[ $2 == -- ]] || return 95; shift 2
+  case $1 in
+    flock) [[ $failure != flock ]] || return "$failure_status" ;;
+    jq) command "$@" || return $? ;;
+    mktemp) command "$@" || return $? ;;
+    sync) sync_count=$((sync_count + 1))
+      [[ $failure != "sync$sync_count" ]] || return "$failure_status" ;;
+    ln) command ln "$4" "$5" || return $? ;;
+    unlink) command unlink "$3" || return $? ;;
+    *) return 94 ;;
+  esac
+  [[ $failure != "$1" ]] || return "$failure_status"
+}
+runner=$(printf '{"pid":%s,"start_time":"42"}' "$writer")
+[[ $failure != identity ]] || runner='{"pid":1,"start_time":"42"}'
+if cka_cert_supervisor_receipt_write 10000 '{}' operation \
+  '{"pid":21,"start_time":"42"}' "$runner" payload; then result=0; else result=$?; fi
+printf '%s' "$result"
+''', "--", str(library), str(root), failure, str(status)], capture_output=True, text=True, check=False, timeout=6)
+            elapsed = time.monotonic() - started
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stderr, "")
+            paths = list(root.glob("command.*"))
+            residue = {path.name: (path.read_text(), path.stat().st_nlink) for path in paths}
+            if failure in ("descendant", "oversized", "nul", "multiline"):
+                self.assertEqual(len(list(root.glob("capture.*"))), 1)
+            if failure == "descendant":
+                self.assertLess(elapsed, 2, "writer waited for surviving descendant output EOF")
+            return int(result.stdout), (root / "log").read_text().splitlines(), residue
+
+    def test_direct_writer_and_shared_deadline(self):
+        status, calls, residue = self.probe()
+        self.assertEqual(status, 0)
+        self.assertEqual(calls.count("jq"), 4)
+        self.assertLess(calls.index("flock"), calls.index("mktemp"))
+        self.assertEqual(calls[-1], "cka_cert_supervisor_receipt_read")
+        self.assertEqual(residue, {"command.json": ("payload\n", 1)})
+
+    def test_refusal_before_publication(self):
+        for failure in ("cka_cert_capture_directory", "cka_cert_supervisor_receipt_payload", "cka_cert_process_check",
+                        "cka_cert_state_descriptor", "flock", "identity"):
+            with self.subTest(failure=failure):
+                status, calls, residue = self.probe(failure)
+                self.assertEqual(status, 1 if failure == "identity" else 124)
+                self.assertNotIn("mktemp", calls)
+                self.assertEqual(residue, {})
+
+    def test_capture_rejects_unbounded_or_nontext_output(self):
+        for failure in ("descendant", "oversized", "nul", "multiline"):
+            with self.subTest(failure=failure):
+                status, calls, residue = self.probe(failure)
+                self.assertEqual(status, 124 if failure == "descendant" else 1)
+                self.assertNotIn("cka_cert_process_check", calls)
+                self.assertEqual(residue, {})
+
+    def test_late_publication_preserves_status_and_residue(self):
+        for failure, count, links in (("sync1", 1, 1), ("ln", 2, 2), ("unlink", 1, 1),
+                                      ("sync2", 1, 1), ("cka_cert_supervisor_receipt_read", 1, 1)):
+            for expected_status in (124, 37):
+                with self.subTest(failure=failure, status=expected_status):
+                    status, calls, residue = self.probe(failure, expected_status)
+                    self.assertEqual(status, expected_status)
+                    self.assertEqual(len(residue), count)
+                    self.assertTrue(all(value == ("payload\n", links) for value in residue.values()))
+                    self.assertEqual("command.json" in residue, failure != "sync1")
+                    self.assertEqual(calls[-1], "sync" if failure.startswith("sync") else failure)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The direct receipt writer now requires one absolute deadline and applies it through payload, transaction, descriptor and read-back checks plus every external utility. It keeps the runner's actual BASHPID checks and preserves uncertain publication artifacts without acknowledging success.

Capturing a timed helper with Bash command substitution could still wait for a surviving descendant's output pipe after timeout returned. The writer now invokes a restricted capture helper directly, using exclusively created private regular files for stdout/stderr. It validates the directory before creation, rejects oversized/NUL/multiline output, reads a bounded snapshot with builtins, rechecks the deadline, and exposes output only on success. It retains failed capture files for reconciliation.

Part of #2478, packet 3c. Writer signature becomes `(deadline, identity, operation, supervisor, runner, payload)`; no production callers exist yet. Payload/read signatures stay unchanged. Authoritative decision publication, runner/supervisor lifecycle and recovery admission remain outside this change.

Validation at `388dd9937cb7e0436128b44bc77a19f4b751c548`:

- 23 focused CKA tests and 176 pipeline tests passed; Ruff, Bash syntax and diff checks passed. Schema tests continue to validate actual payloads rather than merely failing old arity.
- Portable capture tests reject oversized, NUL and multiline output and return promptly despite a finite child retaining stdout/stderr. These tests inject helper status and process identity.
- Nine fresh sequential Linux fixtures passed: positive direct-writer publication with real child PID/wait status, identity/old-arity refusal, expired no-publication, pre-sync, post-link, post-sync, late unlink, late read-back and late payload capture.
- Under a shared 300cs deadline, late unlink/read/payload returned 124 in 271/270/271cs respectively. Fresh FD9 probes remained blocked while finite six-second helpers survived. Later output was never acknowledged; late payload produced no receipt, while late unlink/read preserved the expected final artifact.
- Each fixture passed the five explicit checks: receipt case, five public certificate/manifest file hashes unchanged, authenticated inspection, verified fixture deletion, and baseline cluster-name list preservation. This does not establish universal certificate or unrelated-cluster integrity.
- Private evidence run `c04b2088970a4795b3159815c90d1296`, runtime SHA-256 `68b8c219cb7057d0cede0c559af32396238d50783d6d67e12c8b837cf5e8f7e5`. All nine receipts match the reviewed source/runtime hashes. Independent revised-draft and exact pre-execution reviews passed; final independent review follows as a comment.

Limits: trusted private staging/transaction directories and participants preserving owned inodes. Collision paths refuse. Capture files are not authoritative receipts. Direct builtin reads/opens use explicit checkpoints; this is not a hard OS scheduling guarantee. Closing a local descriptor does not prove surviving children released custody. The writer remains forbidden in the read-helper dispatcher. No certificate mutation, authoritative decision publication, or recovery admission is enabled.

Diff: 176 additions, 19 deletions, three files (195 aggregate lines). No generated artifacts or site content; no local Astro build required. Primary remains on main.
