### PR TITLE
feat(cka): validate decision proposals and observations (#2478)

### DIFF
--- a/scripts/cka_certificate_process.sh
+++ b/scripts/cka_certificate_process.sh
@@ -218,7 +218,11 @@ cka_cert_capture() {
   unset CKA_CERT_CAPTURED
   [[ $# -ge 3 ]] || return 1
   deadline=$1; mode=$2; shift 2
-  case "$mode:$1" in read:cka_cert_supervisor_receipt_payload|utility:jq|utility:mktemp) ;; *) return 1 ;; esac
+  case "$mode:$1" in
+    read:cka_cert_supervisor_receipt_payload|read:cka_cert_decision_observation|\
+    read:cka_cert_decision_proposal|read:cka_cert_decision_classify|utility:jq|utility:mktemp) ;;
+    *) return 1 ;;
+  esac
   cka_cert_deadline_budget "$deadline" || return $?
   cka_cert_run_read_helper "$deadline" cka_cert_capture_directory || return $?
   path=/var/lib/cka-certificate-transaction/capture.$BASHPID.$RANDOM.$RANDOM
@@ -319,6 +323,7 @@ cka_cert_run_read_helper() {
   deadline=$1; shift
   case $1 in
     cka_cert_process_check|cka_cert_process_read|cka_cert_process_payload|cka_cert_capture_directory|\
+    cka_cert_decision_observation|cka_cert_decision_proposal|cka_cert_decision_classify|\
     cka_cert_state_expected|cka_cert_state_descriptor|cka_cert_state_file|\
     cka_cert_supervisor_receipt_payload|cka_cert_supervisor_receipt_read) ;;
     *) return 1 ;;
@@ -422,4 +427,45 @@ cka_cert_control_child_drop() {
      $CKA_CERT_CONTROL_OWNER != "$BASHPID" ]] || return 1
   exec 8>&- || return 1
   unset CKA_CERT_CONTROL_OWNER CKA_CERT_CONTROL_LOCKED
+}
+
+# Pure record helpers only. Run through bounded read/capture dispatch in live callers.
+# Explicit presence prevents a stored JSON null from masquerading as file absence.
+cka_cert_decision_observation() {
+  local observation record
+  [[ $# == 3 && $2 =~ ^[a-f0-9]{32}$ ]] || return 1
+  cka_cert_state_expected "$1" >/dev/null || return 1
+  observation=$(jq -ces 'select(length==1) | .[0] | select(type=="object" and
+    ((.presence=="absent" and keys==["presence"]) or
+     (.presence=="present" and keys==["presence","record"])))' <<< "$3") || return 1
+  if [[ $(jq -r .presence <<< "$observation") == present ]]; then
+    record=$(cka_cert_process_payload "$1" "$2" process "$(jq -c .record <<< "$observation")") || return 1
+    jq -cnS --argjson record "$record" '{presence:"present",record:$record}'
+  else printf '%s\n' '{"presence":"absent"}'; fi
+}
+
+# Shape, expected predecessor and stable operation metadata are not transition permission.
+cka_cert_decision_proposal() {
+  local expected next
+  [[ $# == 4 ]] || return 1
+  expected=$(cka_cert_decision_observation "$1" "$2" "$3") || return 1
+  next=$(cka_cert_process_payload "$1" "$2" process "$4") || return 1
+  jq -cnSe --argjson expected "$expected" --argjson next "$next" '
+    select($expected.presence=="absent" or
+      ($expected.record!=$next and $expected.record.coordinator==$next.coordinator and
+       $expected.record.timeout_seconds==$next.timeout_seconds)) |
+    {schema:1,identity:$next.identity,operation_id:$next.operation_id,expected:$expected,next:$next}'
+}
+
+# Classifies a supplied observation only: no file access, durability claim or retry.
+cka_cert_decision_classify() {
+  local proposal observed
+  [[ $# == 5 ]] || return 1
+  proposal=$(cka_cert_decision_proposal "$1" "$2" "$3" "$4") || return 1
+  observed=$(cka_cert_decision_observation "$1" "$2" "$5") || return 1
+  jq -nr --argjson proposal "$proposal" --argjson observed "$observed" '
+    if $observed=={presence:"present",record:$proposal.next} then "successor"
+    elif $observed==$proposal.expected then "predecessor"
+    elif $observed.presence=="absent" then "missing"
+    else "conflict" end'
 }

--- a/scripts/tests/test_cka_decision_proposal.py
+++ b/scripts/tests/test_cka_decision_proposal.py
@@ -1,0 +1,95 @@
+"""Pure supplied-record checks; no deadline, filesystem observation or custody proof."""
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class TestDecisionProposal(unittest.TestCase):
+    def setUp(self):
+        self.identity = {"transaction_id": "a" * 32, "fixture_cluster": "cert-fixture-" + "b" * 32,
+                         "docker_container_id": "c" * 64, "image_id": "sha256:" + "d" * 64,
+                         "system_namespace_uid": "12345678-1234-1234-1234-123456789abc",
+                         "artifact_hashes": {name + ".sh": "e" * 64 for name in ("state", "observe", "process")}}
+        self.operation = "f" * 32
+        self.before = {"schema": 2, "identity": self.identity, "operation_id": self.operation,
+                       "stage": "launch_requested", "coordinator": {"pid": 21, "start_time": "123"},
+                       "supervisor": None, "timeout_seconds": 30, "cancel_ack": False, "cause": "none",
+                       "launch_disposition": "not_committed",
+                       "command": {"started": None, "child_pid": None, "exit_code": None}}
+        self.after = dict(self.before, stage="launch_committed", launch_disposition="supervisor_committed")
+        self.absent = {"presence": "absent"}
+        self.present = {"presence": "present", "record": self.before}
+
+    def invoke(self, method, *values, accepted=True, identity=None, operation=None):
+        root = Path(__file__).resolve().parents[2]
+        args = [json.dumps(self.identity if identity is None else identity),
+                self.operation if operation is None else operation]
+        args += [value if isinstance(value, str) else json.dumps(value) for value in values]
+        with tempfile.TemporaryDirectory() as directory:
+            result = subprocess.run(["bash", "-c", 'source "$1"; source "$2"; shift 2; "$@"',
+                                     "--", str(root / "scripts/cka_certificate_state.sh"),
+                                     str(root / "scripts/cka_certificate_process.sh"),
+                                     "cka_cert_decision_" + method, *args], cwd=directory,
+                                    capture_output=True, text=True, check=False)
+            self.assertEqual(list(Path(directory).iterdir()), [])
+        self.assertEqual(result.returncode == 0, accepted, result.stderr)
+        if not accepted:
+            self.assertEqual(result.stdout, "")
+        return result.stdout.strip()
+
+    def test_exact_tags_and_malformed_observations(self):
+        for value in (self.absent, self.present):
+            self.assertEqual(json.loads(self.invoke("observation", value)), value)
+        invalid = [None, [], {}, {"presence": "absent", "record": None},
+                   {"presence": "present", "record": None}, {"presence": "present"},
+                   {"presence": "unknown"}, dict(self.present, extra=True), "{",
+                   json.dumps(self.absent) + "\n" + json.dumps(self.absent)]
+        for value in invalid:
+            with self.subTest(value=value):
+                self.invoke("observation", value, accepted=False)
+                self.invoke("proposal", value, self.after, accepted=False)
+
+    def test_proposal_shape_and_binding(self):
+        for expected in (self.absent, self.present):
+            self.assertEqual(json.loads(self.invoke("proposal", expected, self.after)),
+                             {"schema": 1, "identity": self.identity, "operation_id": self.operation,
+                              "expected": expected, "next": self.after})
+        for overrides in ({"identity": {}}, {"identity": dict(self.identity, transaction_id="0" * 32)},
+                          {"operation": "bad"}, {"operation": "0" * 32}):
+            self.invoke("observation", self.present, accepted=False, **overrides)
+            self.invoke("proposal", self.absent, self.after, accepted=False, **overrides)
+        invalid = [None, {}, dict(self.after, schema=1), dict(self.after, extra=True),
+                   dict(self.after, identity={}), dict(self.after, operation_id="0" * 32),
+                   dict(self.after, stage="unknown"), json.dumps(self.after) + "\n" + json.dumps(self.after)]
+        for value in invalid:
+            self.invoke("proposal", self.absent, value, accepted=False)
+            self.invoke("observation", {"presence": "present", "record": value}, accepted=False)
+            self.invoke("classify", self.present, self.after,
+                        {"presence": "present", "record": value}, accepted=False)
+
+    def test_stable_metadata_and_noop(self):
+        for successor in (self.before, dict(self.after, timeout_seconds=31),
+                          dict(self.after, coordinator={"pid": 22, "start_time": "123"})):
+            self.invoke("proposal", self.present, successor, accepted=False)
+        self.invoke("proposal", self.present, dict(reversed(list(self.before.items()))), accepted=False)
+
+    def test_four_classifications_and_semantic_order(self):
+        conflict = dict(self.before, timeout_seconds=31)
+        cases = [(self.present, {"presence": "present", "record": self.after}, "successor"),
+                 (self.present, self.present, "predecessor"), (self.present, self.absent, "missing"),
+                 (self.absent, self.absent, "predecessor"),
+                 (self.present, {"presence": "present", "record": conflict}, "conflict")]
+        for expected, observed, classification in cases:
+            self.assertEqual(self.invoke("classify", expected, self.after, observed), classification)
+        reordered = dict(reversed(list(self.after.items())))
+        reordered["identity"] = dict(reversed(list(self.identity.items())))
+        self.assertEqual(self.invoke("classify", self.present, self.after,
+                                     {"record": reordered, "presence": "present"}), "successor")
+        self.invoke("classify", self.present, None, self.present, accepted=False)
+        self.invoke("classify", None, self.after, self.present, accepted=False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds explicit observation validation and decision-proposal comparisons for #2478. Raw null cannot stand in for file absence; malformed or foreign records fail, and present-predecessor proposals reject no-ops and changed coordinator/timeout metadata. Valid supplied observations classify as successor, predecessor, missing or conflict through the existing bounded read/capture routes.

These helpers compare supplied records only. They grant no lifecycle permission and prove no custody, filesystem existence, durability or actor history. Full delegated publication and fresh-custody uncertainty reconciliation remain required; packet 3d and #2478 are not complete.

Validation at `67d034f1177cc33c5c66f3e0613fd5acba9e208a`: 27 focused tests and 176 pipeline tests passed; Ruff, bash syntax and diff checks passed. Independent Gemini exact-code and pre-execution harness review: PASS. Actual owned Kubernetes v1.35 Linux fixture run: all five checks passed (helper cases, unchanged public certificate/manifests, authenticated inspection, owned fixture deletion, baseline cluster-name preservation). No certificate renewal or rollback was performed. No Astro build required: only shell helper and Python tests changed.

Scope: 2 files, 142 additions and 1 deletion (143 aggregate lines). No generated artifacts included. Primary checkout remains clean on main.
