### PR TITLE
build(deps): bump astro 7.2.10 -> 7.3.2 (#2496)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/markdown-remark": "^7.3.0",
         "@astrojs/starlight": "^0.41.11",
-        "astro": "^7.2.10",
+        "astro": "^7.3.2",
         "mermaid": "^11.17.2",
         "sharp": "^0.35.1"
       },
@@ -3452,14 +3452,14 @@
       }
     },
     "node_modules/astro": {
-      "version": "7.2.10",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-7.2.10.tgz",
-      "integrity": "sha512-uPtD+nK6kQXugyq4kiMPwj9OI3Sae6HSerA5X+fuv2CPaDwxmokFPPFlGRKIAXH0QAKu+zot2q6yrLG61wFmqg==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-7.3.2.tgz",
+      "integrity": "sha512-ysTcdpGP61XZpHoMRYC/CK19DQ94qkBvzXMtXEo0gEqPNkmOU/Tv++CtWmzaI4nF2Ck8RXFdiWvdlTWa2oOr9w==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler-rs": "^0.4.0",
         "@astrojs/internal-helpers": "0.11.0",
-        "@astrojs/markdown-satteri": "0.4.0",
+        "@astrojs/markdown-satteri": "0.4.1",
         "@astrojs/telemetry": "3.3.3",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
@@ -3509,7 +3509,7 @@
         "vitefu": "^1.1.2",
         "xxhash-wasm": "^1.1.0",
         "yargs-parser": "^22.0.0",
-        "zod": "^4.3.6"
+        "zod": "^4.5.4"
       },
       "bin": {
         "astro": "bin/astro.mjs"
@@ -3565,9 +3565,9 @@
       }
     },
     "node_modules/astro/node_modules/@astrojs/markdown-satteri": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.4.0.tgz",
-      "integrity": "sha512-wykOOW9KsUVcZweOpY/CeXpdKcCKZy6fQbdcteWFuI75+sQCiqxYM7VKsGa5b+aGl3cYQscFY37rsbbyal5MRw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.4.1.tgz",
+      "integrity": "sha512-EniHbFNa6SQHDih7JnpPos3NWXO6hdt4raBcOosfGmlfc3gP9CI/sESA3VOf1PgJZ7SFfewlZW9Livn0JugEZg==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/internal-helpers": "0.11.0",
@@ -10026,9 +10026,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.6.1.tgz",
+      "integrity": "sha512-341aRWQsve0rvronKNTqZpjmzdbUDlFuzHaI/XLg/Ej82qffDJRRfBTCuv7+9q/rMjB6LSLyEBnW4InJeMtt/Q==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@astrojs/markdown-remark": "^7.3.0",
     "@astrojs/starlight": "^0.41.11",
-    "astro": "^7.2.10",
+    "astro": "^7.3.2",
     "mermaid": "^11.17.2",
     "sharp": "^0.35.1"
   },


### PR DESCRIPTION
Closes #2496. Residual delivery of closed Dependabot PR #2485.

## Why
- #2485 (astro 7.1.6→7.3.2) failed `npm ci` with ERESOLVE: astro@7.3.2 peerOptional `@astrojs/markdown-remark@^7.3.0` vs then-locked 7.2.2. Dependabot closed it after rebase ('astro is up-to-date now') because the `^7.2.10` **range** covers 7.3.2 — but the merged **lock** still selects 7.2.10, so 7.3.2 was never delivered.
- astro 7.3.2 includes the MDX `<script>/<style>` dynamic-content escaping fix (withastro/astro#17896).

## What
- `package.json`: `astro` `^7.2.10` → `^7.3.2` (1 line)
- `package-lock.json`: astro 7.3.2, `@astrojs/markdown-satteri` 0.4.0→0.4.1, `zod` 4.4.3→4.6.1 (both within astro's declared ranges). `@astrojs/markdown-remark` stays 7.3.0 (supplied by #2451), satisfying the peer — the original ERESOLVE is resolved by construction.

## Validation
- Lock regenerated with `npm install --package-lock-only --ignore-scripts` in an isolated dir (no shared/symlink node_modules touched)
- `npm ci --dry-run --ignore-scripts`: clean, 594 packages, no ERESOLVE
- Exact-head CI on this PR = authoritative install + Astro build validation
- Diff: 2 files, 13 insertions / 13 deletions

Cross-family review to follow as a comment before merge (author: Fable/Anthropic-family fleet lead).

Made with [Cursor](https://cursor.com)