### PR TITLE
feat(quality): revision-bound source acceptance receipt (#2310)

### DIFF
--- a/scripts/quality/source_acceptance.py
+++ b/scripts/quality/source_acceptance.py
@@ -1,0 +1,118 @@
+"""Revision-bound source-acceptance receipt (#2310 packet 1).
+
+Only a complete applicable positive receipt can accept. Frontmatter,
+injection, and inventory pass strings are not inputs. Fixture-valid
+receipts prove validator behavior, not real source support. Read-only:
+no status store, no promotion/backfill.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from typing import Any
+
+from .content_inventory import _normalise_digest
+
+SCHEMA = "kubedojo.source_acceptance.v1"
+SCHEMA_VERSION = 1
+FAILING_VERDICTS = frozenset({"UNSUPPORTED", "CONTRADICTED", "UNREADABLE"})
+UNKNOWN_FAMILIES = frozenset({"", "unknown"})
+
+
+def _reject(reason: str) -> dict[str, Any]:
+    return {"schema": SCHEMA, "accepted": False, "reasons": [reason]}
+
+
+def _id_list(value: Any) -> list[str] | None:
+    if not isinstance(value, list) or any(not isinstance(i, str) or not i.strip() for i in value):
+        return None
+    return [i.strip() for i in value]
+
+
+def _family(block: Any) -> str:
+    value = block.get("family") if isinstance(block, dict) else None
+    return value.strip().lower() if isinstance(value, str) else ""
+
+
+def _source_ok(source: Any) -> bool:
+    uri = source.get("retrieval_uri") if isinstance(source, dict) else None
+    digest = source.get("snapshot_digest") if isinstance(source, dict) else None
+    return isinstance(uri, str) and bool(uri.strip()) and _normalise_digest(digest) is not None
+
+
+def evaluate_source_acceptance(
+    receipt: Any, *, page_digest: str, seed_digest: str, seed_claim_ids: Sequence[str],
+) -> dict[str, Any]:
+    """Fail closed unless the receipt is complete, applicable, and positive."""
+    if receipt is None:
+        return _reject("receipt_missing")
+    if isinstance(receipt, (bytes, str)):
+        try:
+            receipt = json.loads(receipt)
+        except (TypeError, UnicodeError, json.JSONDecodeError):
+            return _reject("receipt_malformed")
+    if not isinstance(receipt, dict):
+        return _reject("receipt_not_object")
+    if receipt.get("schema") != SCHEMA or receipt.get("schema_version") != SCHEMA_VERSION:
+        return _reject("schema_invalid")
+    if receipt.get("disposition") != "applicable":
+        return _reject("disposition_not_applicable")
+
+    want_page, got_page = _normalise_digest(page_digest), _normalise_digest(receipt.get("page_digest"))
+    want_seed, got_seed = _normalise_digest(seed_digest), _normalise_digest(receipt.get("seed_digest"))
+    if want_page is None or got_page is None:
+        return _reject("page_digest_invalid")
+    if got_page != want_page:
+        return _reject("page_digest_stale")
+    if want_seed is None or got_seed is None:
+        return _reject("seed_digest_invalid")
+    if got_seed != want_seed:
+        return _reject("seed_digest_stale")
+
+    coverage = receipt.get("coverage")
+    material = _id_list(coverage.get("material_claim_ids")) if isinstance(coverage, dict) else None
+    reviewed = _id_list(coverage.get("reviewed_claim_ids")) if isinstance(coverage, dict) else None
+    uncovered = _id_list(coverage.get("uncovered_claim_ids")) if isinstance(coverage, dict) else None
+    if material is None or reviewed is None or uncovered is None:
+        return _reject("schema_invalid")
+    if not material:
+        return _reject("coverage_empty")
+    if uncovered or set(reviewed) != set(material):
+        return _reject("coverage_incomplete")
+    expected = [c.strip() for c in seed_claim_ids if isinstance(c, str) and c.strip()]
+    if set(expected) - set(material):
+        return _reject("coverage_omitted")
+
+    claims = receipt.get("claims")
+    if not isinstance(claims, list) or not claims:
+        return _reject("coverage_empty")
+    seen: set[str] = set()
+    for claim in claims:
+        cid = claim.get("claim_id") if isinstance(claim, dict) else None
+        if not isinstance(cid, str) or not cid.strip() or cid in seen:
+            return _reject("schema_invalid")
+        seen.add(cid)
+        verdict = claim.get("verdict")
+        if verdict in FAILING_VERDICTS:
+            return _reject(f"claim_verdict:{verdict}")
+        if verdict != "SUPPORTED" or not _source_ok(claim.get("source")):
+            return _reject("schema_invalid")
+    if set(material) - seen:
+        return _reject("coverage_incomplete")
+
+    run = receipt.get("run") if isinstance(receipt.get("run"), dict) else {}
+    identity, status = run.get("identity"), run.get("status")
+    if not isinstance(identity, str) or not identity.strip():
+        return _reject("run_identity_missing")
+    if status != "complete":
+        return _reject(f"run_status:{status}")
+
+    verifier = receipt.get("verifier")
+    verifier_id = verifier.get("identity") if isinstance(verifier, dict) else None
+    author_f, verifier_f = _family(receipt.get("author")), _family(verifier)
+    if not isinstance(verifier_id, str) or not verifier_id.strip():
+        return _reject("schema_invalid")
+    if author_f in UNKNOWN_FAMILIES or verifier_f in UNKNOWN_FAMILIES or author_f == verifier_f:
+        return _reject("reviewer_not_independent")
+    return {"schema": SCHEMA, "accepted": True, "reasons": []}

--- a/tests/test_source_acceptance.py
+++ b/tests/test_source_acceptance.py
@@ -1,0 +1,76 @@
+"""Fail-closed fixtures for #2310. Prove the validator, not real source support."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from scripts.quality.source_acceptance import SCHEMA, SCHEMA_VERSION, evaluate_source_acceptance
+
+PAGE, SEED, SNAP = "sha256:" + "a" * 64, "sha256:" + "b" * 64, "sha256:" + "c" * 64
+
+
+def _valid(**changes: object) -> dict[str, object]:
+    receipt: dict[str, object] = {
+        "schema": SCHEMA, "schema_version": SCHEMA_VERSION,
+        "page_digest": PAGE, "seed_digest": SEED, "disposition": "applicable",
+        "coverage": {"material_claim_ids": ["C001"], "reviewed_claim_ids": ["C001"], "uncovered_claim_ids": []},
+        "claims": [{"claim_id": "C001", "verdict": "SUPPORTED",
+                    "source": {"retrieval_uri": "https://example.test/src", "snapshot_digest": SNAP}}],
+        "author": {"family": "openai"}, "verifier": {"identity": "agy", "family": "google"},
+        "run": {"status": "complete", "identity": "verify-example-C001-000000Z"},
+    }
+    receipt.update(changes)
+    return receipt
+
+
+def _eval(receipt: object, **kwargs: object) -> dict[str, object]:
+    args: dict[str, object] = {"page_digest": PAGE, "seed_digest": SEED, "seed_claim_ids": ("C001",)}
+    args.update(kwargs)
+    return evaluate_source_acceptance(receipt, **args)  # type: ignore[arg-type]
+
+
+def _verdict(verdict: str) -> dict[str, object]:
+    receipt = _valid()
+    receipt["claims"][0]["verdict"] = verdict  # type: ignore[index]
+    return receipt
+
+
+def test_valid_complete_path_is_not_real_source_proof() -> None:
+    assert _eval(_valid()) == {"schema": SCHEMA, "accepted": True, "reasons": []}
+
+
+def test_frontmatter_and_injection_cannot_bypass() -> None:
+    assert not _eval({"citations_verified": True, "source_acceptance": "accepted"})["accepted"]
+    assert _eval(_valid(citations_verified=False))["accepted"]
+
+
+@pytest.mark.parametrize(("receipt", "kwargs", "needle"), [
+    (None, {}, "receipt_missing"),
+    ("{", {}, "receipt_malformed"),
+    ([], {}, "receipt_not_object"),
+    (_valid(schema="other.v1"), {}, "schema_invalid"),
+    (_valid(schema_version=2), {}, "schema_invalid"),
+    (_valid(page_digest="sha256:" + "d" * 64), {}, "page_digest_stale"),
+    (_valid(seed_digest="sha256:" + "d" * 64), {}, "seed_digest_stale"),
+    (_valid(coverage={"material_claim_ids": [], "reviewed_claim_ids": [], "uncovered_claim_ids": []}), {}, "coverage_empty"),
+    (_valid(claims=[]), {}, "coverage_empty"),
+    (_valid(coverage={"material_claim_ids": ["C001"], "reviewed_claim_ids": [], "uncovered_claim_ids": ["C001"]}), {}, "coverage_incomplete"),
+    (_verdict("UNSUPPORTED"), {}, "claim_verdict:UNSUPPORTED"),
+    (_verdict("CONTRADICTED"), {}, "claim_verdict:CONTRADICTED"),
+    (_verdict("UNREADABLE"), {}, "claim_verdict:UNREADABLE"),
+    (_valid(run={"status": "failed", "identity": "run-1"}), {}, "run_status:failed"),
+    (_valid(run={"status": "partial", "identity": "run-1"}), {}, "run_status:partial"),
+    (_valid(author={"family": "google"}, verifier={"identity": "agy", "family": "google"}), {}, "reviewer_not_independent"),
+    (_valid(verifier={"identity": "agy", "family": "unknown"}), {}, "reviewer_not_independent"),
+    (_valid(disposition="not_applicable"), {}, "disposition_not_applicable"),
+    (_valid(), {"seed_claim_ids": ("C001", "C002")}, "coverage_omitted"),
+    ({"page_digest": PAGE, "disposition": "retain", "independent_statuses": {"technical_source": "pass"}}, {}, "schema_invalid"),
+])
+def test_fail_closed_adversarial_receipts(receipt: object, kwargs: dict[str, object], needle: str) -> None:
+    result = _eval(receipt, **kwargs)
+    assert result["accepted"] is False
+    assert needle in result["reasons"]

--- a/tests/test_source_acceptance.py
+++ b/tests/test_source_acceptance.py
@@ -8,7 +8,11 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-from scripts.quality.source_acceptance import SCHEMA, SCHEMA_VERSION, evaluate_source_acceptance
+from scripts.quality.source_acceptance import (
+    SCHEMA,
+    SCHEMA_VERSION,
+    evaluate_source_acceptance,
+)
 
 PAGE, SEED, SNAP = "sha256:" + "a" * 64, "sha256:" + "b" * 64, "sha256:" + "c" * 64
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
First #2310 packet: a schema-versioned, fail-closed source-acceptance receipt and read-only evaluator. This is not whole-curriculum claim verification (#2275) and does not backfill or promote any page.

Follows the published #2310 split (schema + pure fail-closed validation). Reuses existing seams instead of a parallel status store:

- content digest format from `scripts/quality/content_inventory.py` (`sha256:` + 64 hex)
- claim verdicts from `scripts/verify_citations.py` (`SUPPORTED` / `UNSUPPORTED` / `CONTRADICTED` / `UNREADABLE`)
- inventory pass strings and `citations_verified` frontmatter remain reporting/legacy fields, not acceptance authority

## Schema (`kubedojo.source_acceptance.v1`)

A receipt is applicable only when it binds:

| Field | Role |
|---|---|
| `schema` / `schema_version` | `kubedojo.source_acceptance.v1` / `1` |
| `page_digest` | exact reviewed page bytes |
| `seed_digest` | exact claim/seed bytes |
| `disposition` | must be `applicable` (`not_applicable` is not a pass) |
| `coverage.material_claim_ids` | reviewer-attested material claims (non-empty) |
| `coverage.reviewed_claim_ids` | must equal material; `uncovered_claim_ids` must be empty |
| `claims[]` | every material id, `SUPPORTED`, with `retrieval_uri` + `snapshot_digest` |
| `author.family` / `verifier.identity` + `verifier.family` | independence required; `unknown` fails closed |
| `run.status` / `run.identity` | `complete` plus a completed-run identity |

`evaluate_source_acceptance(receipt, *, page_digest, seed_digest, seed_claim_ids)` is the only acceptance predicate. Caller-supplied `seed_claim_ids` detect omitted seed claims; an unchecked list on the receipt is not coverage proof.

## Fail-closed cases covered

Absent, malformed JSON, non-object, schema/version invalid, stale page digest, stale seed digest, empty material/claims, incomplete/uncovered coverage, omitted seed claim, `UNSUPPORTED` / `CONTRADICTED` / `UNREADABLE`, failed/partial run, missing run identity, same-family or unknown-family reviewer, `not_applicable`, inventory `technical_source: pass` string, and `citations_verified` / injection bits.

One fixture-valid complete path exists. **Those fixtures prove validator behavior, not real source support.**

## Out of scope (follow-up packets)

- Producer provenance / actual provider-reported identity (#2310 split packet 2)
- Coverage-review producer integration (packet 3 remainder)
- Inventory/readiness adaptation, cache invalidation, and a controlled promotion API (packet 5)
- Migration/backfill runbook and other-publisher inventory (packet 6)
- Wiring this evaluator into `dispatch_388_pilot` (hold already landed in #2316/#2318; this PR supplies the receipt it can later consume)
- Any production verification run or historical promotion

## Verification

- `ruff check` clean on the two changed files
- `pytest tests/test_source_acceptance.py` — 22 passed
- `pytest tests/test_content_inventory.py` — 7 passed (digest helper unchanged)
- `python3 scripts/test_pipeline.py -q` — 176 tests OK
- `npm run build` skipped (no `src/content/docs/` or Astro config changes)
- 2 files, 198 aggregate lines

## Test plan

1. Read `scripts/quality/source_acceptance.py` against the #2310 comment split (packets 3 schema + 4 validator).
2. Confirm `evaluate_source_acceptance` never reads frontmatter and ignores `citations_verified`.
3. Run `pytest tests/test_source_acceptance.py`.
4. Do not treat a green fixture as factual acceptance of any curriculum page.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b3e7661-8656-481b-ae2e-ed4ed2d43f67?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b3e7661-8656-481b-ae2e-ed4ed2d43f67&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

