### PR TITLE
docs(ai-ml-engineering): repair prereq 1.2–1.4 source honesty (#2512)

### DIFF
--- a/src/content/docs/ai-ml-engineering/prerequisites/module-1.2-home-ai-workstation-fundamentals.md
+++ b/src/content/docs/ai-ml-engineering/prerequisites/module-1.2-home-ai-workstation-fundamentals.md
@@ -26,7 +26,7 @@ By the end of this module, you will be able to:
 
 ## Why This Module Matters
 
-Maya had a capable laptop, a new interest in local AI coding assistants, and a bookmarked shopping cart full of expensive hardware. She believed the purchase would make her learning serious. Then her first month of work turned out to be mostly Python environments, API calls, notebooks, Git workflows, and reading model documentation. The large GPU she almost bought would have sat idle while her real friction came from a crowded system disk and not enough memory for browser-heavy notebooks.
+*(Maya is a hypothetical illustrative learner, not a documented incident.)* Maya had a capable laptop, a new interest in local AI coding assistants, and a bookmarked shopping cart full of expensive hardware. She believed the purchase would make her learning serious. Then her first month of work turned out to be mostly Python environments, API calls, notebooks, Git workflows, and reading model documentation. The large GPU she almost bought would have sat idle while her real friction came from a crowded system disk and not enough memory for browser-heavy notebooks.
 
 That story repeats constantly in AI engineering. People buy for status, benchmark charts, or social media screenshots before they understand their own workload. The result is not just wasted money. It is also wasted attention, because a learner who is fighting heat, noise, driver issues, bad storage layout, and unstable package installs is not learning model behavior, data flow, evaluation, or deployment discipline.
 
@@ -312,7 +312,7 @@ The worst diagnosis is "the machine is bad." That phrase hides the constraint. R
 
 ### 7. Worked Example: Designing A Workstation Plan For A Specific Learner
 
-Jordan is a software developer who wants to spend the next 6 months learning AI engineering at home. Their budget is limited, they already own a recent laptop with moderate RAM, and they are tempted by a single-GPU desktop build. Their planned work is API-first application development for the first month, local embeddings and RAG experiments by month three, and one small LoRA-style fine-tuning experiment near the end of the period.
+*(Jordan is a hypothetical illustrative learner, not a documented incident.)* Jordan is a software developer who wants to spend the next 6 months learning AI engineering at home. Their budget is limited, they already own a recent laptop with moderate RAM, and they are tempted by a single-GPU desktop build. Their planned work is API-first application development for the first month, local embeddings and RAG experiments by month three, and one small LoRA-style fine-tuning experiment near the end of the period.
 
 The first step is to identify what the current laptop can already teach. API-first development, Python packaging, Git workflows, notebooks, prompt evaluation, and basic service design do not require a local GPU. Jordan should not buy a desktop before discovering whether they can maintain clean environments, run notebooks reliably, and structure projects well. Those skills transfer directly to the future desktop.
 

--- a/src/content/docs/ai-ml-engineering/prerequisites/module-1.3-reproducible-python-cuda-rocm-environments.md
+++ b/src/content/docs/ai-ml-engineering/prerequisites/module-1.3-reproducible-python-cuda-rocm-environments.md
@@ -19,7 +19,7 @@ sidebar:
 
 ## Why This Module Matters
 
-Mira joins a small applied AI team on Monday and receives a model repository, a short README, and a message that says, "It should run after installing the requirements." By Tuesday afternoon, one teammate can train on an NVIDIA GPU, another silently falls back to CPU, and Mira's notebook imports a different package version than the command-line script. Nobody has changed the model code, but every person is seeing a different system.
+*(Mira is a hypothetical illustrative learner, not a documented incident.)* Mira joins a small applied AI team on Monday and receives a model repository, a short README, and a message that says, "It should run after installing the requirements." By Tuesday afternoon, one teammate can train on an NVIDIA GPU, another silently falls back to CPU, and Mira's notebook imports a different package version than the command-line script. Nobody has changed the model code, but every person is seeing a different system.
 
 That failure is not a Python trivia problem. It is a systems problem disguised as setup friction. AI projects combine interpreted code, compiled native extensions, hardware drivers, compute runtimes, and framework wheels that were built against specific assumptions. When those assumptions drift, the learner often blames the line of model code they can see, even though the failure was created several layers below it.
 

--- a/src/content/docs/ai-ml-engineering/prerequisites/module-1.4-notebooks-scripts-project-layouts.md
+++ b/src/content/docs/ai-ml-engineering/prerequisites/module-1.4-notebooks-scripts-project-layouts.md
@@ -27,7 +27,7 @@ This module is not about making notebooks look professional. It is about learnin
 
 ## Why This Module Matters
 
-Maya joined a small AI team two weeks before a customer demo. The model already looked promising, the notebook had attractive charts, and everyone believed the hard part was over. Then she tried to rerun the project from a fresh clone.
+*(Maya is a hypothetical illustrative learner, not a documented incident.)* Maya joined a small AI team two weeks before a customer demo. The model already looked promising, the notebook had attractive charts, and everyone believed the hard part was over. Then she tried to rerun the project from a fresh clone.
 
 The first run failed because the notebook expected a local file that was never committed. The second run completed but produced different metrics because one preprocessing cell had been executed days earlier with a slightly different rule. The third run generated a chart, but nobody could tell whether it came from the current model, last week's model, or a manually edited CSV file.
 
@@ -328,7 +328,7 @@ Dependency hygiene is an operational decision before it is a tooling decision. A
 | PDM workflow | `pyproject.toml` managed with `pdm add` and dependency groups | `pdm.lock` records the resolved environment | Best when the team already standardizes on PDM project management |
 | `pip-tools` workflow | `requirements.in`, `pyproject.toml`, or similar input files | compiled `requirements.txt` from `pip-compile` | Best when deployment or platform policy expects pinned requirements files |
 
-The table is not a ranking. It is a warning against mixing ownership. uv documents project dependencies in `pyproject.toml` and project synchronization through its own workflow. PDM documents dependency management through project metadata and groups. pip-tools documents `pip-compile` as the command that compiles pinned requirement output from higher-level dependency inputs. Each approach can be disciplined when the team follows it consistently. Each approach becomes confusing when its generated files are hand-edited by a different workflow. ([uv: Managing Dependencies](https://docs.astral.sh/uv/concepts/projects/dependencies/), [PDM: Manage Dependencies](https://pdm-project.org/latest/usage/dependency/), [pip-tools: pip-compile](https://pip-tools.readthedocs.io/en/stable/cli/pip-compile/))
+The table is not a ranking. It is a warning against mixing ownership. uv documents project dependencies in `pyproject.toml` and project synchronization through its own workflow. PDM documents dependency management through project metadata and groups. pip-tools documents `pip-compile` as the command that compiles pinned requirement output from higher-level dependency inputs. Each approach can be disciplined when the team follows it consistently. Each approach becomes confusing when its generated files are hand-edited by a different workflow. ([uv: Managing Dependencies](https://docs.astral.sh/uv/concepts/projects/dependencies/), [PDM: Manage Dependencies](https://pdm-project.org/latest/usage/dependency/), [pip-tools: pip-compile](https://pip-tools.readthedocs.io/en/stable/reference/pip-compile/))
 
 ```bash
 # uv-owned project
@@ -435,7 +435,7 @@ The training script is source and should be reviewed directly. The generated PNG
 
 ## Worked Example: From Messy Notebook to Structured Project
 
-Now we will transform a small messy notebook into a maintainable project. The goal is not to create a perfect architecture. The goal is to show the decisions, in order, so you can apply the same reasoning to larger AI projects.
+*(Hypothetical teaching example, not a recorded run or a production incident.)* Now we will transform a small messy notebook into a maintainable project. The goal is not to create a perfect architecture. The goal is to show the decisions, in order, so you can apply the same reasoning to larger AI projects.
 
 Assume the notebook started as a quick text-classification experiment. It loads examples, cleans text, creates simple features, calculates a fake score for demonstration, and writes predictions. The whole experiment works only because the author remembers the cell order.
 
@@ -1069,5 +1069,5 @@ Optional later-phase deep-dives (after you complete Phases 1–4):
 - [Python venv](https://docs.python.org/3/library/venv.html) — Documents isolated Python virtual environments and how installed packages are scoped to them.
 - [uv: Managing Dependencies](https://docs.astral.sh/uv/concepts/projects/dependencies/) — Documents uv project dependency management through project metadata and synchronization.
 - [PDM: Manage Dependencies](https://pdm-project.org/latest/usage/dependency/) — Documents PDM dependency management and dependency groups.
-- [pip-tools: pip-compile](https://pip-tools.readthedocs.io/en/stable/cli/pip-compile/) — Documents compiling pinned requirements from dependency input files.
+- [pip-tools: pip-compile](https://pip-tools.readthedocs.io/en/stable/reference/pip-compile/) — Documents compiling pinned requirements from dependency input files.
 - [Git: gitignore](https://git-scm.com/docs/gitignore) — Documents intentionally untracked files and ignore-pattern behavior for generated paths.


### PR DESCRIPTION
## Summary

- Parent workstream #2287; epic #2272; packet issue #2512. This is a source-honesty repair of English AI/ML Engineering prerequisites **1.2 / 1.3 / 1.4**, not a track rewrite.
- Module 1.4 cited `https://pip-tools.readthedocs.io/en/stable/cli/pip-compile/` (live HTTP **404** on 2026-09-10). Replaced both pins with the canonical live page `https://pip-tools.readthedocs.io/en/stable/reference/pip-compile/` (HTTP **200**, pip-tools v7.6.1), which still documents compiling pinned requirements from `requirements.in` / `pyproject.toml`.
- Maya (1.2, 1.4), Jordan (1.2), and Mira (1.3) are named pedagogical learners with **no** Sources locator, date, organization, or incident report. Added explicit hypothetical/illustrative labels. The 1.4 messy-notebook walkthrough is labeled as a hypothetical teaching example (EN already said “fake score for demonstration”). Sourced product/docs names (NVIDIA, Apple, PyPA, uv, PDM) were not relabeled.

UK PRs #2503 / #2505 / #2507 / #2509 / #2511 were **not** edited and must stay OPEN for independent language review.

## Test plan

- [x] `git diff --check` clean
- [x] `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/test_pipeline.py` — 176 tests, 2.214s, OK
- [x] `scripts/check_citations.py` on the three modules — all pass
- [x] Live URL recheck: `/reference/pip-compile/` HTTP 200; `/cli/pip-compile/` remains 404
- [ ] `npm run build` **not run** (AGENTS.md: never build in `.worktrees/*`; primary left clean). CI Astro is the remaining render gate.
- [ ] Independent-family review required before merge. Author family is **xAI Grok**. Do not treat CI green as review.

Diff: **3 files, +7 / −7**. Generated `.pipeline/reviews/test__module-0.1-test.md` left unstaged.


Made with [Cursor](https://cursor.com)