### PR TITLE
feat(agents): add drive-epic skill for dual-repo fleet orchestration (#2274)

### DIFF
--- a/.claude/skills/curriculum-orchestrator/SKILL.md
+++ b/.claude/skills/curriculum-orchestrator/SKILL.md
@@ -156,6 +156,7 @@ Context discipline in the meantime:
 | Sub-skill | When |
 |---|---|
 | [[cold-start]] | Start of every fresh session |
+| [[drive-epic]] | Driving one GitHub epic end-to-end (site + kubedojo-labs) |
 | [[dispatch-router]] | Picking an agent for a task |
 | [[cross-family-reviewer]] | Running R1/R2 reviews on PRs |
 | [[curriculum-writer]] | Author dispatch protocol |

--- a/.claude/skills/drive-epic/SKILL.md
+++ b/.claude/skills/drive-epic/SKILL.md
@@ -95,9 +95,10 @@ free *compatible* lane. Idle free lane + ready item = utilization failure.
 Never manufacture busywork. Disk wins: `df -h` + `git worktree list` before
 fan-out; reap first.
 
-Epic #2272 cap: **at most four active curriculum worktrees** and one local
-generated `dist/` (remove after validation). Labs worktrees live in
+Honor the **active epic's** stated worktree/disk cap (quote it from the
+issue body — do not remember a number). Labs worktrees live in
 `kubedojo-labs/.worktrees/` and count separately — still reap merged ones.
+Remove local `dist/` after validation.
 
 ### 3. Route by activity × live capacity
 
@@ -302,24 +303,25 @@ Copied from the live epic body when driving #2272 — do not weaken it:
 
 English-first scheduling (when the epic says so) does **not** waive
 Ukrainian obligations. Do not introduce UK regressions in shared
-code/routes. Translation volume still uses the UK roster in
-[[dispatch-router]] (deepseek author, RAG calque gates, 2-family review).
+code/routes. Translation volume uses the UK roster in [[dispatch-router]]
+(author + RAG calque gates + required reviewer families — live data).
 
 ---
 
 ## Per-seat delta
 
-Same playbook; only these adjustments. §2c binds every seat.
+Same playbook. Live **model ids and task-class defaults** are
+[[dispatch-router]] + CodexBar — do not freeze them here. §2c binds every seat.
 
-| Seat | Delta |
+| Seat | Constraint that is not a roster pin |
 | --- | --- |
-| **Cursor (this IDE / `auto`)** | Volume workhorse and strong fixer. If **you** are the Cursor driver, do not dispatch `--agent cursor`. Attest `resolved_model` when identity matters for CF. Anti-passive: a CLEAN PR with CF APPROVE is merged the same turn. |
-| **Claude / Fable / Sonnet** | Cheapest Claude *review* is inline. Headless for author lanes or an independent context on the 1–2 hardest reviews. Heavy headless bursts hit the **5-hour window** first. |
-| **Codex / GPT** | Quality-critical author and code review. Weekly cap — skip when CodexBar shows deficit and cooler seats exist. Review always danger + worktree. |
-| **AGY (Google)** | `--agent agy`. Write on Pro-high after re-prove; Flash is search/review only, never code/lab CF. Check **both** Gemini pools (5h and weekly). |
-| **DeepSeek** | Dirt-cheap author/reviewer; ground-check numbers/schemas. Local only. |
-| **Grok** | grok-build = native CLI, code only, feed complete diffs. grok-4.* content = hermes `xai-oauth`. Driver-only if seated: no multi-file heroics. |
-| **GLM / OpenCode** | Local coherence-audit finder. Never CI. |
+| **Cursor** | If **you** are the Cursor driver, do not `dispatch_smart --agent cursor`. Attest `resolved_model` when CF identity matters. A CLEAN PR with CF APPROVE is merged the same turn. |
+| **Claude** | Cheapest Claude *review* is inline. Headless for author lanes or an independent context on the hardest 1–2 reviews. Session (5h) window beats weekly. |
+| **Codex / GPT** | Skip the lane when CodexBar shows deficit and a cooler eligible seat exists. Review always danger + worktree. |
+| **AGY (Google)** | `--agent agy` (gemini-cli retired). Check **both** Gemini pools. Never Flash-class for code/lab CF. Re-prove write on the live write-tier before load-bearing. |
+| **DeepSeek** | Local only (China-host). Ground-check numbers/schemas. |
+| **Grok** | Native grok CLI = code, complete diffs, no file tools. Content-class Grok is a different harness — resolve in dispatch-router. Driver-only if seated: no multi-file heroics. |
+| **GLM / OpenCode** | Local only. Never CI. |
 
 ---
 

--- a/.claude/skills/drive-epic/SKILL.md
+++ b/.claude/skills/drive-epic/SKILL.md
@@ -1,0 +1,343 @@
+---
+name: drive-epic
+description: >-
+  Model-agnostic playbook for driving one KubeDojo GitHub epic end-to-end over
+  dispatch_smart and the local briefing API. Coordinates the curriculum site
+  (kube-dojo/kube-dojo.github.io) with the Killercoda labs sister repo
+  (kube-dojo/kubedojo-labs). Use when launched as an epic driver, told to
+  "drive this epic", or when the user names an epic such as #2272.
+---
+
+# Drive a KubeDojo epic
+
+You are driving **one epic** (for example `#2272`). You are **not** a clerk
+waiting on a single PR, and you are **not** a solo implementer of the whole
+program. Dispatch exists so the fleet does the volume; you own judgment:
+what is next, which family×harness should do it, whether the artifact
+actually worked, and what residual remains.
+
+**Golden rule: this skill teaches method, never the live roster.** Caps,
+models, and who is healthy change. Read them fresh — never from memory:
+
+- `GET http://127.0.0.1:8768/api/orient` and `/api/briefing/session?compact=1`
+- [[dispatch-router]] — activity × lane matrix and `dispatch_smart` commands
+- `codexbar usage --provider both --no-color` (plus `cursor` / `antigravity`)
+  before a wave of 3+ dispatches or any burst to one lane
+
+If a claim (count, SHA, gate, cap, lab pass/fail) is not in fresh tool output,
+**stop and run the tool**.
+
+Sister-repo details (Killercoda layout, G04, hosted vs local evidence):
+[dual-repo.md](dual-repo.md).
+
+---
+
+## The loop (every cycle)
+
+### 0. Orient
+
+```bash
+KUBEDOJO_ISSUE=<N> bash scripts/cold-start.sh   # or omit env for standalone
+curl -sS --max-time 3 "http://127.0.0.1:8768/api/orient"
+curl -sS --max-time 3 "http://127.0.0.1:8768/api/pipeline/leases"
+curl -sS --max-time 3 "http://127.0.0.1:8768/api/git/cleanup"
+```
+
+Know the epic number, both remotes, and the latest `.agent/session-state/`
+handoff (read the file only if briefing leaves a narrative gap). Drain the
+bridge inbox for this seat:
+
+```bash
+.venv/bin/python -m scripts.ai_agent_bridge inbox --for "$SESSION_HANDOFF_AGENT"
+```
+
+(`gemini` is the CLI default; pass the seat that is actually driving.)
+
+### 1. Inventory the epic (binding)
+
+Quote open-child counts from GitHub, not from memory:
+
+```bash
+gh issue view <EPIC> --repo kube-dojo/kube-dojo.github.io
+# children:
+gh api graphql -f query='query($n:Int!){repository(owner:"kube-dojo",name:"kube-dojo.github.io"){issue(number:$n){subIssues(first:50){nodes{number title state}}}}}' -F n=<EPIC>
+gh issue list --repo kube-dojo/kubedojo-labs --state open --limit 30
+gh pr list --repo kube-dojo/kube-dojo.github.io --state open
+gh pr list --repo kube-dojo/kubedojo-labs --state open
+```
+
+**Step 0 of any dispatch:** `gh pr list --state all --search "<issue-nr>"`.
+An open issue ≠ unfixed.
+
+### 2. Dispose every open child
+
+For each open issue, exactly one of:
+
+- **in_flight** — named PR/task id + head SHA
+- **dispatch now** — ROUTING_CARD + capacity evidence
+- **named hold** with one code:
+  `dependency_blocked | authoring_wip_cap | review_wip_cap | ci_capacity |
+  worktree_wip_cap | disk_capacity | human_decision | no_ready_work |
+  needs_operator_go`
+
+Silence is a driver failure. Ending a turn with only "waiting on review/CI"
+and no fill/disposition is forbidden.
+
+**No fabricated done.** Never invent acceptance thresholds. Quote the tool
+residual count before "done"; `residual > 0` requires a next dispatch in the
+same session. Do not close a bilingual issue on EN-only work.
+
+### 2c. No idle paid lanes
+
+Precedence: correctness → safety/resource bounds → critical path →
+utilization. After any dispatch or review ask, **before** holding, fill every
+free *compatible* lane. Idle free lane + ready item = utilization failure.
+Never manufacture busywork. Disk wins: `df -h` + `git worktree list` before
+fan-out; reap first.
+
+Epic #2272 cap: **at most four active curriculum worktrees** and one local
+generated `dist/` (remove after validation). Labs worktrees live in
+`kubedojo-labs/.worktrees/` and count separately — still reap merged ones.
+
+### 3. Route by activity × live capacity
+
+Load [[dispatch-router]]. Then quote CodexBar before picking a seat:
+
+```bash
+codexbar usage --provider both --no-color
+codexbar usage --provider cursor --no-color
+codexbar usage --provider antigravity --no-color
+```
+
+**CAPACITY_CARD** (required in the brief or issue comment):
+`pick=… avoid=… free=… session_window=…`
+
+Rules:
+
+1. Prefer cool + idle + fit. Do **not** habit-route to Codex while
+   `Pace: … deficit` / `will not last to reset` and a cooler seat exists.
+2. **This driver session is a seat.** If you are Cursor, do **not**
+   `dispatch_smart --agent cursor` (deadlock / quota contention). Same for
+   any seat you occupy.
+3. `--agent gemini` is retired — Google lane is **`--agent agy`**.
+4. China-hosted providers (direct DeepSeek, GLM/z.ai) are **local only**;
+   never from GH Actions.
+5. Hard cap **3 parallel rewrites**. Mix families for 3+ parallel reviews.
+6. Warn the operator before 3+ parallel **or** 5+ sequential to one agent
+   in 10 minutes.
+
+### 3-routing. ROUTING_CARD (no card = no dispatch)
+
+Before every implement `dispatch_smart`:
+
+```
+ROUTING_CARD
+issue: #<n>  repo: kube-dojo/<site|labs>
+owned_paths: …
+acceptance_cmd: …
+model_x_harness: <agent> / <task_class> / <model>
+why: …
+alternatives_considered: (≥2)
+capacity: (quoted CodexBar + avoid list)
+parallel_free_seats: …
+```
+
+Default pattern: **advisor/driver briefs → heap/practical worker**. Do not
+spend frontier models on lockfiles, pointer publishes, or smoke jobs.
+
+After ≥3 implement dispatches this session, require ≥2 agents **and** ≥2
+task-classes/tiers, or a written `NOTE: fleet_breadth` with tool-backed
+blockers.
+
+### 4. Dispatch
+
+Workers use **worktrees**, never primary `main`.
+
+Curriculum:
+
+```bash
+git worktree add .worktrees/<name> -b <branch> main
+.venv/bin/python scripts/dispatch_smart.py <search|edit|draft|review|architect> \
+  --agent <lane> --worktree .worktrees/<name> --task-id <id> \
+  --prompt-file - <<'BRIEF'
+… numbered brief …
+BRIEF
+```
+
+Labs (sister repo — different git root):
+
+```bash
+git -C /path/to/kubedojo-labs worktree add .worktrees/<name> -b <branch> main
+# dispatch with cwd = that worktree; do not mix trees in one PR
+```
+
+Brief must be literal-complete: owned paths, acceptance command, budget
+(`<20 files`, default **≤200 aggregate lines** unless the issue sets another
+reviewed budget), "find and fix ALL occurrences of this pattern, not just
+the listed lines", **no auto-merge**, conventional commit + PR.
+
+Codex danger-mode always needs `--worktree`. Content drafts that must not
+SIGKILL: `draft` + `--timeout 3600`. Agy implement/write is danger-mode
+(headless permissions).
+
+Run dispatches in the background; read
+`logs/dispatch_responses/<task-id>.txt` when the wrapper finishes.
+**Do not** `until grep; sleep` watchers. Headless Claude liveness = the
+session JSONL mtime/`tail -1`, not `ps`.
+
+Stagger same-lane spawns ~10s. Drain inbox again immediately before each
+dispatch.
+
+### 5. Settle
+
+Terminal success for `dispatch_smart` is a zero exit **and** a PR URL or
+stated residual. Before declaring a dispatch dead: `gh pr list --state open`,
+then the worktree for finished-but-unpushed work.
+
+This wait is a fill window, not an idle period.
+
+### 6. Cross-family review (discussion ≠ review)
+
+Load [[cross-family-reviewer]]. Review of record is **independent and
+cross-family**, **exact-head**: attested model, `VERDICT: APPROVE` (or
+`NEEDS_CHANGES`), SHA equals current PR head. Post as a **PR comment**
+(do not `gh pr review --approve` — same GitHub identity owns both sides).
+
+```bash
+.venv/bin/python scripts/dispatch_smart.py review --agent <other-family> \
+  --worktree .worktrees/<name> --task-id review-<N> --prompt-file - <<'BRIEF'
+Cross-family review of PR #<N> at head <SHA>. VERDICT + findings.
+BRIEF
+```
+
+Read the review **content**, apply deltas, re-probe gates yourself. If the
+head moves, CF is stale — re-run before merge. Ground-check every finding
+(web-verify volatile facts; `verify_review.py` for quote/line accuracy).
+
+Do **not** use a Gemini Flash-class model as a code/lab reviewer.
+
+### 7. Merge
+
+PRs only. Never commit or merge on primary `main`.
+
+Order:
+
+1. Independent exact-head CF on the current SHA
+2. Required CI green on **that same head**
+3. Then merge (`gh pr merge --rebase` unless the issue/PR says squash)
+
+Never treat `gh pr merge --auto` as a substitute for CF. Blocking CI red →
+never `--admin`. A driver merges **its own lane's** PR after CF+CI; flag
+another lane's PR rather than merging it.
+
+`npm run build` for content/Astro changes runs from the **primary checkout**
+against the intended revision — not inside `.worktrees/` (symlink
+`node_modules` is one level too shallow).
+
+### 7a. Post-merge cleanup (mandatory)
+
+A merge is not done until residue is gone:
+
+1. Confirm merge SHA; close the issue or prove residual on the parent.
+2. Remove the dispatch worktree (`git worktree remove` after processes leave).
+3. Delete the local branch if it remains; `git fetch --prune`;
+   `git worktree prune`.
+4. Prove with `git worktree list` and `df -h`.
+
+Do not merge obsolete drafts merely to clear disk.
+
+### 7-rollout. Local vs hosted proof
+
+| Kind | Driver owns? |
+| --- | --- |
+| Local proof (API smoke, `npm run build`, scenario `test-scenario.sh`) | **Yes** |
+| Billable cloud / AWS / GCP / Azure provisioning | **Only on present-tense operator GO** |
+| Killercoda **hosted interactive** smoke | Record as residual unless platform access exists |
+| Production Pages cutover | CI deploy after merge; do not claim prod HA |
+
+Missing local proof on a user-visible change is incomplete closeout. Issue
+text sets **scope**, not authorization to spend money.
+
+### 8. Handoff
+
+Load [[session-handoff-writer]]. Write a lean Markdown brief to
+`.agent/session-state/YYYY-MM-DD-session-NN-<topic>.md` and update the live
+index `.agent/STATUS.md` (`## TODO` + `## Blockers`). Never commit handoffs.
+
+Drain inbox once more before signalling done.
+
+---
+
+## Dual-repo split (always)
+
+| Concern | Repo | Typical paths |
+| --- | --- | --- |
+| Curriculum prose, routes, site gates | `kube-dojo/kube-dojo.github.io` | `src/content/docs/`, `scripts/quality/`, Astro |
+| Killercoda scenarios | `kube-dojo/kubedojo-labs` | flat `<id>/index.json` + `stepN/` at **repo root** |
+| Lab *buttons* / `lab.url` | main repo | must match `https://killercoda.com/kubedojo/scenario/<id>` |
+| Scenario CI harness | labs `#1` | Ubuntu vs Kubernetes lanes are separate acceptance |
+
+One PR, one repo. Cross-link issue numbers (`#2276` ↔ labs `#2`). File
+presence is not execution acceptance. Hosted Killercoda HTTP 200 ≠ learner
+scenario. See [dual-repo.md](dual-repo.md).
+
+---
+
+## Evidence standard (content-upgrade epics)
+
+Copied from the live epic body when driving #2272 — do not weaken it:
+
+- Load-bearing facts need a locator, verification date, applicability, and
+  uncertainty. A URL is not proof the claim is supported.
+- Never fabricate dialogue, incidents, benchmarks, execution results, or
+  learner feedback.
+- Label synthetic teaching examples. No forced mystery or gamification.
+- Unavailable verification stays incomplete. Preserve good content;
+  retain/revise/expand — no rewrite quota.
+- PR counts are not completion percentages. Distinguish accepted / partial /
+  untouched / evidence-unavailable.
+- Default diff budget: **<20 files, ≤200 aggregate lines**. Coherent lab
+  scenarios need an **explicit per-issue budget** plus reviewer endorsement
+  (a full Killercoda tree will not fit 200 lines).
+
+English-first scheduling (when the epic says so) does **not** waive
+Ukrainian obligations. Do not introduce UK regressions in shared
+code/routes. Translation volume still uses the UK roster in
+[[dispatch-router]] (deepseek author, RAG calque gates, 2-family review).
+
+---
+
+## Per-seat delta
+
+Same playbook; only these adjustments. §2c binds every seat.
+
+| Seat | Delta |
+| --- | --- |
+| **Cursor (this IDE / `auto`)** | Volume workhorse and strong fixer. If **you** are the Cursor driver, do not dispatch `--agent cursor`. Attest `resolved_model` when identity matters for CF. Anti-passive: a CLEAN PR with CF APPROVE is merged the same turn. |
+| **Claude / Fable / Sonnet** | Cheapest Claude *review* is inline. Headless for author lanes or an independent context on the 1–2 hardest reviews. Heavy headless bursts hit the **5-hour window** first. |
+| **Codex / GPT** | Quality-critical author and code review. Weekly cap — skip when CodexBar shows deficit and cooler seats exist. Review always danger + worktree. |
+| **AGY (Google)** | `--agent agy`. Write on Pro-high after re-prove; Flash is search/review only, never code/lab CF. Check **both** Gemini pools (5h and weekly). |
+| **DeepSeek** | Dirt-cheap author/reviewer; ground-check numbers/schemas. Local only. |
+| **Grok** | grok-build = native CLI, code only, feed complete diffs. grok-4.* content = hermes `xai-oauth`. Driver-only if seated: no multi-file heroics. |
+| **GLM / OpenCode** | Local coherence-audit finder. Never CI. |
+
+---
+
+## Escalate — do not decide solo
+
+1. Architecture / process / gate-threshold changes
+2. Contested CF (author vs reviewer, or two reviewers split)
+3. Fragile-fix whose right layer is unclear
+4. Billable infrastructure or production cutover without present-tense GO
+5. Repo-wide safety interruption of another lane (linter/Python-version
+   bumps, generated-state commits, silent gate weakening)
+
+Gates passing is necessary, not sufficient — verify the real artifact
+renders or the scenario `verify.sh` actually runs.
+
+## This skill is NOT
+
+- A replacement for [[dispatch-router]] or [[curriculum-orchestrator]]
+- A single-module writer (use [[curriculum-writer]])
+- Authority to weaken quality gates, skip CF, or push `main`
+- A license to provision AWS/GCP/Azure because a lab page mentions them

--- a/.claude/skills/drive-epic/dual-repo.md
+++ b/.claude/skills/drive-epic/dual-repo.md
@@ -1,0 +1,106 @@
+# Dual-repo: curriculum site + Killercoda labs
+
+KubeDojo has two GitHub repositories. An epic driver treats them as one
+program with two git roots. Never mix trees in one PR.
+
+| | Curriculum | Labs |
+| --- | --- | --- |
+| Remote | `kube-dojo/kube-dojo.github.io` | `kube-dojo/kubedojo-labs` |
+| Local (typical) | this checkout | sibling `../kubedojo-labs` or `$KUBEDOJO_LABS` |
+| Learner surface | https://kube-dojo.github.io/ | https://killercoda.com/kubedojo/scenario/`<id>` |
+| Worktrees | `.worktrees/<name>` | `kubedojo-labs/.worktrees/<name>` |
+| Default line budget | ≤200 / <20 files | **explicit per-issue budget** (a coherent scenario tree exceeds 200 lines; reviewer must endorse) |
+
+Confirm the labs path with `git -C <labs> rev-parse --show-toplevel` before
+dispatch. Do not assume a hard-coded machine path in briefs.
+
+## Layout (labs)
+
+Scenario directories are **flat at the labs repo root**
+(`linux-2.1-namespaces/`, `cka-2.1-pods/`, `prereq-0.8-servers-ssh/`).
+The labs README nested tree is aspirational — do not "fix" it into
+subfolders as part of a content packet.
+
+Each scenario:
+
+```
+<id>/
+  index.json      # title, details (steps), backend image
+  intro.md setup.sh finish.md
+  stepN/text.md  stepN/verify.sh  [stepN/solution.sh]
+```
+
+`verify.sh` must be deterministic. `setup.sh` must be idempotent.
+Universal-user convention: `verify.sh` resolves `USER_HOME` via `id ubuntu`;
+solutions must not hardcode `/root/...` and must `sudo` for privileged
+commands (labs `#15`).
+
+Test locally:
+
+```bash
+# from the labs repo / worktree
+bash scripts/test-scenario.sh <id>
+# or the CI helper
+bash scripts/ci/run-lane.sh
+```
+
+The Ubuntu CI harness is **unprivileged docker** unless labs `#1` has
+landed a privileged lane. Namespace / cgroup / capability scenarios may
+pass locally in a privileged container and still fail the Ubuntu job —
+that is a **labs `#1` residual**, not proof the scenario is wrong. Record
+the class explicitly; do not "fix" by deleting the lab.
+
+## Curriculum ↔ labs URLs
+
+Main-repo frontmatter / buttons:
+
+```yaml
+lab:
+  url: "https://killercoda.com/kubedojo/scenario/<id>"
+```
+
+`scripts/ci/check_lab_urls.py` requires that exact host/path shape. A 200
+on `killercoda.com/playgrounds/scenario/kubernetes` is the **wrong**
+target (generic playground). Slug mismatches (module says `prereq-0.8-servers-ssh`
+while the tree only has `prereq-0.7-servers-ssh`) are G04 inventory work:
+inspect semantic alignment before rewriting links.
+
+`scripts/lab_pipeline.py` in the main repo coordinates receipts; it is
+not a second lab platform. Do not create a replacement for Killercoda.
+
+## Evidence classes (never collapse these)
+
+| Claim | What counts | What does not |
+| --- | --- | --- |
+| Scenario exists | `index.json` at exact id on a revision | README count, local fixture |
+| Local execution | `verify.sh` receipts (root and ubuntu-sudo when required) | Reading `text.md` |
+| CI harness | GitHub Actions on that head, per lane | Ubuntu-only green ≠ Kubernetes acceptance |
+| Hosted publication | Killercoda page shows the real title | git merge, HTTP 200 on a generic playground |
+| Interactive hosted smoke | Operator/platform session that ran the steps | Page publication |
+| Curriculum alignment | Module outcomes ↔ scenario steps + reset + env | URL string match alone |
+
+## Content-upgrade wiring (#2272 / G04)
+
+When driving epic
+[#2272](https://github.com/kube-dojo/kube-dojo.github.io/issues/2272):
+
+- Main **#2276** owns reproducible lab validation **and** Killercoda
+  coordination.
+- Labs **#2** owns the scenario portfolio and exact-path execution packets.
+- Labs **#1** owns automated scenario testing / CI (including a privileged
+  Kubernetes/namespace lane if still missing).
+- English-first scheduling does not close labs `#2` early.
+
+Priority-1 lab work is unsafe or unverified behavior, not "write more
+scenarios." Missing exact ids are packets under labs `#2`; they need
+semantic + deployed evidence, not a manifest tally.
+
+Do **not** provision billable cloud (AWS VPC NAT, public IPv4, …) without
+present-tense operator GO. Record `probe not executed` honestly.
+
+## Hygiene
+
+Reap merged labs worktrees in the labs repo the same way as curriculum
+worktrees. Stale `feat/linux-2.*` trees after merge are disk defects.
+Keep issue comments on **both** #2276 and labs #2 when a packet lands so
+neither board looks idle.

--- a/.claude/skills/drive-epic/dual-repo.md
+++ b/.claude/skills/drive-epic/dual-repo.md
@@ -79,21 +79,24 @@ not a second lab platform. Do not create a replacement for Killercoda.
 | Interactive hosted smoke | Operator/platform session that ran the steps | Page publication |
 | Curriculum alignment | Module outcomes ↔ scenario steps + reset + env | URL string match alone |
 
-## Content-upgrade wiring (#2272 / G04)
+## Discover cross-repo children from the live epic
 
-When driving epic
-[#2272](https://github.com/kube-dojo/kube-dojo.github.io/issues/2272):
+Do not memorize issue numbers. From the epic body + `gh issue list` on
+**both** remotes, record:
 
-- Main **#2276** owns reproducible lab validation **and** Killercoda
-  coordination.
-- Labs **#2** owns the scenario portfolio and exact-path execution packets.
-- Labs **#1** owns automated scenario testing / CI (including a privileged
-  Kubernetes/namespace lane if still missing).
-- English-first scheduling does not close labs `#2` early.
+- which main-repo child owns lab *receipts* / `lab.url` / pipeline
+- which labs-repo issue owns the scenario portfolio
+- which labs-repo issue owns CI / harness lanes
+- any worktree, line-budget, or English-first constraint
 
-Priority-1 lab work is unsafe or unverified behavior, not "write more
-scenarios." Missing exact ids are packets under labs `#2`; they need
-semantic + deployed evidence, not a manifest tally.
+Quote those numbers into the cycle inventory. If the epic and a labs
+issue disagree, the GitHub issue/PR state on each repo is factual SSOT;
+the epic is the priority queue.
+
+Example (content-upgrade #2272 at writing — re-read before relying):
+G04 `#2276` ↔ labs portfolio `#2` ↔ labs CI `#1`. English-first
+scheduling does not close the labs portfolio early. Priority-1 lab work
+is unsafe or unverified behavior, not "write more scenarios."
 
 Do **not** provision billable cloud (AWS VPC NAT, public IPv4, …) without
 present-tense operator GO. Record `probe not executed` honestly.
@@ -101,6 +104,6 @@ present-tense operator GO. Record `probe not executed` honestly.
 ## Hygiene
 
 Reap merged labs worktrees in the labs repo the same way as curriculum
-worktrees. Stale `feat/linux-2.*` trees after merge are disk defects.
-Keep issue comments on **both** #2276 and labs #2 when a packet lands so
+worktrees. Stale scenario feature trees after merge are disk defects.
+Comment the live main-repo *and* labs-repo owners when a packet lands so
 neither board looks idle.

--- a/agents_extensions/README.md
+++ b/agents_extensions/README.md
@@ -14,6 +14,7 @@ agents_extensions/
 │   └── skills/                    # Used by ALL agents (also at dispatch time)
 │       ├── curriculum-writer/
 │       ├── cross-family-reviewer/
+│       ├── drive-epic/                 # epic-driver playbook (site + labs)
 │       ├── module-quality-reviewer/
 │       ├── session-handoff-writer/
 │       ├── k8s-cert-expert/

--- a/agents_extensions/claude/skills/curriculum-orchestrator/SKILL.md
+++ b/agents_extensions/claude/skills/curriculum-orchestrator/SKILL.md
@@ -156,6 +156,7 @@ Context discipline in the meantime:
 | Sub-skill | When |
 |---|---|
 | [[cold-start]] | Start of every fresh session |
+| [[drive-epic]] | Driving one GitHub epic end-to-end (site + kubedojo-labs) |
 | [[dispatch-router]] | Picking an agent for a task |
 | [[cross-family-reviewer]] | Running R1/R2 reviews on PRs |
 | [[curriculum-writer]] | Author dispatch protocol |

--- a/agents_extensions/deploy.sh
+++ b/agents_extensions/deploy.sh
@@ -99,6 +99,25 @@ deploy_skills() {
                 fi
                 changed=$((changed + 1))
             fi
+            # Companion files (reference.md, dual-repo.md, …) stay next to SKILL.md
+            # so relative links in the skill body resolve after deploy.
+            local extra extra_base target_extra
+            for extra in "$skill_dir"*; do
+                [[ -f "$extra" ]] || continue
+                extra_base=$(basename "$extra")
+                [[ "$extra_base" == "SKILL.md" ]] && continue
+                target_extra="$target_skill_dir/$extra_base"
+                if [[ ! -f "$target_extra" ]] || ! cmp -s "$extra" "$target_extra"; then
+                    if [[ "$CHECK" == "true" ]]; then
+                        log "   ✗ DRIFT skills/$skill_name/$extra_base"
+                    else
+                        mkdir -p "$target_skill_dir"
+                        cp "$extra" "$target_extra"
+                        log "   📄 skills/$skill_name/$extra_base"
+                    fi
+                    changed=$((changed + 1))
+                fi
+            done
         fi
     done
     echo "$changed"

--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -95,9 +95,10 @@ free *compatible* lane. Idle free lane + ready item = utilization failure.
 Never manufacture busywork. Disk wins: `df -h` + `git worktree list` before
 fan-out; reap first.
 
-Epic #2272 cap: **at most four active curriculum worktrees** and one local
-generated `dist/` (remove after validation). Labs worktrees live in
+Honor the **active epic's** stated worktree/disk cap (quote it from the
+issue body — do not remember a number). Labs worktrees live in
 `kubedojo-labs/.worktrees/` and count separately — still reap merged ones.
+Remove local `dist/` after validation.
 
 ### 3. Route by activity × live capacity
 
@@ -302,24 +303,25 @@ Copied from the live epic body when driving #2272 — do not weaken it:
 
 English-first scheduling (when the epic says so) does **not** waive
 Ukrainian obligations. Do not introduce UK regressions in shared
-code/routes. Translation volume still uses the UK roster in
-[[dispatch-router]] (deepseek author, RAG calque gates, 2-family review).
+code/routes. Translation volume uses the UK roster in [[dispatch-router]]
+(author + RAG calque gates + required reviewer families — live data).
 
 ---
 
 ## Per-seat delta
 
-Same playbook; only these adjustments. §2c binds every seat.
+Same playbook. Live **model ids and task-class defaults** are
+[[dispatch-router]] + CodexBar — do not freeze them here. §2c binds every seat.
 
-| Seat | Delta |
+| Seat | Constraint that is not a roster pin |
 | --- | --- |
-| **Cursor (this IDE / `auto`)** | Volume workhorse and strong fixer. If **you** are the Cursor driver, do not dispatch `--agent cursor`. Attest `resolved_model` when identity matters for CF. Anti-passive: a CLEAN PR with CF APPROVE is merged the same turn. |
-| **Claude / Fable / Sonnet** | Cheapest Claude *review* is inline. Headless for author lanes or an independent context on the 1–2 hardest reviews. Heavy headless bursts hit the **5-hour window** first. |
-| **Codex / GPT** | Quality-critical author and code review. Weekly cap — skip when CodexBar shows deficit and cooler seats exist. Review always danger + worktree. |
-| **AGY (Google)** | `--agent agy`. Write on Pro-high after re-prove; Flash is search/review only, never code/lab CF. Check **both** Gemini pools (5h and weekly). |
-| **DeepSeek** | Dirt-cheap author/reviewer; ground-check numbers/schemas. Local only. |
-| **Grok** | grok-build = native CLI, code only, feed complete diffs. grok-4.* content = hermes `xai-oauth`. Driver-only if seated: no multi-file heroics. |
-| **GLM / OpenCode** | Local coherence-audit finder. Never CI. |
+| **Cursor** | If **you** are the Cursor driver, do not `dispatch_smart --agent cursor`. Attest `resolved_model` when CF identity matters. A CLEAN PR with CF APPROVE is merged the same turn. |
+| **Claude** | Cheapest Claude *review* is inline. Headless for author lanes or an independent context on the hardest 1–2 reviews. Session (5h) window beats weekly. |
+| **Codex / GPT** | Skip the lane when CodexBar shows deficit and a cooler eligible seat exists. Review always danger + worktree. |
+| **AGY (Google)** | `--agent agy` (gemini-cli retired). Check **both** Gemini pools. Never Flash-class for code/lab CF. Re-prove write on the live write-tier before load-bearing. |
+| **DeepSeek** | Local only (China-host). Ground-check numbers/schemas. |
+| **Grok** | Native grok CLI = code, complete diffs, no file tools. Content-class Grok is a different harness — resolve in dispatch-router. Driver-only if seated: no multi-file heroics. |
+| **GLM / OpenCode** | Local only. Never CI. |
 
 ---
 

--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -1,0 +1,343 @@
+---
+name: drive-epic
+description: >-
+  Model-agnostic playbook for driving one KubeDojo GitHub epic end-to-end over
+  dispatch_smart and the local briefing API. Coordinates the curriculum site
+  (kube-dojo/kube-dojo.github.io) with the Killercoda labs sister repo
+  (kube-dojo/kubedojo-labs). Use when launched as an epic driver, told to
+  "drive this epic", or when the user names an epic such as #2272.
+---
+
+# Drive a KubeDojo epic
+
+You are driving **one epic** (for example `#2272`). You are **not** a clerk
+waiting on a single PR, and you are **not** a solo implementer of the whole
+program. Dispatch exists so the fleet does the volume; you own judgment:
+what is next, which family×harness should do it, whether the artifact
+actually worked, and what residual remains.
+
+**Golden rule: this skill teaches method, never the live roster.** Caps,
+models, and who is healthy change. Read them fresh — never from memory:
+
+- `GET http://127.0.0.1:8768/api/orient` and `/api/briefing/session?compact=1`
+- [[dispatch-router]] — activity × lane matrix and `dispatch_smart` commands
+- `codexbar usage --provider both --no-color` (plus `cursor` / `antigravity`)
+  before a wave of 3+ dispatches or any burst to one lane
+
+If a claim (count, SHA, gate, cap, lab pass/fail) is not in fresh tool output,
+**stop and run the tool**.
+
+Sister-repo details (Killercoda layout, G04, hosted vs local evidence):
+[dual-repo.md](dual-repo.md).
+
+---
+
+## The loop (every cycle)
+
+### 0. Orient
+
+```bash
+KUBEDOJO_ISSUE=<N> bash scripts/cold-start.sh   # or omit env for standalone
+curl -sS --max-time 3 "http://127.0.0.1:8768/api/orient"
+curl -sS --max-time 3 "http://127.0.0.1:8768/api/pipeline/leases"
+curl -sS --max-time 3 "http://127.0.0.1:8768/api/git/cleanup"
+```
+
+Know the epic number, both remotes, and the latest `.agent/session-state/`
+handoff (read the file only if briefing leaves a narrative gap). Drain the
+bridge inbox for this seat:
+
+```bash
+.venv/bin/python -m scripts.ai_agent_bridge inbox --for "$SESSION_HANDOFF_AGENT"
+```
+
+(`gemini` is the CLI default; pass the seat that is actually driving.)
+
+### 1. Inventory the epic (binding)
+
+Quote open-child counts from GitHub, not from memory:
+
+```bash
+gh issue view <EPIC> --repo kube-dojo/kube-dojo.github.io
+# children:
+gh api graphql -f query='query($n:Int!){repository(owner:"kube-dojo",name:"kube-dojo.github.io"){issue(number:$n){subIssues(first:50){nodes{number title state}}}}}' -F n=<EPIC>
+gh issue list --repo kube-dojo/kubedojo-labs --state open --limit 30
+gh pr list --repo kube-dojo/kube-dojo.github.io --state open
+gh pr list --repo kube-dojo/kubedojo-labs --state open
+```
+
+**Step 0 of any dispatch:** `gh pr list --state all --search "<issue-nr>"`.
+An open issue ≠ unfixed.
+
+### 2. Dispose every open child
+
+For each open issue, exactly one of:
+
+- **in_flight** — named PR/task id + head SHA
+- **dispatch now** — ROUTING_CARD + capacity evidence
+- **named hold** with one code:
+  `dependency_blocked | authoring_wip_cap | review_wip_cap | ci_capacity |
+  worktree_wip_cap | disk_capacity | human_decision | no_ready_work |
+  needs_operator_go`
+
+Silence is a driver failure. Ending a turn with only "waiting on review/CI"
+and no fill/disposition is forbidden.
+
+**No fabricated done.** Never invent acceptance thresholds. Quote the tool
+residual count before "done"; `residual > 0` requires a next dispatch in the
+same session. Do not close a bilingual issue on EN-only work.
+
+### 2c. No idle paid lanes
+
+Precedence: correctness → safety/resource bounds → critical path →
+utilization. After any dispatch or review ask, **before** holding, fill every
+free *compatible* lane. Idle free lane + ready item = utilization failure.
+Never manufacture busywork. Disk wins: `df -h` + `git worktree list` before
+fan-out; reap first.
+
+Epic #2272 cap: **at most four active curriculum worktrees** and one local
+generated `dist/` (remove after validation). Labs worktrees live in
+`kubedojo-labs/.worktrees/` and count separately — still reap merged ones.
+
+### 3. Route by activity × live capacity
+
+Load [[dispatch-router]]. Then quote CodexBar before picking a seat:
+
+```bash
+codexbar usage --provider both --no-color
+codexbar usage --provider cursor --no-color
+codexbar usage --provider antigravity --no-color
+```
+
+**CAPACITY_CARD** (required in the brief or issue comment):
+`pick=… avoid=… free=… session_window=…`
+
+Rules:
+
+1. Prefer cool + idle + fit. Do **not** habit-route to Codex while
+   `Pace: … deficit` / `will not last to reset` and a cooler seat exists.
+2. **This driver session is a seat.** If you are Cursor, do **not**
+   `dispatch_smart --agent cursor` (deadlock / quota contention). Same for
+   any seat you occupy.
+3. `--agent gemini` is retired — Google lane is **`--agent agy`**.
+4. China-hosted providers (direct DeepSeek, GLM/z.ai) are **local only**;
+   never from GH Actions.
+5. Hard cap **3 parallel rewrites**. Mix families for 3+ parallel reviews.
+6. Warn the operator before 3+ parallel **or** 5+ sequential to one agent
+   in 10 minutes.
+
+### 3-routing. ROUTING_CARD (no card = no dispatch)
+
+Before every implement `dispatch_smart`:
+
+```
+ROUTING_CARD
+issue: #<n>  repo: kube-dojo/<site|labs>
+owned_paths: …
+acceptance_cmd: …
+model_x_harness: <agent> / <task_class> / <model>
+why: …
+alternatives_considered: (≥2)
+capacity: (quoted CodexBar + avoid list)
+parallel_free_seats: …
+```
+
+Default pattern: **advisor/driver briefs → heap/practical worker**. Do not
+spend frontier models on lockfiles, pointer publishes, or smoke jobs.
+
+After ≥3 implement dispatches this session, require ≥2 agents **and** ≥2
+task-classes/tiers, or a written `NOTE: fleet_breadth` with tool-backed
+blockers.
+
+### 4. Dispatch
+
+Workers use **worktrees**, never primary `main`.
+
+Curriculum:
+
+```bash
+git worktree add .worktrees/<name> -b <branch> main
+.venv/bin/python scripts/dispatch_smart.py <search|edit|draft|review|architect> \
+  --agent <lane> --worktree .worktrees/<name> --task-id <id> \
+  --prompt-file - <<'BRIEF'
+… numbered brief …
+BRIEF
+```
+
+Labs (sister repo — different git root):
+
+```bash
+git -C /path/to/kubedojo-labs worktree add .worktrees/<name> -b <branch> main
+# dispatch with cwd = that worktree; do not mix trees in one PR
+```
+
+Brief must be literal-complete: owned paths, acceptance command, budget
+(`<20 files`, default **≤200 aggregate lines** unless the issue sets another
+reviewed budget), "find and fix ALL occurrences of this pattern, not just
+the listed lines", **no auto-merge**, conventional commit + PR.
+
+Codex danger-mode always needs `--worktree`. Content drafts that must not
+SIGKILL: `draft` + `--timeout 3600`. Agy implement/write is danger-mode
+(headless permissions).
+
+Run dispatches in the background; read
+`logs/dispatch_responses/<task-id>.txt` when the wrapper finishes.
+**Do not** `until grep; sleep` watchers. Headless Claude liveness = the
+session JSONL mtime/`tail -1`, not `ps`.
+
+Stagger same-lane spawns ~10s. Drain inbox again immediately before each
+dispatch.
+
+### 5. Settle
+
+Terminal success for `dispatch_smart` is a zero exit **and** a PR URL or
+stated residual. Before declaring a dispatch dead: `gh pr list --state open`,
+then the worktree for finished-but-unpushed work.
+
+This wait is a fill window, not an idle period.
+
+### 6. Cross-family review (discussion ≠ review)
+
+Load [[cross-family-reviewer]]. Review of record is **independent and
+cross-family**, **exact-head**: attested model, `VERDICT: APPROVE` (or
+`NEEDS_CHANGES`), SHA equals current PR head. Post as a **PR comment**
+(do not `gh pr review --approve` — same GitHub identity owns both sides).
+
+```bash
+.venv/bin/python scripts/dispatch_smart.py review --agent <other-family> \
+  --worktree .worktrees/<name> --task-id review-<N> --prompt-file - <<'BRIEF'
+Cross-family review of PR #<N> at head <SHA>. VERDICT + findings.
+BRIEF
+```
+
+Read the review **content**, apply deltas, re-probe gates yourself. If the
+head moves, CF is stale — re-run before merge. Ground-check every finding
+(web-verify volatile facts; `verify_review.py` for quote/line accuracy).
+
+Do **not** use a Gemini Flash-class model as a code/lab reviewer.
+
+### 7. Merge
+
+PRs only. Never commit or merge on primary `main`.
+
+Order:
+
+1. Independent exact-head CF on the current SHA
+2. Required CI green on **that same head**
+3. Then merge (`gh pr merge --rebase` unless the issue/PR says squash)
+
+Never treat `gh pr merge --auto` as a substitute for CF. Blocking CI red →
+never `--admin`. A driver merges **its own lane's** PR after CF+CI; flag
+another lane's PR rather than merging it.
+
+`npm run build` for content/Astro changes runs from the **primary checkout**
+against the intended revision — not inside `.worktrees/` (symlink
+`node_modules` is one level too shallow).
+
+### 7a. Post-merge cleanup (mandatory)
+
+A merge is not done until residue is gone:
+
+1. Confirm merge SHA; close the issue or prove residual on the parent.
+2. Remove the dispatch worktree (`git worktree remove` after processes leave).
+3. Delete the local branch if it remains; `git fetch --prune`;
+   `git worktree prune`.
+4. Prove with `git worktree list` and `df -h`.
+
+Do not merge obsolete drafts merely to clear disk.
+
+### 7-rollout. Local vs hosted proof
+
+| Kind | Driver owns? |
+| --- | --- |
+| Local proof (API smoke, `npm run build`, scenario `test-scenario.sh`) | **Yes** |
+| Billable cloud / AWS / GCP / Azure provisioning | **Only on present-tense operator GO** |
+| Killercoda **hosted interactive** smoke | Record as residual unless platform access exists |
+| Production Pages cutover | CI deploy after merge; do not claim prod HA |
+
+Missing local proof on a user-visible change is incomplete closeout. Issue
+text sets **scope**, not authorization to spend money.
+
+### 8. Handoff
+
+Load [[session-handoff-writer]]. Write a lean Markdown brief to
+`.agent/session-state/YYYY-MM-DD-session-NN-<topic>.md` and update the live
+index `.agent/STATUS.md` (`## TODO` + `## Blockers`). Never commit handoffs.
+
+Drain inbox once more before signalling done.
+
+---
+
+## Dual-repo split (always)
+
+| Concern | Repo | Typical paths |
+| --- | --- | --- |
+| Curriculum prose, routes, site gates | `kube-dojo/kube-dojo.github.io` | `src/content/docs/`, `scripts/quality/`, Astro |
+| Killercoda scenarios | `kube-dojo/kubedojo-labs` | flat `<id>/index.json` + `stepN/` at **repo root** |
+| Lab *buttons* / `lab.url` | main repo | must match `https://killercoda.com/kubedojo/scenario/<id>` |
+| Scenario CI harness | labs `#1` | Ubuntu vs Kubernetes lanes are separate acceptance |
+
+One PR, one repo. Cross-link issue numbers (`#2276` ↔ labs `#2`). File
+presence is not execution acceptance. Hosted Killercoda HTTP 200 ≠ learner
+scenario. See [dual-repo.md](dual-repo.md).
+
+---
+
+## Evidence standard (content-upgrade epics)
+
+Copied from the live epic body when driving #2272 — do not weaken it:
+
+- Load-bearing facts need a locator, verification date, applicability, and
+  uncertainty. A URL is not proof the claim is supported.
+- Never fabricate dialogue, incidents, benchmarks, execution results, or
+  learner feedback.
+- Label synthetic teaching examples. No forced mystery or gamification.
+- Unavailable verification stays incomplete. Preserve good content;
+  retain/revise/expand — no rewrite quota.
+- PR counts are not completion percentages. Distinguish accepted / partial /
+  untouched / evidence-unavailable.
+- Default diff budget: **<20 files, ≤200 aggregate lines**. Coherent lab
+  scenarios need an **explicit per-issue budget** plus reviewer endorsement
+  (a full Killercoda tree will not fit 200 lines).
+
+English-first scheduling (when the epic says so) does **not** waive
+Ukrainian obligations. Do not introduce UK regressions in shared
+code/routes. Translation volume still uses the UK roster in
+[[dispatch-router]] (deepseek author, RAG calque gates, 2-family review).
+
+---
+
+## Per-seat delta
+
+Same playbook; only these adjustments. §2c binds every seat.
+
+| Seat | Delta |
+| --- | --- |
+| **Cursor (this IDE / `auto`)** | Volume workhorse and strong fixer. If **you** are the Cursor driver, do not dispatch `--agent cursor`. Attest `resolved_model` when identity matters for CF. Anti-passive: a CLEAN PR with CF APPROVE is merged the same turn. |
+| **Claude / Fable / Sonnet** | Cheapest Claude *review* is inline. Headless for author lanes or an independent context on the 1–2 hardest reviews. Heavy headless bursts hit the **5-hour window** first. |
+| **Codex / GPT** | Quality-critical author and code review. Weekly cap — skip when CodexBar shows deficit and cooler seats exist. Review always danger + worktree. |
+| **AGY (Google)** | `--agent agy`. Write on Pro-high after re-prove; Flash is search/review only, never code/lab CF. Check **both** Gemini pools (5h and weekly). |
+| **DeepSeek** | Dirt-cheap author/reviewer; ground-check numbers/schemas. Local only. |
+| **Grok** | grok-build = native CLI, code only, feed complete diffs. grok-4.* content = hermes `xai-oauth`. Driver-only if seated: no multi-file heroics. |
+| **GLM / OpenCode** | Local coherence-audit finder. Never CI. |
+
+---
+
+## Escalate — do not decide solo
+
+1. Architecture / process / gate-threshold changes
+2. Contested CF (author vs reviewer, or two reviewers split)
+3. Fragile-fix whose right layer is unclear
+4. Billable infrastructure or production cutover without present-tense GO
+5. Repo-wide safety interruption of another lane (linter/Python-version
+   bumps, generated-state commits, silent gate weakening)
+
+Gates passing is necessary, not sufficient — verify the real artifact
+renders or the scenario `verify.sh` actually runs.
+
+## This skill is NOT
+
+- A replacement for [[dispatch-router]] or [[curriculum-orchestrator]]
+- A single-module writer (use [[curriculum-writer]])
+- Authority to weaken quality gates, skip CF, or push `main`
+- A license to provision AWS/GCP/Azure because a lab page mentions them

--- a/agents_extensions/shared/skills/drive-epic/dual-repo.md
+++ b/agents_extensions/shared/skills/drive-epic/dual-repo.md
@@ -1,0 +1,106 @@
+# Dual-repo: curriculum site + Killercoda labs
+
+KubeDojo has two GitHub repositories. An epic driver treats them as one
+program with two git roots. Never mix trees in one PR.
+
+| | Curriculum | Labs |
+| --- | --- | --- |
+| Remote | `kube-dojo/kube-dojo.github.io` | `kube-dojo/kubedojo-labs` |
+| Local (typical) | this checkout | sibling `../kubedojo-labs` or `$KUBEDOJO_LABS` |
+| Learner surface | https://kube-dojo.github.io/ | https://killercoda.com/kubedojo/scenario/`<id>` |
+| Worktrees | `.worktrees/<name>` | `kubedojo-labs/.worktrees/<name>` |
+| Default line budget | ≤200 / <20 files | **explicit per-issue budget** (a coherent scenario tree exceeds 200 lines; reviewer must endorse) |
+
+Confirm the labs path with `git -C <labs> rev-parse --show-toplevel` before
+dispatch. Do not assume a hard-coded machine path in briefs.
+
+## Layout (labs)
+
+Scenario directories are **flat at the labs repo root**
+(`linux-2.1-namespaces/`, `cka-2.1-pods/`, `prereq-0.8-servers-ssh/`).
+The labs README nested tree is aspirational — do not "fix" it into
+subfolders as part of a content packet.
+
+Each scenario:
+
+```
+<id>/
+  index.json      # title, details (steps), backend image
+  intro.md setup.sh finish.md
+  stepN/text.md  stepN/verify.sh  [stepN/solution.sh]
+```
+
+`verify.sh` must be deterministic. `setup.sh` must be idempotent.
+Universal-user convention: `verify.sh` resolves `USER_HOME` via `id ubuntu`;
+solutions must not hardcode `/root/...` and must `sudo` for privileged
+commands (labs `#15`).
+
+Test locally:
+
+```bash
+# from the labs repo / worktree
+bash scripts/test-scenario.sh <id>
+# or the CI helper
+bash scripts/ci/run-lane.sh
+```
+
+The Ubuntu CI harness is **unprivileged docker** unless labs `#1` has
+landed a privileged lane. Namespace / cgroup / capability scenarios may
+pass locally in a privileged container and still fail the Ubuntu job —
+that is a **labs `#1` residual**, not proof the scenario is wrong. Record
+the class explicitly; do not "fix" by deleting the lab.
+
+## Curriculum ↔ labs URLs
+
+Main-repo frontmatter / buttons:
+
+```yaml
+lab:
+  url: "https://killercoda.com/kubedojo/scenario/<id>"
+```
+
+`scripts/ci/check_lab_urls.py` requires that exact host/path shape. A 200
+on `killercoda.com/playgrounds/scenario/kubernetes` is the **wrong**
+target (generic playground). Slug mismatches (module says `prereq-0.8-servers-ssh`
+while the tree only has `prereq-0.7-servers-ssh`) are G04 inventory work:
+inspect semantic alignment before rewriting links.
+
+`scripts/lab_pipeline.py` in the main repo coordinates receipts; it is
+not a second lab platform. Do not create a replacement for Killercoda.
+
+## Evidence classes (never collapse these)
+
+| Claim | What counts | What does not |
+| --- | --- | --- |
+| Scenario exists | `index.json` at exact id on a revision | README count, local fixture |
+| Local execution | `verify.sh` receipts (root and ubuntu-sudo when required) | Reading `text.md` |
+| CI harness | GitHub Actions on that head, per lane | Ubuntu-only green ≠ Kubernetes acceptance |
+| Hosted publication | Killercoda page shows the real title | git merge, HTTP 200 on a generic playground |
+| Interactive hosted smoke | Operator/platform session that ran the steps | Page publication |
+| Curriculum alignment | Module outcomes ↔ scenario steps + reset + env | URL string match alone |
+
+## Content-upgrade wiring (#2272 / G04)
+
+When driving epic
+[#2272](https://github.com/kube-dojo/kube-dojo.github.io/issues/2272):
+
+- Main **#2276** owns reproducible lab validation **and** Killercoda
+  coordination.
+- Labs **#2** owns the scenario portfolio and exact-path execution packets.
+- Labs **#1** owns automated scenario testing / CI (including a privileged
+  Kubernetes/namespace lane if still missing).
+- English-first scheduling does not close labs `#2` early.
+
+Priority-1 lab work is unsafe or unverified behavior, not "write more
+scenarios." Missing exact ids are packets under labs `#2`; they need
+semantic + deployed evidence, not a manifest tally.
+
+Do **not** provision billable cloud (AWS VPC NAT, public IPv4, …) without
+present-tense operator GO. Record `probe not executed` honestly.
+
+## Hygiene
+
+Reap merged labs worktrees in the labs repo the same way as curriculum
+worktrees. Stale `feat/linux-2.*` trees after merge are disk defects.
+Keep issue comments on **both** #2276 and labs #2 when a packet lands so
+neither board looks idle.

--- a/agents_extensions/shared/skills/drive-epic/dual-repo.md
+++ b/agents_extensions/shared/skills/drive-epic/dual-repo.md
@@ -79,21 +79,24 @@ not a second lab platform. Do not create a replacement for Killercoda.
 | Interactive hosted smoke | Operator/platform session that ran the steps | Page publication |
 | Curriculum alignment | Module outcomes ↔ scenario steps + reset + env | URL string match alone |
 
-## Content-upgrade wiring (#2272 / G04)
+## Discover cross-repo children from the live epic
 
-When driving epic
-[#2272](https://github.com/kube-dojo/kube-dojo.github.io/issues/2272):
+Do not memorize issue numbers. From the epic body + `gh issue list` on
+**both** remotes, record:
 
-- Main **#2276** owns reproducible lab validation **and** Killercoda
-  coordination.
-- Labs **#2** owns the scenario portfolio and exact-path execution packets.
-- Labs **#1** owns automated scenario testing / CI (including a privileged
-  Kubernetes/namespace lane if still missing).
-- English-first scheduling does not close labs `#2` early.
+- which main-repo child owns lab *receipts* / `lab.url` / pipeline
+- which labs-repo issue owns the scenario portfolio
+- which labs-repo issue owns CI / harness lanes
+- any worktree, line-budget, or English-first constraint
 
-Priority-1 lab work is unsafe or unverified behavior, not "write more
-scenarios." Missing exact ids are packets under labs `#2`; they need
-semantic + deployed evidence, not a manifest tally.
+Quote those numbers into the cycle inventory. If the epic and a labs
+issue disagree, the GitHub issue/PR state on each repo is factual SSOT;
+the epic is the priority queue.
+
+Example (content-upgrade #2272 at writing — re-read before relying):
+G04 `#2276` ↔ labs portfolio `#2` ↔ labs CI `#1`. English-first
+scheduling does not close the labs portfolio early. Priority-1 lab work
+is unsafe or unverified behavior, not "write more scenarios."
 
 Do **not** provision billable cloud (AWS VPC NAT, public IPv4, …) without
 present-tense operator GO. Record `probe not executed` honestly.
@@ -101,6 +104,6 @@ present-tense operator GO. Record `probe not executed` honestly.
 ## Hygiene
 
 Reap merged labs worktrees in the labs repo the same way as curriculum
-worktrees. Stale `feat/linux-2.*` trees after merge are disk defects.
-Keep issue comments on **both** #2276 and labs #2 when a packet lands so
+worktrees. Stale scenario feature trees after merge are disk defects.
+Comment the live main-repo *and* labs-repo owners when a packet lands so
 neither board looks idle.

--- a/scripts/quality/test_deploy_check.sh
+++ b/scripts/quality/test_deploy_check.sh
@@ -60,6 +60,15 @@ rm -f "$TMP/.claude/hooks/standalone.sh"
 # 7. missing deployed copy → exit 1
 rm -f "$TMP/.claude/skills/demo/SKILL.md"
 run_check && bad "missing deployed should exit 1" || ok "missing deployed → exit 1"
+printf 'hello\n' > "$TMP/.claude/skills/demo/SKILL.md"
+
+# 8. companion markdown next to SKILL.md is copied and drift-checked
+printf 'ref\n' > "$TMP/agents_extensions/claude/skills/demo/dual-repo.md"
+redeploy
+[ -f "$TMP/.claude/skills/demo/dual-repo.md" ] && ok "companion file deployed" || bad "companion file not copied"
+printf 'drift\n' >> "$TMP/.claude/skills/demo/dual-repo.md"
+run_check && bad "companion drift should exit 1" || ok "companion drift → exit 1"
+redeploy; run_check && ok "deploy re-syncs companion → exit 0" || bad "deploy did not re-sync companion"
 
 if [ "$fail" -ne 0 ]; then echo "[deploy-check-test] FAIL"; exit 1; fi
 echo "[deploy-check-test] PASS"


### PR DESCRIPTION
## Summary
- Adds a KubeDojo `drive-epic` skill (learn-ukrainian playbook, this repo's APIs): orient → inventory → capacity-first `dispatch_smart` → exact-head cross-family review → merge → handoff.
- Documents the curriculum ↔ `kube-dojo/kubedojo-labs` split (flat Killercoda scenarios, evidence classes, no billable cloud without GO).
- Deploy copies companion skill files; regression coverage in `test_deploy_check.sh`.

Refs #2274 (writer/reviewer tooling) and the #2272 driver loop.

## Test plan
- [x] `bash scripts/quality/test_deploy_check.sh` PASS (including new companion-file cases)
- [x] `bash agents_extensions/deploy.sh --check --target claude` after deploy
- [ ] Cross-family review on this exact head (not Cursor/Grok)
- [ ] Confirm relative `dual-repo.md` link resolves in `.claude/skills/drive-epic/`


Made with [Cursor](https://cursor.com)