### PR TITLE
feat(quality): consume markdown links via canonical resolver (#2346)

### DIFF
--- a/scripts/quality/markdown-link-consumer.mjs
+++ b/scripts/quality/markdown-link-consumer.mjs
@@ -1,0 +1,112 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { parseArgs } from 'node:util';
+import { resolveRoute, UnsupportedRoute } from './route-resolver.mjs';
+import { buildDocumentRouteSet } from './document-route-set.mjs';
+
+const SOURCE_PREFIX = 'src/content/docs/';
+
+export function extractLinks(content) {
+  const links = [];
+  const lines = content.split('\n');
+  const linkRegex = /\[(?:[^\]\\]|\\.)*\]\(\s*([^)\s]+)(?:\s+"[^"]*")?\s*\)/g;
+  for (let i = 0; i < lines.length; i++) {
+    let match;
+    while ((match = linkRegex.exec(lines[i])) !== null) {
+      links.push({ href: match[1], line: i + 1 });
+    }
+  }
+  return links;
+}
+
+export function consumeMarkdownLinks(manifest, docsRoot) {
+  const routeSet = buildDocumentRouteSet(manifest);
+  const fallbackPaths = new Set(routeSet.fallbacks.map(f => f.pathname));
+  
+  const files = [];
+  function walk(dir) {
+    if (!fs.existsSync(dir)) return;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(fullPath);
+      else if (entry.isFile() && /\.(md|mdx)$/i.test(entry.name)) files.push(fullPath);
+    }
+  }
+  walk(docsRoot);
+  
+  const report = [];
+  
+  for (const file of files) {
+    const relativeToDocs = path.relative(docsRoot, file).split(path.sep).join('/');
+    const source = SOURCE_PREFIX + relativeToDocs;
+    
+    const primary = routeSet.primaryBySource.get(source);
+    if (!primary) continue;
+    
+    const content = fs.readFileSync(file, 'utf8');
+    const links = extractLinks(content);
+    
+    for (const { href, line } of links) {
+      let target = null;
+      let disposition = '';
+      
+      if (href.startsWith('#')) {
+        disposition = 'fragment-only';
+        target = new URL(href, primary.url).href;
+      } else {
+        try {
+          const resolved = resolveRoute(href, primary.url, routeSet.origin, routeSet.targetPaths);
+          target = resolved.url;
+          if (resolved.kind === 'external-http' || resolved.kind === 'mailto') {
+            disposition = 'external';
+          } else if (resolved.routeExists) {
+            disposition = fallbackPaths.has(resolved.path) ? 'present-fallback' : 'present';
+          } else {
+            disposition = 'missing';
+          }
+        } catch (error) {
+          if (error instanceof UnsupportedRoute) {
+            disposition = 'unsupported';
+          } else {
+            throw error;
+          }
+        }
+      }
+      
+      report.push({
+        source,
+        line,
+        href,
+        target,
+        disposition
+      });
+    }
+  }
+  return report;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const { values, positionals } = parseArgs({
+    options: {
+      output: { type: 'string', default: '.agent/markdown-links.json' },
+    },
+    allowPositionals: true,
+  });
+  
+  const manifestPath = positionals[0];
+  if (!manifestPath) {
+    console.error('Usage: node markdown-link-consumer.mjs <manifest.json> [--output path]');
+    process.exit(1);
+  }
+  
+  const manifestRaw = fs.readFileSync(manifestPath, 'utf8');
+  const manifest = JSON.parse(manifestRaw);
+  
+  const docsRoot = path.resolve(process.cwd(), 'src/content/docs');
+  
+  const report = consumeMarkdownLinks(manifest, docsRoot);
+  
+  fs.mkdirSync(path.dirname(values.output), { recursive: true });
+  fs.writeFileSync(values.output, JSON.stringify(report, null, 2), 'utf8');
+  console.log(`Wrote ${report.length} links to ${values.output}`);
+}

--- a/scripts/quality/markdown-link-consumer.mjs
+++ b/scripts/quality/markdown-link-consumer.mjs
@@ -10,9 +10,18 @@ export function extractLinks(content) {
   const links = [];
   const lines = content.split('\n');
   const linkRegex = /\[(?:[^\]\\]|\\.)*\]\(\s*([^)\s]+)(?:\s+"[^"]*")?\s*\)/g;
+  let inFencedBlock = false;
   for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim().startsWith('```')) {
+      inFencedBlock = !inFencedBlock;
+      continue;
+    }
+    if (inFencedBlock) continue;
+    
+    let processedLine = line.replace(/`[^`]*`/g, '');
     let match;
-    while ((match = linkRegex.exec(lines[i])) !== null) {
+    while ((match = linkRegex.exec(processedLine)) !== null) {
       links.push({ href: match[1], line: i + 1 });
     }
   }
@@ -35,6 +44,7 @@ export function consumeMarkdownLinks(manifest, docsRoot) {
   walk(docsRoot);
   
   const report = [];
+  const memo = new Map();
   
   for (const file of files) {
     const relativeToDocs = path.relative(docsRoot, file).split(path.sep).join('/');
@@ -54,22 +64,30 @@ export function consumeMarkdownLinks(manifest, docsRoot) {
         disposition = 'fragment-only';
         target = new URL(href, primary.url).href;
       } else {
-        try {
-          const resolved = resolveRoute(href, primary.url, routeSet.origin, routeSet.targetPaths);
-          target = resolved.url;
-          if (resolved.kind === 'external-http' || resolved.kind === 'mailto') {
-            disposition = 'external';
-          } else if (resolved.routeExists) {
-            disposition = fallbackPaths.has(resolved.path) ? 'present-fallback' : 'present';
-          } else {
-            disposition = 'missing';
+        const memoKey = `${href}::${primary.url}`;
+        if (memo.has(memoKey)) {
+          const res = memo.get(memoKey);
+          target = res.target;
+          disposition = res.disposition;
+        } else {
+          try {
+            const resolved = resolveRoute(href, primary.url, routeSet.origin, routeSet.targetPaths);
+            target = resolved.url;
+            if (resolved.kind === 'external-http' || resolved.kind === 'mailto') {
+              disposition = 'external';
+            } else if (resolved.routeExists) {
+              disposition = fallbackPaths.has(resolved.path) ? 'present-fallback' : 'present';
+            } else {
+              disposition = 'missing';
+            }
+          } catch (error) {
+            if (error instanceof UnsupportedRoute) {
+              disposition = 'unsupported';
+            } else {
+              throw error;
+            }
           }
-        } catch (error) {
-          if (error instanceof UnsupportedRoute) {
-            disposition = 'unsupported';
-          } else {
-            throw error;
-          }
+          memo.set(memoKey, { target, disposition });
         }
       }
       

--- a/scripts/quality/markdown-link-consumer.test.mjs
+++ b/scripts/quality/markdown-link-consumer.test.mjs
@@ -58,6 +58,16 @@ test('consumeMarkdownLinks handles various fixtures', (t) => {
         isFallback: true,
         locale: 'uk',
         lang: 'uk'
+      },
+      {
+        id: 'uk/module-c.md',
+        url: 'https://site.test/uk/module-c/',
+        pathname: '/uk/module-c/',
+        source: 'src/content/docs/uk/module-c.md',
+        sourceSha256: 'c'.repeat(64),
+        isFallback: false,
+        locale: 'uk',
+        lang: 'uk'
       }
     ]
   };
@@ -71,6 +81,9 @@ test('consumeMarkdownLinks handles various fixtures', (t) => {
 [root-relative](/dir1/module-b/)
 [fragment](#section)
 [unsupported form](ftp://invalid)
+\`\`\`
+[fenced link](/should/not/exist)
+\`\`\`
   `;
   
   fs.mkdirSync(path.join(tmpdir, 'dir1'), { recursive: true });
@@ -80,6 +93,9 @@ test('consumeMarkdownLinks handles various fixtures', (t) => {
   
   fs.mkdirSync(path.join(tmpdir, 'uk/dir1'), { recursive: true });
   fs.writeFileSync(path.join(tmpdir, 'uk/dir1/module-b.md'), 'uk b content');
+  
+  fs.mkdirSync(path.join(tmpdir, 'uk'), { recursive: true });
+  fs.writeFileSync(path.join(tmpdir, 'uk/module-c.md'), '[UK Source internal](../../dir1/module-a/)');
   
   const report = consumeMarkdownLinks(manifest, tmpdir);
   fs.rmSync(tmpdir, { recursive: true, force: true });
@@ -117,4 +133,12 @@ test('consumeMarkdownLinks handles various fixtures', (t) => {
   const unsupported = findReport('unsupported form');
   assert.equal(unsupported.disposition, 'unsupported');
   assert.equal(unsupported.target, null);
+
+  const fencedLink = report.find(r => r.href === '/should/not/exist');
+  assert.ok(!fencedLink, 'Fenced link should not appear in the report');
+
+  const ukSourceInternal = report.find(r => r.source === 'src/content/docs/uk/module-c.md' && r.href === '../../dir1/module-a/');
+  assert.ok(ukSourceInternal, 'UK Source link not found');
+  assert.equal(ukSourceInternal.disposition, 'present');
+  assert.equal(ukSourceInternal.target, 'https://site.test/dir1/module-a/');
 });

--- a/scripts/quality/markdown-link-consumer.test.mjs
+++ b/scripts/quality/markdown-link-consumer.test.mjs
@@ -1,0 +1,120 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { consumeMarkdownLinks } from './markdown-link-consumer.mjs';
+
+test('consumeMarkdownLinks handles various fixtures', (t) => {
+  const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'md-links-test-'));
+  
+  const manifest = {
+    schemaVersion: 1,
+    scope: 'starlight-document-routes',
+    config: {
+      site: 'https://site.test',
+      base: '/',
+      trailingSlash: 'always',
+      buildFormat: 'directory'
+    },
+    redirects: [],
+    routes: [
+      {
+        id: 'dir1/module-a.md',
+        url: 'https://site.test/dir1/module-a/',
+        pathname: '/dir1/module-a/',
+        source: 'src/content/docs/dir1/module-a.md',
+        sourceSha256: 'a'.repeat(64),
+        isFallback: false,
+        locale: 'en',
+        lang: 'en'
+      },
+      {
+        id: 'dir1/module-b.md',
+        url: 'https://site.test/dir1/module-b/',
+        pathname: '/dir1/module-b/',
+        source: 'src/content/docs/dir1/module-b.md',
+        sourceSha256: 'b'.repeat(64),
+        isFallback: false,
+        locale: 'en',
+        lang: 'en'
+      },
+      {
+        id: 'index.md',
+        url: 'https://site.test/',
+        pathname: '/',
+        source: 'src/content/docs/index.md',
+        sourceSha256: 'c'.repeat(64),
+        isFallback: false,
+        locale: 'en',
+        lang: 'en'
+      },
+      {
+        id: 'uk/dir1/module-b.md',
+        url: 'https://site.test/uk/dir1/module-b/',
+        pathname: '/uk/dir1/module-b/',
+        source: 'src/content/docs/dir1/module-b.md',
+        sourceSha256: 'b'.repeat(64),
+        isFallback: true,
+        locale: 'uk',
+        lang: 'uk'
+      }
+    ]
+  };
+
+  const mdContent = `
+[broken sibling](./module-b/)
+[correct sibling](../module-b/)
+[UK relative](../../uk/dir1/module-b/)
+[index](../../)
+[explicit slug](/dir1/module-b/)
+[root-relative](/dir1/module-b/)
+[fragment](#section)
+[unsupported form](ftp://invalid)
+  `;
+  
+  fs.mkdirSync(path.join(tmpdir, 'dir1'), { recursive: true });
+  fs.writeFileSync(path.join(tmpdir, 'dir1/module-a.md'), mdContent);
+  fs.writeFileSync(path.join(tmpdir, 'dir1/module-b.md'), 'b content');
+  fs.writeFileSync(path.join(tmpdir, 'index.md'), 'index content');
+  
+  fs.mkdirSync(path.join(tmpdir, 'uk/dir1'), { recursive: true });
+  fs.writeFileSync(path.join(tmpdir, 'uk/dir1/module-b.md'), 'uk b content');
+  
+  const report = consumeMarkdownLinks(manifest, tmpdir);
+  fs.rmSync(tmpdir, { recursive: true, force: true });
+  
+  const findReport = (text) => report.find(r => r.href === text || mdContent.split('\n')[r.line - 1].includes(text));
+
+  const brokenSibling = findReport('broken sibling');
+  assert.equal(brokenSibling.disposition, 'missing', 'Wrong sibling false-pass reported as missing');
+  assert.equal(brokenSibling.target, 'https://site.test/dir1/module-a/module-b/');
+
+  const correctSibling = findReport('correct sibling');
+  assert.equal(correctSibling.disposition, 'present');
+  assert.equal(correctSibling.target, 'https://site.test/dir1/module-b/');
+
+  const ukRelative = findReport('UK relative');
+  assert.equal(ukRelative.disposition, 'present-fallback');
+  assert.equal(ukRelative.target, 'https://site.test/uk/dir1/module-b/');
+
+  const indexPage = findReport('index');
+  assert.equal(indexPage.disposition, 'present');
+  assert.equal(indexPage.target, 'https://site.test/');
+
+  const explicitSlug = findReport('explicit slug');
+  assert.equal(explicitSlug.disposition, 'present');
+  assert.equal(explicitSlug.target, 'https://site.test/dir1/module-b/');
+
+  const rootRelative = findReport('root-relative');
+  assert.equal(rootRelative.disposition, 'present');
+  assert.equal(rootRelative.target, 'https://site.test/dir1/module-b/');
+
+  const fragment = findReport('fragment');
+  assert.equal(fragment.disposition, 'fragment-only');
+  assert.equal(fragment.target, 'https://site.test/dir1/module-a/#section');
+
+  const unsupported = findReport('unsupported form');
+  assert.equal(unsupported.disposition, 'unsupported');
+  assert.equal(unsupported.target, null);
+});


### PR DESCRIPTION
Adds a markdown-link consumer script that extracts internal markdown hrefs, resolves them against a given manifest, and emits a revision-bound JSON report. Includes `node --test` fixtures for missing, sibling, fallback, UK-as-source, and fenced-code omission cases. (actual +274 lines).