### PR TITLE
feat(agents): thin --epic N launcher bind for drive-epic (#2274)

### DIFF
--- a/.claude/agents/epic-driver.md
+++ b/.claude/agents/epic-driver.md
@@ -1,0 +1,55 @@
+---
+name: epic-driver
+description: >-
+  Drive one GitHub epic end-to-end via the drive-epic skill and the fleet
+  (dispatch_smart). Not the default curriculum queue and not the infra lane.
+  Started with ./start-claude.sh --epic N (or SESSION_EPIC=N).
+tools: "*"
+model: inherit
+initialPrompt: |
+  You are an epic driver. SESSION_EPIC / KUBEDOJO_ISSUE name the epic number.
+  Orient before anything else: Read the drive-epic skill
+  (agents_extensions/shared/skills/drive-epic/SKILL.md), then run
+  `KUBEDOJO_ISSUE=$SESSION_EPIC bash scripts/cold-start.sh` (or --issue).
+  Before any dispatch: CodexBar capacity (`codexbar usage --provider both
+  --no-color`) → CAPACITY_CARD. Drive that epic via the fleet — inventory both
+  remotes, dispatch_smart in worktrees, exact-head CF as PR comments, merge when
+  CI matches the reviewed SHA. Do not solo volume work; do not fall into the
+  default UK curriculum DO-NEXT. State the epic and first action in one line,
+  then proceed.
+---
+
+# KubeDojo Epic Driver
+
+You drive **one** GitHub epic (for example `#2272`). Load and follow
+[[drive-epic]]. Sister labs repo: `kube-dojo/kubedojo-labs` (see
+`drive-epic/dual-repo.md`).
+
+## Launch
+
+```bash
+./start-claude.sh --epic <N>
+./start-codex.sh --epic <N>
+./start-cursor-driver.sh --epic <N>
+```
+
+Exports `SESSION_EPIC` + `KUBEDOJO_ISSUE`. SessionStart emits an epic-driver
+packet instead of the default curriculum UK DO-NEXT.
+
+## In scope
+
+- Inventory, disposition, capacity routing, fleet dispatch, CF, merge, handoff
+  for the named epic and its children (site + labs).
+- Worktrees under `.worktrees/`; never branch on primary `main`.
+
+## Out of scope
+
+- Default curriculum queue / UK volume unless that work is an epic child.
+- Infra-only tooling (hand to `./start-claude.sh --agent infra-orchestrator`)
+  unless the epic is itself an infra epic.
+
+## Capacity (load-bearing)
+
+Always CodexBar before a wave. Prefer cool idle seats. Never habit-route Codex
+on pace deficit. If **you** are the Cursor seat, do not `dispatch_smart
+--agent cursor`.

--- a/.claude/agents/infra-orchestrator.md
+++ b/.claude/agents/infra-orchestrator.md
@@ -27,7 +27,8 @@ work to the default lane and vice versa.
 - `.claude/hooks/**` and their source in `agents_extensions/claude/hooks/**`
   (deployed via `agents_extensions/deploy.sh`).
 - `agents_extensions/**` — skills, agents, commands, statusline, `deploy.sh`.
-- Launchers: `start-claude.sh`, `start-codex.sh`, `start-docs.sh`.
+- Launchers: `start-claude.sh` (`--epic N` → epic-driver), `start-codex.sh`
+  (`--epic N`), `start-cursor-driver.sh` (`--epic N`), `start-docs.sh`.
 - CI: `.github/workflows/**`, `.github/actions/**`, `dependabot.yml`, `zizmor.yml`.
 - Agent-runtime plumbing, handoff identity, the briefing/orientation system.
 

--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -107,15 +107,26 @@ fi
 # briefing) but EXTRACT only a compact summary — never inline the whole dump.
 # Outer timeout so a slow/down API can't hang session start; on failure the
 # extractor falls back to a "run cold-start yourself" directive.
+# When SESSION_EPIC / KUBEDOJO_ISSUE is set (./start-*.sh --epic N), pass the
+# issue into cold-start so the epic bind is visible in the dump.
 COLDSTART_BIN="$PROJECT_DIR/scripts/cold-start.sh"
 COLDSTART_OUT=""
+EPIC_NUM="${SESSION_EPIC:-${KUBEDOJO_ISSUE:-}}"
+if [ -n "$EPIC_NUM" ]; then
+  export KUBEDOJO_ISSUE="$EPIC_NUM"
+  export SESSION_EPIC="$EPIC_NUM"
+fi
 if [ -f "$COLDSTART_BIN" ]; then
+  COLDSTART_ARGS=()
+  if [ -n "$EPIC_NUM" ]; then
+    COLDSTART_ARGS=(--issue "$EPIC_NUM")
+  fi
   if command -v timeout >/dev/null 2>&1; then
-    COLDSTART_OUT=$(timeout 30 bash "$COLDSTART_BIN" 2>/dev/null || true)
+    COLDSTART_OUT=$(timeout 30 bash "$COLDSTART_BIN" "${COLDSTART_ARGS[@]}" 2>/dev/null || true)
   elif command -v gtimeout >/dev/null 2>&1; then
-    COLDSTART_OUT=$(gtimeout 30 bash "$COLDSTART_BIN" 2>/dev/null || true)
+    COLDSTART_OUT=$(gtimeout 30 bash "$COLDSTART_BIN" "${COLDSTART_ARGS[@]}" 2>/dev/null || true)
   else
-    COLDSTART_OUT=$(bash "$COLDSTART_BIN" 2>/dev/null || true)
+    COLDSTART_OUT=$(bash "$COLDSTART_BIN" "${COLDSTART_ARGS[@]}" 2>/dev/null || true)
   fi
 fi
 
@@ -180,15 +191,43 @@ if [ -z "$ORIENT_BODY" ]; then
   ORIENT_BODY="(cold-start produced no briefing — RUN IT YOURSELF NOW as your first action: bash scripts/cold-start.sh, then act on its DO-NEXT focus item.)"
 fi
 
-# ============================================================================
+# =============================================================================
 # LANE SELECTION — SESSION_HANDOFF_AGENT (exported by start-claude.sh from the
 # selected --agent; see scripts/lib/handoff_identity.sh) routes the orientation
 # identity + handoff slot. cold-start ran ABOVE for BOTH lanes, so the infra
 # lane still orients via the API even on its FIRST session (no handoff file
-# yet). The DEFAULT (curriculum) lane keeps its exact original CONTEXT, byte for
-# byte. Additive only — #2113 (learn-ukrainian parity).
-# ============================================================================
-if [ "${SESSION_HANDOFF_AGENT:-}" = "claude-infra" ]; then
+# yet). SESSION_EPIC / KUBEDOJO_ISSUE (./start-*.sh --epic N) selects the
+# epic-driver packet and OVERRIDES the default curriculum UK DO-NEXT.
+# The DEFAULT (curriculum) lane keeps its exact original CONTEXT when no epic
+# is bound. Additive — #2113 (learn-ukrainian parity) + thin --epic bind.
+# =============================================================================
+if [ -n "${EPIC_NUM:-}" ]; then
+  EPIC_HANDOFF="$PROJECT_DIR/.agent/claude-epic-thread-handoff.md"
+  if [ -f "$EPIC_HANDOFF" ]; then
+    EPIC_LEAD="PREVIOUS-SESSION EPIC HANDOFF — read this FIRST if it matches epic #${EPIC_NUM}:
+  Read: $EPIC_HANDOFF
+(gitignored local thread state; never committed. Write the next handoff to this same path at session end.)"
+  else
+    EPIC_LEAD="No epic-lane handoff yet (.agent/claude-epic-thread-handoff.md absent). Orient via cold-start + drive-epic."
+  fi
+  CONTEXT="EPIC-DRIVER SESSION — auto-oriented by the SessionStart hook. You ARE driving GitHub epic #${EPIC_NUM} (SESSION_EPIC=${EPIC_NUM}). You are NOT the default curriculum UK-volume queue and NOT the infra lane unless this epic is infra.
+
+Load-bearing discipline (do NOT violate):
+  - Read and follow the drive-epic skill before acting (agents_extensions/shared/skills/drive-epic/SKILL.md).
+  - Before any dispatch wave: CodexBar capacity (\`codexbar usage --provider both --no-color\` + cursor/antigravity as needed) → CAPACITY_CARD. Never habit-route Codex on pace deficit.
+  - Drive via the fleet (\`dispatch_smart\` in worktrees). Do not solo-implement volume. Exact-head CF as a PR comment (not gh approve). Merge only when CI is green on the reviewed SHA.
+  - Branch in .worktrees/ — NEVER branch/switch in the primary dir; never push direct to main.
+  - Inventory BOTH remotes: kube-dojo/kube-dojo.github.io AND kube-dojo/kubedojo-labs.
+
+$EPIC_LEAD
+
+Live state from the API (situational — the curriculum DO-NEXT below is NOT your task list when it conflicts with epic #${EPIC_NUM}):
+$ORIENT_BODY
+
+AUTO-ORIENT — before responding to the user's first message: state that you are driving epic #${EPIC_NUM}, run CodexBar → CAPACITY_CARD if a wave is next, then proceed on that epic unless the user redirects you. Cold-start has ALREADY run with --issue ${EPIC_NUM}.
+
+SESSION SETUP CHECK:"
+elif [ "${SESSION_HANDOFF_AGENT:-}" = "claude-infra" ]; then
   INFRA_HANDOFF="$PROJECT_DIR/.agent/claude-infra-thread-handoff.md"
   if [ -f "$INFRA_HANDOFF" ]; then
     INFRA_LEAD="PREVIOUS-SESSION INFRA HANDOFF — read this FIRST, as your first action:

--- a/.claude/skills/drive-epic/SKILL.md
+++ b/.claude/skills/drive-epic/SKILL.md
@@ -30,6 +30,19 @@ If a claim (count, SHA, gate, cap, lab pass/fail) is not in fresh tool output,
 Sister-repo details (Killercoda layout, G04, hosted vs local evidence):
 [dual-repo.md](dual-repo.md).
 
+## Launch (thin `--epic` bind)
+
+```bash
+./start-claude.sh --epic <N>          # Claude Code → --agent epic-driver
+./start-codex.sh --epic <N>           # Codex + initial bind prompt
+./start-cursor-driver.sh --epic <N>   # cursor-agent + bind prompt
+```
+
+These export `SESSION_EPIC` + `KUBEDOJO_ISSUE`, cold-start with `--issue N`, and
+require a CodexBar `CAPACITY_CARD` before dispatch. SessionStart emits an
+epic-driver packet (not the default UK curriculum DO-NEXT). This is **not** a
+learn-ukrainian lease/canary port — binding only.
+
 ---
 
 ## The loop (every cycle)

--- a/agents_extensions/claude/agents/epic-driver.md
+++ b/agents_extensions/claude/agents/epic-driver.md
@@ -1,0 +1,55 @@
+---
+name: epic-driver
+description: >-
+  Drive one GitHub epic end-to-end via the drive-epic skill and the fleet
+  (dispatch_smart). Not the default curriculum queue and not the infra lane.
+  Started with ./start-claude.sh --epic N (or SESSION_EPIC=N).
+tools: "*"
+model: inherit
+initialPrompt: |
+  You are an epic driver. SESSION_EPIC / KUBEDOJO_ISSUE name the epic number.
+  Orient before anything else: Read the drive-epic skill
+  (agents_extensions/shared/skills/drive-epic/SKILL.md), then run
+  `KUBEDOJO_ISSUE=$SESSION_EPIC bash scripts/cold-start.sh` (or --issue).
+  Before any dispatch: CodexBar capacity (`codexbar usage --provider both
+  --no-color`) → CAPACITY_CARD. Drive that epic via the fleet — inventory both
+  remotes, dispatch_smart in worktrees, exact-head CF as PR comments, merge when
+  CI matches the reviewed SHA. Do not solo volume work; do not fall into the
+  default UK curriculum DO-NEXT. State the epic and first action in one line,
+  then proceed.
+---
+
+# KubeDojo Epic Driver
+
+You drive **one** GitHub epic (for example `#2272`). Load and follow
+[[drive-epic]]. Sister labs repo: `kube-dojo/kubedojo-labs` (see
+`drive-epic/dual-repo.md`).
+
+## Launch
+
+```bash
+./start-claude.sh --epic <N>
+./start-codex.sh --epic <N>
+./start-cursor-driver.sh --epic <N>
+```
+
+Exports `SESSION_EPIC` + `KUBEDOJO_ISSUE`. SessionStart emits an epic-driver
+packet instead of the default curriculum UK DO-NEXT.
+
+## In scope
+
+- Inventory, disposition, capacity routing, fleet dispatch, CF, merge, handoff
+  for the named epic and its children (site + labs).
+- Worktrees under `.worktrees/`; never branch on primary `main`.
+
+## Out of scope
+
+- Default curriculum queue / UK volume unless that work is an epic child.
+- Infra-only tooling (hand to `./start-claude.sh --agent infra-orchestrator`)
+  unless the epic is itself an infra epic.
+
+## Capacity (load-bearing)
+
+Always CodexBar before a wave. Prefer cool idle seats. Never habit-route Codex
+on pace deficit. If **you** are the Cursor seat, do not `dispatch_smart
+--agent cursor`.

--- a/agents_extensions/claude/agents/infra-orchestrator.md
+++ b/agents_extensions/claude/agents/infra-orchestrator.md
@@ -27,7 +27,8 @@ work to the default lane and vice versa.
 - `.claude/hooks/**` and their source in `agents_extensions/claude/hooks/**`
   (deployed via `agents_extensions/deploy.sh`).
 - `agents_extensions/**` — skills, agents, commands, statusline, `deploy.sh`.
-- Launchers: `start-claude.sh`, `start-codex.sh`, `start-docs.sh`.
+- Launchers: `start-claude.sh` (`--epic N` → epic-driver), `start-codex.sh`
+  (`--epic N`), `start-cursor-driver.sh` (`--epic N`), `start-docs.sh`.
 - CI: `.github/workflows/**`, `.github/actions/**`, `dependabot.yml`, `zizmor.yml`.
 - Agent-runtime plumbing, handoff identity, the briefing/orientation system.
 

--- a/agents_extensions/claude/hooks/session-setup.sh
+++ b/agents_extensions/claude/hooks/session-setup.sh
@@ -107,15 +107,26 @@ fi
 # briefing) but EXTRACT only a compact summary — never inline the whole dump.
 # Outer timeout so a slow/down API can't hang session start; on failure the
 # extractor falls back to a "run cold-start yourself" directive.
+# When SESSION_EPIC / KUBEDOJO_ISSUE is set (./start-*.sh --epic N), pass the
+# issue into cold-start so the epic bind is visible in the dump.
 COLDSTART_BIN="$PROJECT_DIR/scripts/cold-start.sh"
 COLDSTART_OUT=""
+EPIC_NUM="${SESSION_EPIC:-${KUBEDOJO_ISSUE:-}}"
+if [ -n "$EPIC_NUM" ]; then
+  export KUBEDOJO_ISSUE="$EPIC_NUM"
+  export SESSION_EPIC="$EPIC_NUM"
+fi
 if [ -f "$COLDSTART_BIN" ]; then
+  COLDSTART_ARGS=()
+  if [ -n "$EPIC_NUM" ]; then
+    COLDSTART_ARGS=(--issue "$EPIC_NUM")
+  fi
   if command -v timeout >/dev/null 2>&1; then
-    COLDSTART_OUT=$(timeout 30 bash "$COLDSTART_BIN" 2>/dev/null || true)
+    COLDSTART_OUT=$(timeout 30 bash "$COLDSTART_BIN" "${COLDSTART_ARGS[@]}" 2>/dev/null || true)
   elif command -v gtimeout >/dev/null 2>&1; then
-    COLDSTART_OUT=$(gtimeout 30 bash "$COLDSTART_BIN" 2>/dev/null || true)
+    COLDSTART_OUT=$(gtimeout 30 bash "$COLDSTART_BIN" "${COLDSTART_ARGS[@]}" 2>/dev/null || true)
   else
-    COLDSTART_OUT=$(bash "$COLDSTART_BIN" 2>/dev/null || true)
+    COLDSTART_OUT=$(bash "$COLDSTART_BIN" "${COLDSTART_ARGS[@]}" 2>/dev/null || true)
   fi
 fi
 
@@ -180,15 +191,43 @@ if [ -z "$ORIENT_BODY" ]; then
   ORIENT_BODY="(cold-start produced no briefing — RUN IT YOURSELF NOW as your first action: bash scripts/cold-start.sh, then act on its DO-NEXT focus item.)"
 fi
 
-# ============================================================================
+# =============================================================================
 # LANE SELECTION — SESSION_HANDOFF_AGENT (exported by start-claude.sh from the
 # selected --agent; see scripts/lib/handoff_identity.sh) routes the orientation
 # identity + handoff slot. cold-start ran ABOVE for BOTH lanes, so the infra
 # lane still orients via the API even on its FIRST session (no handoff file
-# yet). The DEFAULT (curriculum) lane keeps its exact original CONTEXT, byte for
-# byte. Additive only — #2113 (learn-ukrainian parity).
-# ============================================================================
-if [ "${SESSION_HANDOFF_AGENT:-}" = "claude-infra" ]; then
+# yet). SESSION_EPIC / KUBEDOJO_ISSUE (./start-*.sh --epic N) selects the
+# epic-driver packet and OVERRIDES the default curriculum UK DO-NEXT.
+# The DEFAULT (curriculum) lane keeps its exact original CONTEXT when no epic
+# is bound. Additive — #2113 (learn-ukrainian parity) + thin --epic bind.
+# =============================================================================
+if [ -n "${EPIC_NUM:-}" ]; then
+  EPIC_HANDOFF="$PROJECT_DIR/.agent/claude-epic-thread-handoff.md"
+  if [ -f "$EPIC_HANDOFF" ]; then
+    EPIC_LEAD="PREVIOUS-SESSION EPIC HANDOFF — read this FIRST if it matches epic #${EPIC_NUM}:
+  Read: $EPIC_HANDOFF
+(gitignored local thread state; never committed. Write the next handoff to this same path at session end.)"
+  else
+    EPIC_LEAD="No epic-lane handoff yet (.agent/claude-epic-thread-handoff.md absent). Orient via cold-start + drive-epic."
+  fi
+  CONTEXT="EPIC-DRIVER SESSION — auto-oriented by the SessionStart hook. You ARE driving GitHub epic #${EPIC_NUM} (SESSION_EPIC=${EPIC_NUM}). You are NOT the default curriculum UK-volume queue and NOT the infra lane unless this epic is infra.
+
+Load-bearing discipline (do NOT violate):
+  - Read and follow the drive-epic skill before acting (agents_extensions/shared/skills/drive-epic/SKILL.md).
+  - Before any dispatch wave: CodexBar capacity (\`codexbar usage --provider both --no-color\` + cursor/antigravity as needed) → CAPACITY_CARD. Never habit-route Codex on pace deficit.
+  - Drive via the fleet (\`dispatch_smart\` in worktrees). Do not solo-implement volume. Exact-head CF as a PR comment (not gh approve). Merge only when CI is green on the reviewed SHA.
+  - Branch in .worktrees/ — NEVER branch/switch in the primary dir; never push direct to main.
+  - Inventory BOTH remotes: kube-dojo/kube-dojo.github.io AND kube-dojo/kubedojo-labs.
+
+$EPIC_LEAD
+
+Live state from the API (situational — the curriculum DO-NEXT below is NOT your task list when it conflicts with epic #${EPIC_NUM}):
+$ORIENT_BODY
+
+AUTO-ORIENT — before responding to the user's first message: state that you are driving epic #${EPIC_NUM}, run CodexBar → CAPACITY_CARD if a wave is next, then proceed on that epic unless the user redirects you. Cold-start has ALREADY run with --issue ${EPIC_NUM}.
+
+SESSION SETUP CHECK:"
+elif [ "${SESSION_HANDOFF_AGENT:-}" = "claude-infra" ]; then
   INFRA_HANDOFF="$PROJECT_DIR/.agent/claude-infra-thread-handoff.md"
   if [ -f "$INFRA_HANDOFF" ]; then
     INFRA_LEAD="PREVIOUS-SESSION INFRA HANDOFF — read this FIRST, as your first action:

--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -30,6 +30,19 @@ If a claim (count, SHA, gate, cap, lab pass/fail) is not in fresh tool output,
 Sister-repo details (Killercoda layout, G04, hosted vs local evidence):
 [dual-repo.md](dual-repo.md).
 
+## Launch (thin `--epic` bind)
+
+```bash
+./start-claude.sh --epic <N>          # Claude Code → --agent epic-driver
+./start-codex.sh --epic <N>           # Codex + initial bind prompt
+./start-cursor-driver.sh --epic <N>   # cursor-agent + bind prompt
+```
+
+These export `SESSION_EPIC` + `KUBEDOJO_ISSUE`, cold-start with `--issue N`, and
+require a CodexBar `CAPACITY_CARD` before dispatch. SessionStart emits an
+epic-driver packet (not the default UK curriculum DO-NEXT). This is **not** a
+learn-ukrainian lease/canary port — binding only.
+
 ---
 
 ## The loop (every cycle)

--- a/scripts/lib/epic_driver_bind.sh
+++ b/scripts/lib/epic_driver_bind.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Thin epic-driver binding for KubeDojo launchers (not a LU lease/canary port).
+#
+# Parses --epic N from argv, exports SESSION_EPIC + KUBEDOJO_ISSUE, and builds
+# the cold-start prompt that loads drive-epic, checks CodexBar, and drives via
+# the fleet (dispatch_smart) — not solo volume.
+#
+# Used by: start-claude.sh, start-codex.sh, start-cursor-driver.sh
+# SessionStart (.claude/hooks/session-setup.sh) honors SESSION_EPIC when set.
+
+# epic_number_from_argv "$@"
+# Echo the last --epic <N> / --epic=<N> before `--`, or nothing.
+# Does NOT consume argv; callers strip separately. LAST-wins (commander-style).
+epic_number_from_argv() {
+  local prev='' arg='' found=''
+  for arg in "$@"; do
+    if [ "$arg" = "--" ]; then
+      break
+    fi
+    case "$arg" in
+      --epic=*)
+        found="${arg#--epic=}"
+        ;;
+    esac
+    if [ "$prev" = "--epic" ]; then
+      found="$arg"
+    fi
+    prev="$arg"
+  done
+  printf '%s' "$found"
+}
+
+# epic_strip_from_argv "$@"
+# Echo remaining argv with --epic / --epic=N removed (before `--`).
+# Prints one arg per line so callers can mapfile / while-read safely.
+epic_strip_from_argv() {
+  local prev_was_epic=0
+  local seen_dd=0
+  local arg=''
+  for arg in "$@"; do
+    if [ "$seen_dd" = "1" ]; then
+      printf '%s\n' "$arg"
+      continue
+    fi
+    if [ "$arg" = "--" ]; then
+      seen_dd=1
+      printf '%s\n' "$arg"
+      continue
+    fi
+    if [ "$prev_was_epic" = "1" ]; then
+      prev_was_epic=0
+      continue
+    fi
+    case "$arg" in
+      --epic)
+        prev_was_epic=1
+        continue
+        ;;
+      --epic=*)
+        continue
+        ;;
+    esac
+    printf '%s\n' "$arg"
+  done
+}
+
+# epic_validate_number <N>
+# Exit 2 with a message on stderr if N is not a positive integer.
+epic_validate_number() {
+  local n="${1:-}"
+  if [[ ! "$n" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'Error: --epic requires a positive integer issue number (got %q)\n' "$n" >&2
+    return 2
+  fi
+  return 0
+}
+
+# epic_export_env <N>
+# Export SESSION_EPIC + KUBEDOJO_ISSUE (issue env wins if already set to same N).
+epic_export_env() {
+  local n="$1"
+  epic_validate_number "$n" || return $?
+  export SESSION_EPIC="$n"
+  export KUBEDOJO_ISSUE="$n"
+}
+
+# epic_driver_prompt <N>
+# One-shot / initialPrompt text: load drive-epic, cold-start, CodexBar, fleet.
+epic_driver_prompt() {
+  local n="$1"
+  cat <<EOF
+You are the epic driver for GitHub epic #${n}.
+
+1. Load the drive-epic skill first (Read agents_extensions/shared/skills/drive-epic/SKILL.md or .claude/skills/drive-epic/SKILL.md) and follow it — method only; live roster/caps from tools.
+2. Cold-start for this epic: \`KUBEDOJO_ISSUE=${n} bash scripts/cold-start.sh\` (or \`bash scripts/cold-start.sh --issue ${n}\`). SessionStart may already have run it — still act on the epic, not the default curriculum UK DO-NEXT.
+3. Before any dispatch wave: run CodexBar capacity checks (\`codexbar usage --provider both --no-color\`, plus cursor/antigravity as needed) and write a CAPACITY_CARD (pick / avoid / free). Never habit-route Codex when pace-deficit; prefer cool idle seats.
+4. Drive epic #${n} end-to-end via the fleet: inventory children on kube-dojo/kube-dojo.github.io AND kube-dojo/kubedojo-labs, dispose every open child, \`dispatch_smart\` in worktrees, exact-head cross-family review as a PR comment (not gh approve), CI green on the same SHA, rebase-merge. Do not solo-implement volume work.
+5. State in one line what you are picking up on #${n}, then proceed — do not wait to be told to orient.
+EOF
+}

--- a/scripts/lib/handoff_identity.sh
+++ b/scripts/lib/handoff_identity.sh
@@ -49,6 +49,7 @@ handoff_agent_from_argv() {
 handoff_identity_for_agent() {
   case "${1:-}" in
     infra-orchestrator) printf '%s' 'claude-infra' ;;
+    epic-driver) printf '%s' 'claude-epic' ;;
     # curriculum-orchestrator / curriculum-writer / unset → default lane.
     *) ;;
   esac

--- a/scripts/quality/test_epic_driver_bind.sh
+++ b/scripts/quality/test_epic_driver_bind.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Regression tests for scripts/lib/epic_driver_bind.sh — thin --epic launcher bind.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIB="$SCRIPT_DIR/../lib/epic_driver_bind.sh"
+# shellcheck source=../lib/epic_driver_bind.sh
+source "$LIB"
+
+fail=0
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  ok   %-50s [%s]\n' "$label" "$actual"
+  else
+    printf '  FAIL %-50s expected [%s] got [%s]\n' "$label" "$expected" "$actual"
+    fail=1
+  fi
+}
+
+assert_eq "single --epic <N>"           "2272" "$(epic_number_from_argv --epic 2272)"
+assert_eq "--epic=<N>"                  "2272" "$(epic_number_from_argv --epic=2272)"
+assert_eq "stops at --"                 ""     "$(epic_number_from_argv -- --epic 2272)"
+assert_eq "epic before -- still wins"   "2272" "$(epic_number_from_argv --epic 2272 -- rest)"
+assert_eq "repeated: last wins"         "99"   "$(epic_number_from_argv --epic 1 --epic 99)"
+assert_eq "no --epic"                   ""     "$(epic_number_from_argv --chrome)"
+assert_eq "empty argv"                  ""     "$(epic_number_from_argv)"
+
+strip="$(epic_strip_from_argv --epic 2272 --chrome --permission-mode bypassPermissions | tr '\n' ' ')"
+assert_eq "strip removes --epic N"      "--chrome --permission-mode bypassPermissions " "$strip"
+
+strip2="$(epic_strip_from_argv --epic=2272 --agent epic-driver | tr '\n' ' ')"
+assert_eq "strip removes --epic=N"      "--agent epic-driver " "$strip2"
+
+if epic_validate_number 2272; then
+  assert_eq "validate ok 2272" "0" "0"
+else
+  assert_eq "validate ok 2272" "0" "1"
+fi
+if epic_validate_number 0 >/dev/null 2>&1; then
+  assert_eq "validate rejects 0" "1" "0"
+else
+  assert_eq "validate rejects 0" "1" "1"
+fi
+if epic_validate_number abc >/dev/null 2>&1; then
+  assert_eq "validate rejects abc" "1" "0"
+else
+  assert_eq "validate rejects abc" "1" "1"
+fi
+
+prompt="$(epic_driver_prompt 2272)"
+case "$prompt" in
+  *'epic #2272'*|*'#2272'*) assert_eq "prompt names epic" "yes" "yes" ;;
+  *) assert_eq "prompt names epic" "yes" "no" ;;
+esac
+case "$prompt" in
+  *codexbar*|*'CodexBar'*) assert_eq "prompt requires CodexBar" "yes" "yes" ;;
+  *) assert_eq "prompt requires CodexBar" "yes" "no" ;;
+esac
+case "$prompt" in
+  *dispatch_smart*|*'fleet'*) assert_eq "prompt requires fleet" "yes" "yes" ;;
+  *) assert_eq "prompt requires fleet" "yes" "no" ;;
+esac
+case "$prompt" in
+  *drive-epic*) assert_eq "prompt loads drive-epic" "yes" "yes" ;;
+  *) assert_eq "prompt loads drive-epic" "yes" "no" ;;
+esac
+
+( set -e; source "$LIB"; n="$(epic_number_from_argv --epic 5)"; epic_validate_number "$n" )
+assert_eq "set -e: helpers return 0" "0" "$?"
+
+if [ "$fail" -ne 0 ]; then
+  echo "[epic-driver-bind-test] FAIL"
+  exit 1
+fi
+echo "[epic-driver-bind-test] PASS"

--- a/scripts/quality/test_handoff_identity.sh
+++ b/scripts/quality/test_handoff_identity.sh
@@ -37,6 +37,7 @@ assert_eq "empty argv"                  ""                   "$(handoff_agent_fr
 
 # --- handoff_identity_for_agent ---
 assert_eq "slot: infra-orchestrator"    "claude-infra"       "$(handoff_identity_for_agent infra-orchestrator)"
+assert_eq "slot: epic-driver"           "claude-epic"        "$(handoff_identity_for_agent epic-driver)"
 assert_eq "slot: curriculum (default)"  ""                   "$(handoff_identity_for_agent curriculum-orchestrator)"
 assert_eq "slot: unknown (default)"     ""                   "$(handoff_identity_for_agent something-else)"
 assert_eq "slot: empty (default)"       ""                   "$(handoff_identity_for_agent '')"

--- a/start-claude.sh
+++ b/start-claude.sh
@@ -148,22 +148,42 @@ unset ANTHROPIC_BASE_URL OPENAI_BASE_URL COPILOT_PROVIDER_BASE_URL
 echo "headroom routing DISABLED -- launching Claude DIRECT (no proxy)"
 # --- end headroom routing ---
 
+# Thin --epic N bind (scripts/lib/epic_driver_bind.sh): export SESSION_EPIC +
+# KUBEDOJO_ISSUE, strip the flag so Claude never sees an unknown option, default
+# --agent epic-driver. SessionStart honors SESSION_EPIC and skips the UK queue.
+_claude_forward=("$@")
+_selected_epic=""
+if [ -f "$PROJECT_DIR/scripts/lib/epic_driver_bind.sh" ]; then
+    # shellcheck source=scripts/lib/epic_driver_bind.sh
+    source "$PROJECT_DIR/scripts/lib/epic_driver_bind.sh"
+    _selected_epic="$(epic_number_from_argv "$@")"
+    if [ -n "$_selected_epic" ]; then
+        epic_export_env "$_selected_epic" || exit $?
+        _claude_forward=()
+        while IFS= read -r _line; do
+            [ -n "$_line" ] || continue
+            _claude_forward+=("$_line")
+        done < <(epic_strip_from_argv "$@")
+        echo "Epic driver → SESSION_EPIC=$_selected_epic (drive-epic + CodexBar + fleet)"
+    fi
+fi
+
 # Derive the cold-start handoff identity from the selected `--agent`, so ONE
 # launcher serves multiple lanes: the SessionStart hook keys its orientation +
 # handoff slot off SESSION_HANDOFF_AGENT. The default curriculum lane derives
 # nothing → the hook keeps its existing single-lane behavior byte-for-byte.
-# `--agent infra-orchestrator` → SESSION_HANDOFF_AGENT=claude-infra. An explicit
-# SESSION_HANDOFF_AGENT already in the environment wins. Mapping + argv parsing
-# live in scripts/lib/handoff_identity.sh (mirrors learn-ukrainian, #2113).
-# Derive the selected `--agent` from argv ONCE (last-wins, stops at `--`) — used
-# both for the cold-start handoff identity and for the default-lane agent
-# injection below. Sourcing is unconditional (it only defines functions); the
-# handoff-identity export still only happens when SESSION_HANDOFF_AGENT is unset.
+# `--agent infra-orchestrator` → SESSION_HANDOFF_AGENT=claude-infra.
+# `--epic N` / `--agent epic-driver` → SESSION_HANDOFF_AGENT=claude-epic.
+# An explicit SESSION_HANDOFF_AGENT already in the environment wins. Mapping +
+# argv parsing live in scripts/lib/handoff_identity.sh (mirrors learn-ukrainian, #2113).
 _selected_agent=""
 if [ -f "$PROJECT_DIR/scripts/lib/handoff_identity.sh" ]; then
     # shellcheck source=scripts/lib/handoff_identity.sh
     source "$PROJECT_DIR/scripts/lib/handoff_identity.sh"
-    _selected_agent="$(handoff_agent_from_argv "$@")"
+    _selected_agent="$(handoff_agent_from_argv "${_claude_forward[@]}")"
+    if [ -z "$_selected_agent" ] && [ -n "${_selected_epic:-}" ]; then
+        _selected_agent="epic-driver"
+    fi
     if [ -z "${SESSION_HANDOFF_AGENT:-}" ]; then
         _handoff_slot="$(handoff_identity_for_agent "$_selected_agent")"
         if [ -n "$_handoff_slot" ]; then
@@ -179,14 +199,20 @@ fi
 # starts driving WITHOUT the user typing a first message. The default
 # (curriculum) lane carries no explicit `--agent`, so default it to
 # `curriculum-orchestrator` here — making `./start-claude.sh` symmetric with
-# `--agent infra-orchestrator`. Any explicit `--agent` (incl. infra) is left
-# untouched. Opt out (bare, idle claude) with KUBEDOJO_NO_DEFAULT_AGENT=1.
+# `--agent infra-orchestrator`. `--epic N` defaults to `epic-driver` when no
+# explicit `--agent` is present. Opt out with KUBEDOJO_NO_DEFAULT_AGENT=1.
 CLAUDE_ARGS=(--chrome --permission-mode bypassPermissions)
-if [ -z "$_selected_agent" ] && [ -z "${SESSION_HANDOFF_AGENT:-}" ] && [ -z "${KUBEDOJO_NO_DEFAULT_AGENT:-}" ]; then
+_has_explicit_agent=0
+if [ -n "$(handoff_agent_from_argv "${_claude_forward[@]}")" ]; then
+    _has_explicit_agent=1
+fi
+if [ -n "${_selected_epic:-}" ] && [ "$_has_explicit_agent" = "0" ] && [ -z "${KUBEDOJO_NO_DEFAULT_AGENT:-}" ]; then
+    CLAUDE_ARGS+=(--agent epic-driver)
+    echo "Epic lane → --agent epic-driver (drive-epic; CodexBar before dispatch; fleet only)"
+elif [ -z "$_selected_agent" ] && [ -z "${SESSION_HANDOFF_AGENT:-}" ] && [ -z "${KUBEDOJO_NO_DEFAULT_AGENT:-}" ]; then
     CLAUDE_ARGS+=(--agent curriculum-orchestrator)
     echo "Default lane → --agent curriculum-orchestrator (auto-orients + drives the queue; no typing needed)"
 fi
-unset _selected_agent
 
 echo "Launching Claude Code (native build from PATH: $(command -v claude))..."
-exec claude "${CLAUDE_ARGS[@]}" "$@"
+exec claude "${CLAUDE_ARGS[@]}" "${_claude_forward[@]}"

--- a/start-codex.sh
+++ b/start-codex.sh
@@ -26,11 +26,12 @@ while [ "$#" -gt 0 ]; do
     case "$1" in
         --help-wrapper)
             cat <<'EOF'
-Usage: ./start-codex.sh [--main|--worktree] [codex args...]
+Usage: ./start-codex.sh [--main|--worktree] [--epic N] [codex args...]
 
 KubeDojo Codex launcher:
   - runs Codex in the primary main checkout by default
   - use --worktree to run in .worktrees/codex-interactive instead
+  - --epic N  bind drive-epic (SESSION_EPIC + KUBEDOJO_ISSUE); CodexBar + fleet
   - always adds --dangerously-bypass-approvals-and-sandbox
   - enables Codex multi-agent support by default
   - set CODEX_ENABLE_MULTI_AGENT=0 to disable multi-agent support
@@ -46,12 +47,32 @@ EOF
             CODEX_TARGET="worktree"
             shift
             ;;
+        --epic)
+            if [ "$#" -lt 2 ]; then
+                echo "Error: --epic requires a positive integer" >&2
+                exit 2
+            fi
+            CODEX_EPIC="$2"
+            shift 2
+            ;;
+        --epic=*)
+            CODEX_EPIC="${1#--epic=}"
+            shift
+            ;;
         *)
             CODEX_ARGS+=("$1")
             shift
             ;;
     esac
 done
+
+if [ -n "${CODEX_EPIC:-}" ]; then
+    # shellcheck source=scripts/lib/epic_driver_bind.sh
+    source "$SCRIPT_DIR/scripts/lib/epic_driver_bind.sh"
+    epic_export_env "$CODEX_EPIC" || exit $?
+    echo "Epic driver → SESSION_EPIC=$SESSION_EPIC (drive-epic + CodexBar + fleet)"
+    CODEX_ARGS+=("$(epic_driver_prompt "$CODEX_EPIC")")
+fi
 
 case "$CODEX_TARGET" in
     main|worktree)

--- a/start-cursor-driver.sh
+++ b/start-cursor-driver.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Thin Cursor epic-driver launcher (no LU lease/canary stack).
+# Exports SESSION_EPIC + KUBEDOJO_ISSUE, then starts an interactive cursor-agent
+# session with the drive-epic bind prompt (CodexBar + fleet).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/epic_driver_bind.sh
+source "$ROOT/scripts/lib/epic_driver_bind.sh"
+
+EPIC="$(epic_number_from_argv "$@")"
+if [ -z "$EPIC" ]; then
+  cat <<'EOF' >&2
+Usage: ./start-cursor-driver.sh --epic <N> [cursor-agent args...]
+
+Loads drive-epic, cold-starts issue N, requires CodexBar capacity before
+dispatch, and drives the epic via the fleet (dispatch_smart).
+EOF
+  exit 2
+fi
+epic_export_env "$EPIC" || exit $?
+
+FORWARD=()
+while IFS= read -r line; do
+  [ -n "$line" ] || continue
+  FORWARD+=("$line")
+done < <(epic_strip_from_argv "$@")
+
+cd "$ROOT"
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:$PATH"
+hash -r 2>/dev/null || true
+
+if ! command -v cursor-agent >/dev/null 2>&1; then
+  echo "Error: cursor-agent not found on PATH." >&2
+  echo "  Install the Cursor agent CLI, or open the IDE from a shell that" >&2
+  echo "  already exported SESSION_EPIC=$EPIC (SessionStart honors it)." >&2
+  exit 1
+fi
+
+PROMPT="$(epic_driver_prompt "$EPIC")"
+echo "Starting Cursor epic driver for #$EPIC..."
+echo "SESSION_EPIC=$SESSION_EPIC KUBEDOJO_ISSUE=$KUBEDOJO_ISSUE"
+echo "CodexBar + fleet bind is in the initial prompt."
+
+# Interactive agent session (no --print). Remaining args forward; prompt last.
+exec cursor-agent --force "${FORWARD[@]}" "$PROMPT"


### PR DESCRIPTION
## Summary
- Add `scripts/lib/epic_driver_bind.sh` + `epic-driver` Claude agent; SessionStart emits an epic-driver packet when `SESSION_EPIC` / `KUBEDOJO_ISSUE` is set (overrides default UK DO-NEXT).
- `./start-claude.sh --epic N`, `./start-codex.sh --epic N`, and new `./start-cursor-driver.sh --epic N` export the bind and require CodexBar `CAPACITY_CARD` + `dispatch_smart` fleet use (not solo volume).
- Tests: `scripts/quality/test_epic_driver_bind.sh` + handoff slot `claude-epic`.

## Test plan
- [x] `bash scripts/quality/test_epic_driver_bind.sh`
- [x] `bash scripts/quality/test_handoff_identity.sh`
- [x] `bash -n` on launchers + session-setup
- [ ] Launch `./start-claude.sh --epic 2272` (or cursor/codex twin) and confirm SessionStart says EPIC-DRIVER + CodexBar before first dispatch


Made with [Cursor](https://cursor.com)