### PR TITLE
feat(quality): resolve redirect chains to final canonical pathnames (#2346)

### DIFF
--- a/scripts/quality/document-route-set.mjs
+++ b/scripts/quality/document-route-set.mjs
@@ -32,12 +32,12 @@ function safeSource(value) {
   return source;
 }
 
-function serializedPath(value, origin) {
-  const pathname = text(value, 'route.pathname');
-  if (!pathname.startsWith('/') || pathname.startsWith('//') || pathname.includes('?') || pathname.includes('#')) fail('route.pathname must be a root-relative serialized pathname');
+function serializedPath(value, origin, label = 'route.pathname') {
+  const pathname = text(value, label);
+  if (!pathname.startsWith('/') || pathname.startsWith('//') || pathname.includes('?') || pathname.includes('#')) fail(`${label} must be a root-relative serialized pathname`);
   let url;
-  try { url = new URL(pathname, origin); } catch { fail('route.pathname must be a URL pathname'); }
-  if (url.origin !== origin || url.pathname !== pathname || url.search || url.hash) fail('route.pathname must be a serialized pathname');
+  try { url = new URL(pathname, origin); } catch { fail(`${label} must be a URL pathname`); }
+  if (url.origin !== origin || url.pathname !== pathname || url.search || url.hash) fail(`${label} must be a serialized pathname`);
   return pathname;
 }
 
@@ -56,13 +56,18 @@ function record(value, { origin, base }) {
   return { id: text(value.id, 'route.id'), url: urlText, pathname, source: safeSource(value.source), sourceSha256: hash, isFallback: value.isFallback, locale: optionalText(value.locale, 'route.locale'), lang: optionalText(value.lang, 'route.lang') };
 }
 
-function validateRedirects(value) {
+function redirectRecords(value, origin) {
   if (!Array.isArray(value)) fail('manifest.redirects must be an array');
-  value.forEach((redirect) => {
+  const seen = new Set();
+  return value.map((redirect) => {
     object(redirect, 'redirect');
     if (redirect.status !== null && (!Number.isInteger(redirect.status) || redirect.status < 300 || redirect.status > 399)) fail('redirect.status must be a 3xx integer or null');
-    text(redirect.source, 'redirect.source');
-    text(redirect.target, 'redirect.target');
+    const source = serializedPath(redirect.source, origin, 'redirect.source');
+    const target = serializedPath(redirect.target, origin, 'redirect.target');
+    if (/[\[\]*]/.test(source) || /[\[\]*]/.test(target)) fail('redirect patterns are unsupported');
+    if (seen.has(source)) fail(`duplicate redirect.source: ${source}`);
+    seen.add(source);
+    return { source, target, status: redirect.status };
   });
 }
 
@@ -71,7 +76,7 @@ export function buildDocumentRouteSet(manifest) {
   object(manifest, 'manifest');
   if (manifest.schemaVersion !== 1 || manifest.scope !== 'starlight-document-routes') fail('unsupported manifest schema or scope');
   const config = originFor(object(manifest.config, 'manifest.config'));
-  validateRedirects(manifest.redirects);
+  const redirects = redirectRecords(manifest.redirects, config.origin);
   if (!Array.isArray(manifest.routes)) fail('manifest.routes must be an array');
   const routes = manifest.routes.map((route) => record(route, config));
   const targetPaths = new Set();
@@ -90,5 +95,5 @@ export function buildDocumentRouteSet(manifest) {
     if (primary.length !== 1) fail(`source requires exactly one primary route: ${source}`);
     primaryBySource.set(source, primary[0]);
   }
-  return { origin: config.origin, config: manifest.config, routes, targetPaths, primaryBySource, fallbacks: routes.filter((route) => route.isFallback) };
+  return { origin: config.origin, config: manifest.config, routes, targetPaths, primaryBySource, fallbacks: routes.filter((route) => route.isFallback), redirects };
 }

--- a/scripts/quality/document-route-set.test.mjs
+++ b/scripts/quality/document-route-set.test.mjs
@@ -56,7 +56,10 @@ test('rejects unsupported schema/config/source metadata and leaves redirects out
   rejects(manifest([route()], { redirects: [{ source: '/old/', target: '/new/', status: 302.5 }] }), /3xx integer/);
   rejects(manifest([route()], { redirects: [{ source: '/old/', target: '/new/', status: Number.NaN }] }), /3xx integer/);
   rejects(manifest([route()], { redirects: [{ source: '/old/', target: '/new/', status: 200 }] }), /3xx integer/);
+  rejects(manifest([route()], { redirects: [{ source: '/old/', target: '../new/', status: 301 }] }), /serialized pathname/);
+  rejects(manifest([route()], { redirects: [{ source: '/old/[...slug]/', target: '/docs/guide/one/', status: 301 }] }), /unsupported/);
+  rejects(manifest([route()], { redirects: [{ source: '/old/', target: '/docs/guide/one/', status: 301 }, { source: '/old/', target: '/docs/other/', status: 302 }] }), /duplicate/);
   const result = buildDocumentRouteSet(manifest([route()], { redirects: [{ source: '/old/', target: '/docs/guide/one/', status: 301 }] }));
   assert.equal(result.targetPaths.has('/old/'), false);
-  assert.equal('redirects' in result, false);
+  assert.deepEqual(result.redirects, [{ source: '/old/', target: '/docs/guide/one/', status: 301 }]);
 });

--- a/scripts/quality/markdown-link-consumer.mjs
+++ b/scripts/quality/markdown-link-consumer.mjs
@@ -71,7 +71,7 @@ export function consumeMarkdownLinks(manifest, docsRoot) {
           disposition = res.disposition;
         } else {
           try {
-            const resolved = resolveRoute(href, primary.url, routeSet.origin, routeSet.targetPaths);
+            const resolved = resolveRoute(href, primary.url, routeSet.origin, routeSet.targetPaths, routeSet.redirects);
             target = resolved.url;
             if (resolved.kind === 'external-http' || resolved.kind === 'mailto') {
               disposition = 'external';

--- a/scripts/quality/markdown-link-consumer.test.mjs
+++ b/scripts/quality/markdown-link-consumer.test.mjs
@@ -17,7 +17,10 @@ test('consumeMarkdownLinks handles various fixtures', (t) => {
       trailingSlash: 'always',
       buildFormat: 'directory'
     },
-    redirects: [],
+    redirects: [
+      { source: '/legacy-module-b/', target: '/dir1/module-b/', status: 301 },
+      { source: '/gone-alias/', target: '/no-such-page/', status: 302 }
+    ],
     routes: [
       {
         id: 'dir1/module-a.md',
@@ -79,6 +82,8 @@ test('consumeMarkdownLinks handles various fixtures', (t) => {
 [index](../../)
 [explicit slug](/dir1/module-b/)
 [root-relative](/dir1/module-b/)
+[redirect source](/legacy-module-b/)
+[dead redirect](/gone-alias/)
 [fragment](#section)
 [unsupported form](ftp://invalid)
 \`\`\`
@@ -125,6 +130,14 @@ test('consumeMarkdownLinks handles various fixtures', (t) => {
   const rootRelative = findReport('root-relative');
   assert.equal(rootRelative.disposition, 'present');
   assert.equal(rootRelative.target, 'https://site.test/dir1/module-b/');
+
+  const redirectSource = findReport('/legacy-module-b/');
+  assert.equal(redirectSource.disposition, 'present');
+  assert.equal(redirectSource.target, 'https://site.test/dir1/module-b/');
+
+  const deadRedirect = findReport('/gone-alias/');
+  assert.equal(deadRedirect.disposition, 'missing');
+  assert.equal(deadRedirect.target, 'https://site.test/no-such-page/');
 
   const fragment = findReport('fragment');
   assert.equal(fragment.disposition, 'fragment-only');

--- a/scripts/quality/route-resolver.mjs
+++ b/scripts/quality/route-resolver.mjs
@@ -47,14 +47,68 @@ function manifestRoutes(paths, origin) {
   return routes;
 }
 
-/** Resolve one URL; routeExists checks paths only, never anchors or redirect destinations. */
-export function resolveRoute(href, canonicalSourceValue, siteOriginValue, knownPaths) {
+function serializedRedirectPath(value, origin, label) {
+  const path = text(value, label);
+  if (!path.startsWith('/') || path.startsWith('//') || path.includes('?') || path.includes('#') || /[\[\]*]/.test(path)) {
+    throw new UnsupportedRoute(`${label} must be a root-relative pathname`);
+  }
+  const route = parsed(path, label, origin);
+  if (route.origin !== origin.origin || route.search || route.hash || route.pathname !== path) {
+    throw new UnsupportedRoute(`${label} must be a serialized pathname`);
+  }
+  return path;
+}
+
+function redirectMap(redirects, origin) {
+  if (redirects === undefined) return new Map();
+  if (typeof redirects === 'string' || !redirects || typeof redirects[Symbol.iterator] !== 'function') {
+    throw new UnsupportedRoute('redirects must be a non-string iterable');
+  }
+  const map = new Map();
+  for (const entry of redirects) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) throw new UnsupportedRoute('redirect must be an object');
+    const source = serializedRedirectPath(entry.source, origin, 'redirect source');
+    const target = serializedRedirectPath(entry.target, origin, 'redirect target');
+    if (map.has(source)) throw new UnsupportedRoute('duplicate redirect source');
+    map.set(source, target);
+  }
+  return map;
+}
+
+function followRedirects(pathname, map) {
+  const seen = new Set();
+  let current = pathname;
+  while (map.has(current)) {
+    if (seen.has(current)) throw new UnsupportedRoute('redirect cycle');
+    if (seen.size >= 32) throw new UnsupportedRoute('redirect chain too long');
+    seen.add(current);
+    current = map.get(current);
+  }
+  return current;
+}
+
+function rewritePath(url, pathname, origin) {
+  const next = parsed(pathname, 'redirect destination', origin);
+  if (next.origin !== origin.origin || next.search || next.hash || next.pathname !== pathname) {
+    throw new UnsupportedRoute('redirect destination must be a serialized pathname');
+  }
+  next.search = url.search;
+  next.hash = url.hash;
+  return next;
+}
+
+/** Resolve one URL; configured redirect sources follow to the final pathname before routeExists. */
+export function resolveRoute(href, canonicalSourceValue, siteOriginValue, knownPaths, redirects) {
   const origin = siteOrigin(siteOriginValue);
   const source = canonicalSource(canonicalSourceValue, origin);
   const routes = manifestRoutes(knownPaths, origin);
+  const chains = redirectMap(redirects, origin);
   const target = parsed(href, 'href', source);
   if (target.protocol === 'mailto:') return { url: target.href, kind: 'mailto', path: null, routeExists: null };
   if (!['http:', 'https:'].includes(target.protocol)) throw new UnsupportedRoute('only HTTP(S) and mailto links are supported');
   const internal = target.origin === origin.origin;
-  return { url: target.href, kind: internal ? 'internal' : 'external-http', path: target.pathname, routeExists: internal ? routes.has(target.pathname) : null };
+  if (!internal) return { url: target.href, kind: 'external-http', path: target.pathname, routeExists: null };
+  const path = followRedirects(target.pathname, chains);
+  const resolved = path === target.pathname ? target : rewritePath(target, path, origin);
+  return { url: resolved.href, kind: 'internal', path, routeExists: routes.has(path) };
 }

--- a/scripts/quality/route-resolver.test.mjs
+++ b/scripts/quality/route-resolver.test.mjs
@@ -97,3 +97,25 @@ test('explicit inputs and manifest paths must be canonical', () => {
   assert.throws(() => resolveRoute('/x/', '/x/', `${ORIGIN}/base/`, ['/x/']), { name: 'TypeError', message: /HTTP\(S\) origin/ });
   assert.throws(() => resolveRoute('/x/', '/x/', ORIGIN, '/x/'), { name: 'TypeError', message: /non-string iterable/ });
 });
+
+test('redirect source resolves to the final canonical pathname', () => {
+  const redirects = [{ source: '/old/', target: '/mid/' }, { source: '/mid/', target: '/final/' }];
+  const chained = resolveRoute('/old/?q=1#part', '/source/', ORIGIN, ['/final/'], redirects);
+  assert.deepEqual(chained, { url: 'https://site.test/final/?q=1#part', kind: 'internal', path: '/final/', routeExists: true });
+  const relative = resolveRoute('../old/', '/section/page/', ORIGIN, ['/new/'], [{ source: '/section/old/', target: '/new/' }]);
+  assert.equal(relative.path, '/new/');
+  assert.equal(relative.routeExists, true);
+  const missing = resolveRoute('/old/', '/source/', ORIGIN, ['/elsewhere/'], [{ source: '/old/', target: '/gone/' }]);
+  assert.equal(missing.path, '/gone/');
+  assert.equal(missing.routeExists, false);
+});
+
+test('redirect chains fail closed and do not invent filename-derived URLs', () => {
+  assert.equal(resolveRoute('/docs/old-name/', '/source/', ORIGIN, ['/docs/new-name/']).path, '/docs/old-name/');
+  assert.equal(resolveRoute('/docs/old-name/', '/source/', ORIGIN, ['/docs/new-name/']).routeExists, false);
+  assert.equal(resolveRoute('/old', '/source/', ORIGIN, ['/new/'], [{ source: '/old/', target: '/new/' }]).path, '/old');
+  assert.throws(() => resolveRoute('/a/', '/source/', ORIGIN, ['/a/'], [{ source: '/a/', target: '/b/' }, { source: '/b/', target: '/a/' }]), UnsupportedRoute);
+  assert.throws(() => resolveRoute('/a/', '/source/', ORIGIN, ['/b/'], [{ source: '/a/', target: '../b/' }]), UnsupportedRoute);
+  assert.throws(() => resolveRoute('/a/', '/source/', ORIGIN, ['/b/'], [{ source: '/old/[...slug]/', target: '/b/' }]), UnsupportedRoute);
+  assert.throws(() => resolveRoute('/a/', '/source/', ORIGIN, ['/b/'], [{ source: '/a/', target: '/b/' }, { source: '/a/', target: '/c/' }]), UnsupportedRoute);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Redirect-chain packet for #2346. A browser href that lands on a configured redirect **source** now follows to the final serialized pathname before `routeExists`.

## What this does

- `resolveRoute(..., redirects?)` follows exact source→target pairs (including multi-hop) and rewrites the resolved URL pathname while preserving query/fragment.
- `routeExists` is checked against the **final** destination, not the alias. Redirect sources stay out of document `targetPaths`.
- Fail closed on cycles, duplicate sources, relative/pattern/non-serialized forms, and slash mismatches. No filename-derived URLs and no legacy-baseline expansion.
- `buildDocumentRouteSet` returns validated `redirects`; the markdown-link consumer passes them through so `/legacy/` → present/missing on the destination.

## Out of scope

- Gate wiring (`check_site_health.py`, `check_route_coherence.py`, CI link-check)
- Mass content link repair
- Replacing legacy gates

## Verification

```
node --test scripts/quality/route-resolver.test.mjs \
  scripts/quality/document-route-set.test.mjs \
  scripts/quality/markdown-link-consumer.test.mjs \
  scripts/quality/custom-astro-page-proof.test.mjs \
  scripts/quality/document-source-validation.test.mjs
```

All focused tests passed. `git diff --check` clean. Diff: 6 files, +114/−17 (within the ≤200 packet budget). Python/pipeline/`npm run build` not run — JS quality tooling only; no `src/content/docs/` or Astro config changes.

#2346 stays open (gate wiring + content repair remain).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9756497b-253a-497a-b14e-9dd1c6290a24?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9756497b-253a-497a-b14e-9dd1c6290a24&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

