### PR TITLE
fix(ai-ml): parent-relative sibling links in prereq 1.2 (Refs #2346)

### DIFF
--- a/src/content/docs/ai-ml-engineering/prerequisites/module-1.2-home-ai-workstation-fundamentals.md
+++ b/src/content/docs/ai-ml-engineering/prerequisites/module-1.2-home-ai-workstation-fundamentals.md
@@ -607,8 +607,8 @@ Write one final paragraph using this format: "For the next stage, I will choose 
 
 ## Next Module
 
-- [Reproducible Python, CUDA, and ROCm Environments](./module-1.3-reproducible-python-cuda-rocm-environments/)
-- [Notebooks, Scripts, and Project Layouts](./module-1.4-notebooks-scripts-project-layouts/)
+- [Reproducible Python, CUDA, and ROCm Environments](../module-1.3-reproducible-python-cuda-rocm-environments/)
+- [Notebooks, Scripts, and Project Layouts](../module-1.4-notebooks-scripts-project-layouts/)
 
 ## Sources
 

--- a/src/content/docs/uk/ai-ml-engineering/prerequisites/module-1.2-home-ai-workstation-fundamentals.md
+++ b/src/content/docs/uk/ai-ml-engineering/prerequisites/module-1.2-home-ai-workstation-fundamentals.md
@@ -609,8 +609,8 @@ Next action:
 
 ## Наступний модуль
 
-- [Відтворювані середовища Python, CUDA та ROCm](./module-1.3-reproducible-python-cuda-rocm-environments/)
-- [Ноутбуки, скрипти та макети проєктів](./module-1.4-notebooks-scripts-project-layouts/)
+- [Відтворювані середовища Python, CUDA та ROCm](../module-1.3-reproducible-python-cuda-rocm-environments/)
+- [Ноутбуки, скрипти та макети проєктів](../module-1.4-notebooks-scripts-project-layouts/)
 
 ## Джерела
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-on content repair for the same `trailingSlash: always` sibling-404 class as #2523.

From `/ai-ml-engineering/prerequisites/module-1.2-home-ai-workstation-fundamentals/`, `./module-1.3-…/` resolves beneath the current module and 404s. The correct Starlight form is `../module-…/`.

**Owned files only**
- `src/content/docs/ai-ml-engineering/prerequisites/module-1.2-home-ai-workstation-fundamentals.md`
- `src/content/docs/uk/ai-ml-engineering/prerequisites/module-1.2-home-ai-workstation-fundamentals.md`

Four same-folder next-module hrefs: `./module-…` → `../module-…`. No gate-script changes.

**Refs #2346**

Diff: 2 files, +4 / −4. Epic stays open.

**Verification**
- `git diff --check` clean
- `rg '](./module-'` on owned files: 0 remaining
- Project `route-resolver.mjs` (WHATWG): `./module-1.3-…/` from the 1.2 canonical route nests under 1.2 (`routeExists=false`); `../module-1.3-…/` and `../module-1.4-…/` resolve to the sibling routes (`routeExists=true`) for EN and UK
- Skipped `.venv/bin/ruff` and `scripts/test_pipeline.py`: no Python
- Skipped local `npm run build`: no `node_modules` in this environment; href-only change, no frontmatter/schema/nav edits. CI Astro build is the render gate
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad75daa3-2e80-4907-85a2-c220e4bcfe7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad75daa3-2e80-4907-85a2-c220e4bcfe7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

