### PR TITLE
fix(ai-ml): parent-relative next-module links in mlops (#2346)

### DIFF
--- a/src/content/docs/ai-ml-engineering/mlops/module-1.1-ml-devops-foundations.md
+++ b/src/content/docs/ai-ml-engineering/mlops/module-1.1-ml-devops-foundations.md
@@ -1356,4 +1356,4 @@ Success criteria:
 
 ## Next Module
 
-Up next: [Module 1.2: Docker for ML](./module-1.2-docker-for-ml/), where you package ML dependencies into repeatable container images so local, CI, and Kubernetes execution environments stay aligned.
+Up next: [Module 1.2: Docker for ML](../module-1.2-docker-for-ml/), where you package ML dependencies into repeatable container images so local, CI, and Kubernetes execution environments stay aligned.

--- a/src/content/docs/ai-ml-engineering/mlops/module-1.2-docker-for-ml.md
+++ b/src/content/docs/ai-ml-engineering/mlops/module-1.2-docker-for-ml.md
@@ -1326,7 +1326,7 @@ docker rm ml-api-debug
 
 ## Next Module
 
-Continue to [Module 1.3: CI/CD for ML](./module-1.3-cicd-for-ml/) to wire the container images you built here into automated pipelines—image builds on every merge, data and model validation gates, and deployment workflows that treat the Docker contract as a first-class release artifact rather than a manual local step.
+Continue to [Module 1.3: CI/CD for ML](../module-1.3-cicd-for-ml/) to wire the container images you built here into automated pipelines—image builds on every merge, data and model validation gates, and deployment workflows that treat the Docker contract as a first-class release artifact rather than a manual local step.
 
 ## Learner check
 

--- a/src/content/docs/ai-ml-engineering/mlops/module-1.3-cicd-for-ml.md
+++ b/src/content/docs/ai-ml-engineering/mlops/module-1.3-cicd-for-ml.md
@@ -1390,7 +1390,7 @@ kubectl rollout status deployment/ml-inference-server --timeout=10s || true
 
 You now have the release-discipline foundation for ML systems: code gates, data gates, model gates, Continuous Training triggers, portable pipeline execution, and cost controls based on measured evidence. The next module moves from validation into runtime orchestration, where a model artifact becomes a Kubernetes workload with rollout, scaling, health, and rollback behavior.
 
-Next: [Kubernetes Fundamentals for ML](./module-1.4-kubernetes-for-ml/) - learn how to package validated models and deploy them resiliently using production-grade orchestration.
+Next: [Kubernetes Fundamentals for ML](../module-1.4-kubernetes-for-ml/) - learn how to package validated models and deploy them resiliently using production-grade orchestration.
 
 ## Sources
 

--- a/src/content/docs/ai-ml-engineering/mlops/module-1.4-kubernetes-for-ml.md
+++ b/src/content/docs/ai-ml-engineering/mlops/module-1.4-kubernetes-for-ml.md
@@ -575,7 +575,7 @@ k delete namespace ml-k8s-lab
 
 ## Next Module
 
-Next, continue to [Module 1.5: Advanced Kubernetes](./module-1.5-advanced-kubernetes/) to connect these workload primitives to deeper cluster operations, production policies, and advanced deployment patterns.
+Next, continue to [Module 1.5: Advanced Kubernetes](../module-1.5-advanced-kubernetes/) to connect these workload primitives to deeper cluster operations, production policies, and advanced deployment patterns.
 
 ## Sources
 

--- a/src/content/docs/ai-ml-engineering/mlops/module-1.5-advanced-kubernetes.md
+++ b/src/content/docs/ai-ml-engineering/mlops/module-1.5-advanced-kubernetes.md
@@ -1091,7 +1091,7 @@ The `kubectl exec` approach connects directly to the Ray head pod without requir
 
 ## Next Module
 
-Continue to [Module 1.6: Experiment Tracking](./module-1.6-experiment-tracking/) to learn MLflow and Weights & Biases—the tooling that records run history, model lineage, and reproducibility metadata so you never lose track of which artifact reached production.
+Continue to [Module 1.6: Experiment Tracking](../module-1.6-experiment-tracking/) to learn MLflow and Weights & Biases—the tooling that records run history, model lineage, and reproducibility metadata so you never lose track of which artifact reached production.
 
 ---
 

--- a/src/content/docs/ai-ml-engineering/mlops/module-1.7-data-pipelines.md
+++ b/src/content/docs/ai-ml-engineering/mlops/module-1.7-data-pipelines.md
@@ -1066,7 +1066,7 @@ Start with DVC plus explicit pipeline stages in `dvc.yaml`. Wire Great Expectati
 
 ## Next Module
 
-Continue to [Module 1.8: ML Pipelines](./module-1.8-ml-pipelines/) for workflow orchestration patterns that wire validated, versioned data into training, evaluation, and deployment DAGs.
+Continue to [Module 1.8: ML Pipelines](../module-1.8-ml-pipelines/) for workflow orchestration patterns that wire validated, versioned data into training, evaluation, and deployment DAGs.
 
 ---
 

--- a/src/content/docs/ai-ml-engineering/mlops/module-1.8-ml-pipelines.md
+++ b/src/content/docs/ai-ml-engineering/mlops/module-1.8-ml-pipelines.md
@@ -2039,7 +2039,7 @@ Confirm the Dagster exercise succeeded before finishing the module:
 
 ## Next Module
 
-Continue to [Module 1.9: Model Serving](./module-1.9-model-serving/) for deployment patterns—FastAPI and gRPC inference endpoints, canary rollouts, and Kubernetes-native serving controls that consume the artifacts your pipelines produce.
+Continue to [Module 1.9: Model Serving](../module-1.9-model-serving/) for deployment patterns—FastAPI and gRPC inference endpoints, canary rollouts, and Kubernetes-native serving controls that consume the artifacts your pipelines produce.
 
 ## Sources
 

--- a/src/content/docs/ai-ml-engineering/mlops/module-1.9-model-serving.md
+++ b/src/content/docs/ai-ml-engineering/mlops/module-1.9-model-serving.md
@@ -1522,7 +1522,7 @@ kubectl apply -f ingress-canary.yaml
 
 ## Next Module
 
-Continue to [Module 1.10: ML Monitoring](./module-1.10-ml-monitoring/) to instrument the serving paths you built here—latency histograms, error budgets, drift detection, and alert design that keep models trustworthy after deployment. Monitoring closes the loop opened in this module: serving exposes versioned predictions under SLOs, and observability tells you when to roll back, retrain, or fix the platform before users notice.
+Continue to [Module 1.10: ML Monitoring](../module-1.10-ml-monitoring/) to instrument the serving paths you built here—latency histograms, error budgets, drift detection, and alert design that keep models trustworthy after deployment. Monitoring closes the loop opened in this module: serving exposes versioned predictions under SLOs, and observability tells you when to roll back, retrain, or fix the platform before users notice.
 
 ## Sources
 


### PR DESCRIPTION
Update sibling module links to be parent-relative to fix broken navigation in mlops section. Replaced `./module-` with `../module-` for 'Next', 'Continue', and 'Up next' references.