### PR TITLE
fix(k8s): parent-relative next-module links in cnpa/cgoa/lfcs (#2346)

### DIFF
--- a/src/content/docs/k8s/cgoa/module-1.1-exam-strategy-and-blueprint-review.md
+++ b/src/content/docs/k8s/cgoa/module-1.1-exam-strategy-and-blueprint-review.md
@@ -553,4 +553,4 @@ EOF
 
 ## Next Module
 
-Continue with [CGOA GitOps Principles Review](./module-1.2-gitops-principles-review/).
+Continue with [CGOA GitOps Principles Review](../module-1.2-gitops-principles-review/).

--- a/src/content/docs/k8s/cgoa/module-1.2-gitops-principles-review.md
+++ b/src/content/docs/k8s/cgoa/module-1.2-gitops-principles-review.md
@@ -551,4 +551,4 @@ The log should show at least two commits, the manifest should show the debug ima
 
 ## Next Module
 
-Continue with [CGOA Patterns and Tooling Review](./module-1.3-patterns-and-tooling-review/).
+Continue with [CGOA Patterns and Tooling Review](../module-1.3-patterns-and-tooling-review/).

--- a/src/content/docs/k8s/cgoa/module-1.3-patterns-and-tooling-review.md
+++ b/src/content/docs/k8s/cgoa/module-1.3-patterns-and-tooling-review.md
@@ -549,4 +549,4 @@ Success criteria:
 
 ## Next Module
 
-Continue with [CGOA Practice Questions Set 1](./module-1.4-practice-questions-set-1/) to turn these patterns into exam-style reasoning under time pressure.
+Continue with [CGOA Practice Questions Set 1](../module-1.4-practice-questions-set-1/) to turn these patterns into exam-style reasoning under time pressure.

--- a/src/content/docs/k8s/cgoa/module-1.4-practice-questions-set-1.md
+++ b/src/content/docs/k8s/cgoa/module-1.4-practice-questions-set-1.md
@@ -604,4 +604,4 @@ A strong final explanation says GitOps uses Git as the reviewed desired-state so
 
 ## Next Module
 
-Continue with [CGOA Practice Questions Set 2](./module-1.5-practice-questions-set-2/), where you will apply the same GitOps reasoning to a second set of scenario-driven questions.
+Continue with [CGOA Practice Questions Set 2](../module-1.5-practice-questions-set-2/), where you will apply the same GitOps reasoning to a second set of scenario-driven questions.

--- a/src/content/docs/k8s/cnpa/module-1.1-exam-strategy-and-blueprint-review.md
+++ b/src/content/docs/k8s/cnpa/module-1.1-exam-strategy-and-blueprint-review.md
@@ -515,4 +515,4 @@ The next study action should be traceable to evidence. If your error log shows t
 
 ## Next Module
 
-Continue with [CNPA Core Platform Fundamentals Review](./module-1.2-core-platform-fundamentals-review/), where you will apply this strategy to the platform engineering concepts that anchor the rest of the CNPA blueprint.
+Continue with [CNPA Core Platform Fundamentals Review](../module-1.2-core-platform-fundamentals-review/), where you will apply this strategy to the platform engineering concepts that anchor the rest of the CNPA blueprint.

--- a/src/content/docs/k8s/cnpa/module-1.2-core-platform-fundamentals-review.md
+++ b/src/content/docs/k8s/cnpa/module-1.2-core-platform-fundamentals-review.md
@@ -799,4 +799,4 @@ When you answer CNPA questions, use the framework as a filtering tool. Reject an
 
 ## Next Module
 
-Continue with [CNPA Delivery, APIs, and Observability Review](./module-1.3-delivery-apis-and-observability-review/).
+Continue with [CNPA Delivery, APIs, and Observability Review](../module-1.3-delivery-apis-and-observability-review/).

--- a/src/content/docs/k8s/cnpa/module-1.3-delivery-apis-and-observability-review.md
+++ b/src/content/docs/k8s/cnpa/module-1.3-delivery-apis-and-observability-review.md
@@ -442,7 +442,7 @@ logs, metrics, and SLO alerts. The next move is to inspect the SLI numerator and
 
 ## Next Module
 
-Continue with [CNPA Practice Questions Set 1](./module-1.4-practice-questions-set-1/).
+Continue with [CNPA Practice Questions Set 1](../module-1.4-practice-questions-set-1/).
 
 ## Sources
 

--- a/src/content/docs/k8s/cnpa/module-1.4-practice-questions-set-1.md
+++ b/src/content/docs/k8s/cnpa/module-1.4-practice-questions-set-1.md
@@ -527,4 +527,4 @@ Both delete commands should return a deletion message if the namespaces exist. I
 
 ## Next Module
 
-Continue with [CNPA Practice Questions Set 2](./module-1.5-practice-questions-set-2/) to practice comparison traps across reconciliation, platform ownership, delivery APIs, and developer experience metrics.
+Continue with [CNPA Practice Questions Set 2](../module-1.5-practice-questions-set-2/) to practice comparison traps across reconciliation, platform ownership, delivery APIs, and developer experience metrics.

--- a/src/content/docs/k8s/lfcs/module-1.1-exam-strategy-and-workflow.md
+++ b/src/content/docs/k8s/lfcs/module-1.1-exam-strategy-and-workflow.md
@@ -413,4 +413,4 @@ Start by writing the object, desired state, and proof command for each practice 
 
 ## Next Module
 
-Continue to [LFCS Essential Commands Practice](./module-1.2-essential-commands-practice/) to turn this strategy into repeated file, text, permissions, and shell-navigation drills.
+Continue to [LFCS Essential Commands Practice](../module-1.2-essential-commands-practice/) to turn this strategy into repeated file, text, permissions, and shell-navigation drills.

--- a/src/content/docs/k8s/lfcs/module-1.3-running-systems-and-networking-practice.md
+++ b/src/content/docs/k8s/lfcs/module-1.3-running-systems-and-networking-practice.md
@@ -551,4 +551,4 @@ Success criteria should prove both repair and cleanup, so do not mark the exerci
 
 ## Next Module
 
-Continue to [LFCS Storage, Services & Users Practice](./module-1.4-storage-services-and-users-practice/).
+Continue to [LFCS Storage, Services & Users Practice](../module-1.4-storage-services-and-users-practice/).

--- a/src/content/docs/k8s/lfcs/module-1.4-storage-services-and-users-practice.md
+++ b/src/content/docs/k8s/lfcs/module-1.4-storage-services-and-users-practice.md
@@ -686,4 +686,4 @@ After the service starts, check the exact success condition the task names. If t
 
 ## Next Module
 
-Next: [LFCS Full Mock Exam](./module-1.5-full-mock-exam/) brings these skills together in a timed end-to-end practice run where identity, storage, service, and verification habits must work as one coherent operating routine.
+Next: [LFCS Full Mock Exam](../module-1.5-full-mock-exam/) brings these skills together in a timed end-to-end practice run where identity, storage, service, and verification habits must work as one coherent operating routine.


### PR DESCRIPTION
Fix sibling relative links by changing `./module-` to `../module-` for Next/Continue links in cnpa, cgoa, and lfcs tracks, fixing trailing slash issues.