### PR TITLE
fix(glossary): distinguish SLO objectives from SLA agreements (#2386)

### DIFF
--- a/src/content/docs/glossary.md
+++ b/src/content/docs/glossary.md
@@ -69,7 +69,8 @@ title: "\u0413\u043b\u043e\u0441\u0430\u0440\u0456\u0439 KubeDojo / KubeDojo Glo
 | metrics | метрики |
 | alerting | оповіщення |
 | incident | інцидент |
-| SLO | SLO (угода про рівень обслуговування) |
+| SLO | SLO (ціль рівня обслуговування, вимірюється через SLI) |
+| SLA | SLA (угода про рівень обслуговування з наслідками за порушення) |
 | error budget | бюджет помилок |
 | GitOps | GitOps |
 | CI/CD | CI/CD |

--- a/src/content/docs/uk/glossary.md
+++ b/src/content/docs/uk/glossary.md
@@ -69,7 +69,8 @@ title: "Глосарій KubeDojo / KubeDojo Glossary"
 | metrics | метрики |
 | alerting | оповіщення |
 | incident | інцидент |
-| SLO | SLO (угода про рівень обслуговування) |
+| SLO | SLO (ціль рівня обслуговування, вимірюється через SLI) |
+| SLA | SLA (угода про рівень обслуговування з наслідками за порушення) |
 | error budget | бюджет помилок |
 | GitOps | GitOps |
 | CI/CD | CI/CD |


### PR DESCRIPTION
## Summary
- Fixes #2386 (epic #2272, parent #2300)
- Both `src/content/docs/glossary.md` and `src/content/docs/uk/glossary.md` wrongly mapped **SLO** to «угода про рівень обслуговування» (service level *agreement*).
- SLO row now reads «ціль рівня обслуговування, вимірюється через SLI» — the objective/target, per the Google SRE book's Objectives vs Agreements distinction.
- Added the missing **SLA** row as «угода про рівня обслуговування з наслідками за порушення» — the agreement with consequences.

## Verification
- `npx markdownlint-cli2` on both files: 0 issues
- Table formatting matches neighboring 2-column rows; no other glossary rows touched
- Astro build not run from this worktree (known worktree resolution limitation per AGENTS.md); branch CI will validate — change is a 2-line markdown table edit

## Scope
- 2 files changed, 4 insertions, 2 deletions
- No #2110 production wording work; no unrelated glossary edits