### PR TITLE
feat(cka): runner write/evidence/receipt helpers (#2478)

### DIFF
--- a/scripts/cka_certificate_process.sh
+++ b/scripts/cka_certificate_process.sh
@@ -219,8 +219,9 @@ cka_cert_capture() {
   [[ $# -ge 3 ]] || return 1
   deadline=$1; mode=$2; shift 2
   case "$mode:$1" in
-    read:cka_cert_supervisor_receipt_payload|read:cka_cert_decision_observation|\
-    read:cka_cert_decision_proposal|read:cka_cert_decision_classify|read:cka_cert_runner_payload|read:cka_cert_runner_read|utility:jq|utility:mktemp|utility:stat) ;;
+    read:cka_cert_runner_payload|read:cka_cert_runner_read|read:cka_cert_runner_evidence|\
+    read:cka_cert_runner_receipt_read|read:cka_cert_supervisor_receipt_payload|read:cka_cert_decision_observation|\
+    read:cka_cert_decision_proposal|read:cka_cert_decision_classify|utility:jq|utility:mktemp|utility:stat) ;;
     *) return 1 ;;
   esac
   cka_cert_deadline_budget "$deadline" || return $?
@@ -324,8 +325,10 @@ cka_cert_run_read_helper() {
   case $1 in
     cka_cert_process_check|cka_cert_process_read|cka_cert_process_payload|cka_cert_capture_directory|\
     cka_cert_decision_observation|cka_cert_decision_proposal|cka_cert_decision_classify|\
+    cka_cert_runner_payload|cka_cert_runner_live|cka_cert_runner_read|cka_cert_runner_permission|\
+    cka_cert_runner_evidence|cka_cert_runner_receipt_read|cka_cert_runner_before|\
     cka_cert_state_expected|cka_cert_state_descriptor|cka_cert_state_file|\
-    cka_cert_supervisor_receipt_payload|cka_cert_supervisor_receipt_read|cka_cert_runner_payload|cka_cert_runner_live|cka_cert_runner_read) ;;
+    cka_cert_supervisor_receipt_payload|cka_cert_supervisor_receipt_read) ;;
     *) return 1 ;;
   esac
   cka_cert_deadline_budget "$deadline" || return $?
@@ -687,4 +690,78 @@ cka_cert_runner_read() {
   cka_cert_state_file "$path" || return 1
   payload=$(cat -- "$path") || return 1
   cka_cert_runner_payload "$1" "$2" "$3" "$4" "$payload"
+}
+
+# Evidence records are exclusive, never an alternate lifecycle authority.
+# Direct invocation only; all utility children drop FD8 while this actor retains it.
+cka_cert_runner_write() {
+  local deadline identity operation binding kind payload target temporary actor child
+  [[ $# == 6 && ${CKA_CERT_STATE_OWNS_FD:-0} == 1 ]] || return 1
+  deadline=$1; identity=$2; operation=$3; binding=$4; kind=$5
+  cka_cert_capture "$deadline" read cka_cert_runner_payload "$identity" "$operation" "$binding" "$kind" "$6" || return $?
+  payload=$CKA_CERT_CAPTURED
+  cka_cert_capture "$deadline" utility jq -cr .child <<< "$payload" || return $?
+  child=$CKA_CERT_CAPTURED
+  case $kind in ready) actor=.runner.pid ;; admission) actor=.supervisor.pid ;; *) actor=.child.pid ;; esac
+  cka_cert_capture "$deadline" utility jq -er "$actor" <<< "$payload" || return $?
+  [[ $BASHPID == "$CKA_CERT_CAPTURED" ]] || return 1
+  cka_cert_run_read_helper "$deadline" cka_cert_runner_live "$binding" "$child" || return $?
+  cka_cert_run_read_helper "$deadline" cka_cert_process_check "$identity" "$operation" || return $?
+  cka_cert_run_read_helper "$deadline" cka_cert_state_descriptor || return $?
+  cka_cert_run_utility "$deadline" -- flock -n 9 || return $?
+  target=/var/lib/cka-certificate-transaction/runner-$kind.json
+  [[ ! -e $target && ! -L $target ]] || return 1
+  cka_cert_capture "$deadline" utility mktemp /var/lib/cka-certificate-transaction/runner.XXXXXXXX || return $?
+  temporary=$CKA_CERT_CAPTURED
+  cka_cert_run_read_helper "$deadline" cka_cert_state_file "$temporary" || return $?
+  cka_cert_deadline_budget "$deadline" || return $?
+  printf '%s\n' "$payload" > "$temporary" || return 1
+  cka_cert_run_utility "$deadline" -- sync -f "$temporary" || return $?
+  cka_cert_run_utility "$deadline" -- ln -T -- "$temporary" "$target" || return $?
+  cka_cert_run_utility "$deadline" -- unlink -- "$temporary" || return $?
+  cka_cert_run_utility "$deadline" -- sync -f /var/lib/cka-certificate-transaction || return $?
+  cka_cert_run_read_helper "$deadline" cka_cert_runner_read "$identity" "$operation" "$binding" "$kind" >/dev/null
+}
+
+# The caller retains freshly acquired FD8. A cancelled or changed state refuses launch.
+cka_cert_runner_permission() {
+  local record
+  [[ $# == 4 && ( $4 == supervisor_ready || $4 == command_launch_committed ) ]] || return 1
+  cka_cert_runner_live "$3" null || return 1
+  record=$(cka_cert_process_read "$1" "$2") || return 1
+  jq -e --argjson binding "$3" --arg stage "$4" \
+    '.stage==$stage and .supervisor==$binding.supervisor and .cancel_ack==false and .cause=="none"' \
+    <<< "$record" >/dev/null || return 1
+  cka_cert_process_cancel_read "$1" "$2" && [[ $CKA_CERT_PROCESS_CANCEL == 0 ]]
+}
+
+# Constructor uses the invocation's original binding, never adopts recorded argv.
+cka_cert_runner_record() {
+  [[ $# == 6 ]] || return 1
+  cka_cert_capture "$1" utility jq -cn --argjson identity "$2" --arg operation "$3" \
+    --argjson binding "$4" --arg kind "$5" --argjson child "$6" \
+    '$binding+{schema:1,identity:$identity,operation_id:$operation,kind:$kind,child:$child}'
+}
+
+# Retrospective validation uses preserved live evidence, not /proc after reaping.
+cka_cert_runner_evidence() {
+  local birth entry
+  [[ $# == 3 ]] || return 1
+  birth=$(cka_cert_runner_read "$1" "$2" "$3" birth) || return 1
+  entry=$(cka_cert_runner_read "$1" "$2" "$3" entry) || return 1
+  jq -ce --argjson birth "$birth" 'select(.==($birth|.kind="entry")) | .child' <<< "$entry"
+}
+
+# Only this composite reader supplies accepted command evidence to supervision.
+# Expected binding (including argv) comes from the original admitted invocation.
+cka_cert_runner_receipt_read() {
+  local child receipt supervisor runner
+  [[ $# == 3 ]] || return 1
+  cka_cert_runner_read "$1" "$2" "$3" ready >/dev/null || return 1
+  cka_cert_runner_read "$1" "$2" "$3" admission >/dev/null || return 1
+  child=$(cka_cert_runner_evidence "$1" "$2" "$3") || return 1
+  supervisor=$(jq -ce .supervisor <<< "$3") || return 1
+  runner=$(jq -ce .runner <<< "$3") || return 1
+  receipt=$(cka_cert_supervisor_receipt_read "$1" "$2" "$supervisor" "$runner") || return 1
+  jq -ce --argjson child "$child" 'select(.child_pid==$child.pid)' <<< "$receipt"
 }

--- a/scripts/tests/test_cka_runner_write_evidence.py
+++ b/scripts/tests/test_cka_runner_write_evidence.py
@@ -1,0 +1,117 @@
+"""Runner write/evidence helpers with injected custody; not kind renewal proof."""
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class TestRunnerWriteEvidence(unittest.TestCase):
+    def setUp(self):
+        self.identity = {
+            "transaction_id": "a" * 32,
+            "fixture_cluster": "cert-fixture-" + "b" * 32,
+            "docker_container_id": "c" * 64,
+            "image_id": "sha256:" + "d" * 64,
+            "system_namespace_uid": "12345678-1234-1234-1234-123456789abc",
+            "artifact_hashes": {
+                name + ".sh": "e" * 64 for name in ("state", "observe", "process")
+            },
+        }
+        self.operation = "f" * 32
+        self.binding = {
+            "supervisor": {"pid": 21, "pgid": 21, "sid": 21, "start_time": "123"},
+            "runner": {"pid": 22, "start_time": "124"},
+            "argv": ["/bin/true"],
+        }
+        self.root = Path(__file__).resolve().parents[2]
+
+    def bash(self, script, *args, library=None):
+        return subprocess.run(
+            ["bash", "-c", script, "--",
+             str(self.root / "scripts/cka_certificate_state.sh"),
+             str(library or self.root / "scripts/cka_certificate_process.sh"), *args],
+            capture_output=True, text=True, check=False, timeout=8,
+        )
+
+    def test_record_and_evidence(self):
+        result = self.bash(
+            r'''
+source "$1"; source "$2"
+CKA_CERT_STATE_OWNS_FD=1
+cka_cert_capture() { shift 2; "$@"; CKA_CERT_CAPTURED=$(cat); }
+cka_cert_runner_record 10000 "$3" "$4" "$5" ready null
+printf '%s' "$CKA_CERT_CAPTURED"
+''',
+            json.dumps(self.identity), self.operation, json.dumps(self.binding),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual((payload["schema"], payload["kind"], payload["child"]), (1, "ready", None))
+
+        child = {"pid": 23, "start_time": "125"}
+        birth = {**self.binding, "schema": 1, "identity": self.identity,
+                 "operation_id": self.operation, "kind": "birth", "child": child}
+        entry = dict(birth, kind="entry")
+        ok = self.bash(
+            r'''
+source "$1"; source "$2"
+birth_json=$3; entry_json=$4
+cka_cert_runner_read() {
+  case $4 in birth) printf '%s' "$birth_json" ;; entry) printf '%s' "$entry_json" ;; *) return 1 ;; esac
+}
+cka_cert_runner_evidence id op '{}'
+''',
+            json.dumps(birth), json.dumps(entry),
+        )
+        self.assertEqual(ok.returncode, 0, ok.stderr)
+        self.assertEqual(json.loads(ok.stdout), child)
+
+    def test_write_publishes_exclusive_ready_record(self):
+        process = (self.root / "scripts/cka_certificate_process.sh").read_text()
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            library = base / "process.sh"
+            library.write_text(process.replace("/var/lib/cka-certificate-transaction", str(base)))
+            payload = {**self.binding, "schema": 1, "identity": self.identity,
+                       "operation_id": self.operation, "kind": "ready", "child": None}
+            result = self.bash(
+                r'''
+source "$1"; source "$2"
+root=$3; payload=$4; CKA_CERT_STATE_OWNS_FD=1
+cka_cert_deadline_budget() { [[ $1 == 10000 ]]; }
+cka_cert_capture() {
+  local deadline=$1 mode=$2; shift 2
+  case $mode:$1 in
+    read:cka_cert_runner_payload) shift; CKA_CERT_CAPTURED=$5 ;;
+    utility:jq|utility:mktemp) CKA_CERT_CAPTURED=$(command "$@") || return $? ;;
+    *) return 1 ;;
+  esac
+}
+cka_cert_run_read_helper() {
+  shift
+  case $1 in
+    cka_cert_runner_live|cka_cert_process_check|cka_cert_state_descriptor) ;;
+    cka_cert_state_file) [[ -f $2 ]] ;;
+    cka_cert_runner_read) cat -- "$root/runner-ready.json" ;;
+    *) return 1 ;;
+  esac
+}
+cka_cert_run_utility() {
+  shift; [[ $1 == -- ]] || return 1; shift
+  case $1 in
+    flock|sync) ;;
+    unlink) command unlink -- "$3" ;;
+    ln) shift; while [[ ${1:-} == -T || ${1:-} == -- ]]; do shift; done; command ln "$1" "$2" ;;
+    *) return 1 ;;
+  esac
+}
+pid=$BASHPID
+payload=$(jq -c --argjson pid "$pid" '.runner.pid=$pid' <<< "$payload")
+cka_cert_runner_write 10000 "$5" "$6" "$7" ready "$payload"
+jq -e --argjson want "$payload" '.==$want' < "$root/runner-ready.json" >/dev/null
+''',
+                str(base), json.dumps(payload), json.dumps(self.identity),
+                self.operation, json.dumps(self.binding), library=library,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)


### PR DESCRIPTION
## Summary
- Slice C of #2478: `cka_cert_runner_write`, `record`, `evidence`, `receipt_read`, `permission`
- Capture/read allowlists extended for evidence/receipt/before
- Unit tests (2 passed) with injected custody; macOS harness maps `ln -T`

Follows #2538 / #2539. Parent #2280 / epic #2272. Still no kind renewal.

## Test plan
- [x] ruff + pytest on new tests
- [ ] CI green on exact head
- [ ] Cross-family review (exact head + VERDICT)


Made with [Cursor](https://cursor.com)