### PR TITLE
feat(cka): runner wait_candidate + entry (#2478)

### DIFF
--- a/scripts/cka_certificate_process.sh
+++ b/scripts/cka_certificate_process.sh
@@ -628,6 +628,27 @@ cka_cert_decision_reconcile() {
   return "$result"
 }
 
+cka_cert_runner_wait_candidate() {
+  local child generation result completed
+  unset CKA_CERT_WAIT_EXIT
+  [[ $# == 1 && $1 =~ ^[1-9][0-9]*$ &&
+     ${CKA_CERT_WAIT_GENERATION:-} =~ ^[0-9]+$ ]] || return 1
+  child=$1
+  [[ ! -o posix && ! -o monitor ]] || return 1
+  while :; do
+    generation=$CKA_CERT_WAIT_GENERATION
+    unset completed
+    if wait -p completed "$child"; then result=0; else result=$?; fi
+    # Conservatively repeat even if the signal followed a real completion.
+    # Non-POSIX explicit wait retains the cached status for this same PID.
+    (( generation == CKA_CERT_WAIT_GENERATION )) || continue
+    [[ ${completed:-} == "$child" ]] || return 1
+    CKA_CERT_WAIT_EXIT=$result
+    return 0
+  done
+}
+
+
 # Pure runner-record schema validation (Slice A / #2478). No live custody.
 # Rejects argv with embedded NUL; ready/admission require child==null;
 # birth/entry require a person-shaped child distinct from runner/supervisor.
@@ -764,4 +785,25 @@ cka_cert_runner_receipt_read() {
   runner=$(jq -ce .runner <<< "$3") || return 1
   receipt=$(cka_cert_supervisor_receipt_read "$1" "$2" "$supervisor" "$runner") || return 1
   jq -ce --argjson child "$child" 'select(.child_pid==$child.pid)' <<< "$receipt"
+}
+
+# Fixed clean-Bash entrypoint; reaching this function occurs AFTER its exec.
+# Entry proves this wrapper began, never that the reviewed nested argv executed.
+cka_cert_runner_entry() {
+  local deadline identity operation binding birth child argv result
+  [[ $# -ge 5 && ${BASH_VERSINFO[0]} == 5 && ${BASH_VERSINFO[1]} == 2 ]] || return 1
+  deadline=$1; identity=$2; operation=$3; binding=$4; shift 4
+  cka_cert_capture "$deadline" utility jq -cn --args '$ARGS.positional' -- "$@" || return $?
+  argv=$CKA_CERT_CAPTURED
+  cka_cert_capture "$deadline" utility jq -ce --argjson argv "$argv" \
+    'select(.argv==$argv)' <<< "$binding" || return $?
+  cka_cert_capture "$deadline" read cka_cert_runner_read "$identity" "$operation" "$binding" birth || return $?
+  birth=$CKA_CERT_CAPTURED
+  cka_cert_capture "$deadline" utility jq -ce .child <<< "$birth" || return $?
+  child=$CKA_CERT_CAPTURED
+  cka_cert_runner_record "$deadline" "$identity" "$operation" "$binding" entry "$child" || return $?
+  cka_cert_runner_write "$deadline" "$identity" "$operation" "$binding" entry "$CKA_CERT_CAPTURED" || return $?
+  cka_cert_deadline_budget "$deadline" || return $?
+  if "$@"; then result=0; else result=$?; fi
+  return "$result"
 }

--- a/scripts/tests/test_cka_runner_entry_wait.py
+++ b/scripts/tests/test_cka_runner_entry_wait.py
@@ -1,0 +1,92 @@
+"""Runner wait_candidate + entry gates with injected custody; not kind renewal."""
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+
+class TestRunnerEntryWait(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(__file__).resolve().parents[2]
+        self.binding = {
+            "supervisor": {"pid": 21, "pgid": 21, "sid": 21, "start_time": "123"},
+            "runner": {"pid": 22, "start_time": "124"},
+            "argv": ["/bin/true"],
+        }
+
+    def bash(self, script, *args):
+        return subprocess.run(
+            [
+                "bash",
+                "-c",
+                script,
+                "--",
+                str(self.root / "scripts/cka_certificate_state.sh"),
+                str(self.root / "scripts/cka_certificate_process.sh"),
+                *args,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=8,
+        )
+
+    def test_wait_candidate_records_child_exit(self):
+        result = self.bash(
+            r"""
+source "$1"; source "$2"
+set +o posix; set +m
+CKA_CERT_WAIT_GENERATION=0
+(exit 42) &
+child=$!
+cka_cert_runner_wait_candidate "$child" || exit 1
+[[ $CKA_CERT_WAIT_EXIT == 42 ]]
+"""
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+    def test_entry_enforces_bash_52_and_argv(self):
+        birth = {
+            **self.binding,
+            "schema": 1,
+            "kind": "birth",
+            "child": {"pid": 23, "start_time": "125"},
+            "identity": {"transaction_id": "a" * 32},
+            "operation_id": "f" * 32,
+        }
+        result = self.bash(
+            r"""
+source "$1"; source "$2"
+binding=$3
+birth_json=$4
+CKA_CERT_STATE_OWNS_FD=1
+cka_cert_deadline_budget() { [[ $1 == 10000 ]]; }
+cka_cert_capture() {
+  local deadline=$1 mode=$2; shift 2
+  case $mode:$1 in
+    utility:jq) CKA_CERT_CAPTURED=$(command "$@") || return $? ;;
+    read:cka_cert_runner_read) CKA_CERT_CAPTURED=$birth_json ;;
+    *) return 1 ;;
+  esac
+}
+cka_cert_runner_record() {
+  CKA_CERT_CAPTURED=$(jq -cn --argjson binding "$4" --arg kind "$5" --argjson child "$6" \
+    '$binding+{schema:1,kind:$kind,child:$child}')
+}
+cka_cert_runner_write() { [[ $5 == entry && -n $6 ]]; }
+if cka_cert_runner_entry 10000 id op "$binding" /bin/echo ok; then
+  printf 'ran:%s.%s\n' "${BASH_VERSINFO[0]}" "${BASH_VERSINFO[1]}"
+else
+  printf 'refuse:%s.%s\n' "${BASH_VERSINFO[0]}" "${BASH_VERSINFO[1]}"
+fi
+""",
+            json.dumps(self.binding),
+            json.dumps(birth),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        major, minor = result.stdout.strip().split(":")[1].split(".")
+        if (major, minor) == ("5", "2"):
+            self.assertTrue(result.stdout.startswith("ran:"), result.stdout)
+        else:
+            self.assertTrue(result.stdout.startswith("refuse:"), result.stdout)


### PR DESCRIPTION
## Summary
- Slice D1 of #2478: `cka_cert_runner_wait_candidate` + `cka_cert_runner_entry`
- Unit tests for wait exit capture + Bash 5.2 gate (refuses on 5.3 hosts; runs on 5.2 CI)
- `body` / `before` / `launch*` deferred to keep ≤200 LOC

Parent #2280 / epic #2272. English-first; UK parked.

## Test plan
- [x] ruff + pytest on new tests
- [ ] CI green on exact head
- [ ] Cross-family review (exact head + VERDICT)


Made with [Cursor](https://cursor.com)