### PR TITLE
feat(k8s): Release Radar for 1.35–1.37 dual-track onboarding (#2542)

### DIFF
--- a/.claude/rules/module-quality.md
+++ b/.claude/rules/module-quality.md
@@ -55,7 +55,7 @@ paths:
 - Code blocks specify language (```bash, ```yaml, ```go)
 - YAML: 2-space indentation
 - kubectl alias: use `k` after explaining it once
-- K8s version: 1.35+
+- K8s version: 1.35+ for exam-pinned cert content; Release Radar covers supported upstream minors (see `docs/pins/kubernetes.yaml`)
 - Do NOT repeat the number 47 (known LLM pattern)
 - Do NOT use emojis
 - Do NOT write "list of facts" modules — if sections are just bullets, it's a reference doc, not a lesson

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,7 @@ and final `git status --short --branch` for worktree and primary checkout.
 
 Published content lives in `src/content/docs/`; Ukrainian content mirrors it in
 `src/content/docs/uk/`. Navigation uses Starlight configuration and frontmatter,
-including `title:` and `sidebar.order:`. Kubernetes content targets 1.35 unless
+including `title:` and `sidebar.order:`. Kubernetes **exam-pinned** content targets 1.35 unless
 the task establishes a newer target. Pipeline v2 is the default; v1 remains for
 compatibility.
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -342,6 +342,11 @@ export default defineConfig({
           items: [
             { label: 'Certifications Hub', link: '/k8s/' },
             {
+              label: 'Release Radar',
+              collapsed: true,
+              items: [{ autogenerate: { directory: 'k8s/releases', collapsed: true } }],
+            },
+            {
               label: 'Core Kubernetes',
               collapsed: true,
               items: [

--- a/docs/pins/kubernetes.yaml
+++ b/docs/pins/kubernetes.yaml
@@ -1,0 +1,20 @@
+# KubeDojo Kubernetes version pins (X06 / #2542).
+# Agents: bump exam_pin only after verifying LF/CNCF exam environment.
+# Bump latest_stable_track when upstream adds a new supported minor.
+
+exam_pin:
+  kubernetes_minor: "1.35"
+  applies_to: ["cka", "ckad", "cks", "kcna", "kcsa"]
+  verified_date: "2026-09-12"
+  verified_note: "Curriculum remains exam-pinned at 1.35 until LF/CNCF exam docs show otherwise."
+
+latest_stable_track:
+  policy: "tracks upstream supported minor branches (typically three)"
+  supported_minors: ["1.37", "1.36", "1.35"]
+  as_of: "2026-09-12"
+  source: "https://kubernetes.io/releases/"
+
+kind_node_images:
+  "1.35": "kindest/node:v1.35.0"
+  "1.36": "kindest/node:v1.36.1"
+  "1.37": "kindest/node:v1.37.0"

--- a/docs/release-maintenance/kubernetes-minor-release-playbook.md
+++ b/docs/release-maintenance/kubernetes-minor-release-playbook.md
@@ -1,0 +1,54 @@
+# Kubernetes minor-release playbook (agents)
+
+Standing workflow for X06 (#2542). Humans may run the same steps.
+
+## Rules
+
+1. **Do not rewrite CKA/CKAD/CKS modules** when upstream ships a minor.
+2. **Exam pin** (`docs/pins/kubernetes.yaml` → `exam_pin`) moves only after web-verified LF/CNCF exam / curriculum PDF change.
+3. **Latest-stable track** always mirrors upstream’s supported minors (~3).
+4. Prefer **official** release blogs + CHANGELOG + docs version paths as sources. Third-party roundups are secondary.
+5. Ignore most **alpha** unless paradigm-shifting; teach beta (esp. on-by-default) and GA deeply.
+6. Never confuse **busybox:1.36** (image tag) with cluster version **1.36**.
+
+## Detect
+
+1. Open https://kubernetes.io/releases/ — note the three supported minors.
+2. If a new GA minor appears that is missing under `src/content/docs/k8s/releases/`, open/update the X06 child issue and proceed.
+
+## Inventory
+
+1. Read the official release blog (`kubernetes.io/blog/.../kubernetes-v1-XX-release/`).
+2. Skim `CHANGELOG/CHANGELOG-1.XX.md` for removals/deprecations.
+3. Classify: Stable / Beta / Alpha / Deprecated / Removed.
+4. Set **cert impact**: `none` | `watch` | `bump-needed` (bump-needed only when exam pin moves).
+
+## Author
+
+Copy the structure of an existing `v1.XX.md` Release Radar page:
+
+- Executive summary + theme name
+- Learner-visible Stable table (who cares)
+- Deprecations / removals
+- Cert impact box
+- Practice pointers (kind image from `docs/pins/kubernetes.yaml`)
+- Sources (official links + verification date)
+
+Update `latest_stable_track.supported_minors` and sidebar order (newest first). Add a What’s New (`changelog.md`) bullet.
+
+## Review / merge
+
+Cross-family review on exact head. Build from **primary** checkout, not a worktree.
+
+## Retire
+
+When a minor leaves upstream support, move its page to an “Archive” note on the Release Radar index; keep the page for history but remove it from “supported now”.
+
+## Exam-pin bump (rare)
+
+Only when LF/CNCF exam environment version changes:
+
+1. Update `exam_pin` in `docs/pins/kubernetes.yaml` with new `verified_date`.
+2. Update `AGENTS.md`, `.claude/rules/module-quality.md`, `scripts/prompts/module-writer.md`.
+3. Grep `1.3N` / `v1-3N.docs` / `kindest/node:v1.3N` / fixture scripts — surgical patches only, driven by Release Radar migration notes.
+4. Separate PR from Release Radar delta authorship.

--- a/docs/release-maintenance/kubernetes-release-bundle-template.md
+++ b/docs/release-maintenance/kubernetes-release-bundle-template.md
@@ -1,0 +1,26 @@
+# Per-minor Release Radar bundle template
+
+Copy this structure into `src/content/docs/k8s/releases/v1.XX.md` for every new upstream minor (X06 / #2545).
+
+```markdown
+---
+title: "Kubernetes 1.XX — <Theme>"
+description: "Release Radar for Kubernetes 1.XX: Stable highlights, cert impact, and practice links."
+sidebar:
+  order: <newest=3, then increment>
+  label: "1.XX <Theme>"
+---
+
+> **Cert impact:** `none` | `watch` | `bump-needed`
+> **Upstream status:** Actively supported | Maintenance | EOL
+> **GA:** YYYY-MM-DD · Theme: **Name**
+
+## Who should read this
+## Stable highlights (learner-visible)  # table: Theme | What | Why
+## Removals / breaking                 # required if any
+## Practice                            # kind image + 1–2 diff drills
+## Agent checklist
+## Sources                             # official blog, CHANGELOG, releases page; verification date
+```
+
+**Required:** official sources + verification date. **Forbidden:** rewriting cert tracks in the same PR; documenting every alpha as production guidance.

--- a/scripts/prompts/module-writer.md
+++ b/scripts/prompts/module-writer.md
@@ -88,7 +88,7 @@ TASK: Write a complete KubeDojo educational module.
 - YAML: 2-space indentation, valid syntax
 - Code blocks must specify the language (```bash, ```yaml, ```go, etc.)
 - Do NOT rely on shell aliases in runnable Bash examples. Do not define a short alias for `kubectl`, and do not use the `k` shorthand for get/describe/apply-style commands inside fenced ```bash / ```sh / ```shell / ```zsh blocks. Aliases do not expand in non-interactive shells, so use the full `kubectl` binary name in copy-paste examples. Prose like "many engineers use a short kubectl alias interactively" is fine.
-- Kubernetes version: 1.35+
+- Kubernetes version: 1.35+ for exam-pinned cert modules; use Release Radar (`/k8s/releases/`) for 1.36/1.37+ deltas
 
 **PEDAGOGICAL REQUIREMENTS** (from `docs/pedagogical-framework.md`):
 - Every module must operate at Bloom's Taxonomy Level 3 (Apply) or above

--- a/src/content/docs/changelog.md
+++ b/src/content/docs/changelog.md
@@ -6,6 +6,10 @@ sidebar:
   label: "What's New"
 ---
 
+## September 2026
+
+- **Kubernetes Release Radar (1.35 / 1.36 / 1.37).** New [Release Radar](/k8s/releases/) under Certifications: dual-track [exam version policy](/k8s/releases/exam-version-policy/) (exam pin stays **1.35** until LF moves), per-minor pages for [1.37 Garhwal](/k8s/releases/v1.37/), [1.36 Haru](/k8s/releases/v1.36/), and [1.35 Timbernetes](/k8s/releases/v1.35/), plus a [kind practice matrix](/k8s/releases/practice-kind-matrix/). Machine pins in `docs/pins/kubernetes.yaml`; agent playbook in `docs/release-maintenance/`. Workstream #2542 (X06).
+
 ## June 2026
 
 - **AI/ML Engineering — the track is complete and currency-reviewed end to end.** The [AI/ML Engineering track](/ai-ml-engineering/) is now a full ~120-module curriculum across its phases, and every module has passed an independent cross-family quality review for technical accuracy and currency — model names, framework versions, and CNCF project maturity verified against upstream sources and quarantined into dated snapshots so the fast-moving specifics stay refreshable without rewriting the lessons. This cycle rounded out the track beyond the from-scratch deep-learning and machine-learning arcs noted below: [generative AI](/ai-ml-engineering/generative-ai/), [vector search & RAG](/ai-ml-engineering/vector-rag/), [agent frameworks](/ai-ml-engineering/frameworks-agents/), [advanced generative AI](/ai-ml-engineering/advanced-genai/), [multimodal AI](/ai-ml-engineering/multimodal-ai/), [AI infrastructure on Kubernetes](/ai-ml-engineering/ai-infrastructure/), and [reinforcement learning](/ai-ml-engineering/reinforcement-learning/). Issues #2020, #2031.

--- a/src/content/docs/k8s/index.md
+++ b/src/content/docs/k8s/index.md
@@ -4,6 +4,8 @@ sidebar:
   order: 1
   label: "Certifications"
 ---
+> **Release Radar:** Onboard Kubernetes **1.35 / 1.36 / 1.37** (and future minors) without mixing them into exam lessons — start at [Release Radar](/k8s/releases/) and the [exam version policy](/k8s/releases/exam-version-policy/).
+
 **The Kubestronaut Path** — All 5 certifications required for [Kubestronaut](https://www.cncf.io/training/kubestronaut/) status, CNCF's recognition for passing KCNA, KCSA, CKAD, CKA, and CKS.
 
 ---

--- a/src/content/docs/k8s/releases/exam-version-policy.md
+++ b/src/content/docs/k8s/releases/exam-version-policy.md
@@ -1,0 +1,53 @@
+---
+title: "Exam version policy"
+description: "Dual-track rules: exam-pinned certifications vs latest-stable Release Radar."
+sidebar:
+  order: 2
+  label: "Exam version policy"
+---
+
+KubeDojo runs **two tracks** on purpose. Mixing them is how learners fail exams and how agents rewrite the wrong files.
+
+## Track A — Exam pin (certifications)
+
+| Field | Value |
+|-------|-------|
+| Current pin | **Kubernetes 1.35** |
+| Applies to | CKA, CKAD, CKS, and associate tracks that declare the same target |
+| Verified | 2026-09-12 (re-check LF/CNCF exam docs before any bump) |
+| Source of truth | `docs/pins/kubernetes.yaml` → `exam_pin` |
+
+**Rules**
+
+- Cert modules teach the **exam environment** version, not “whatever is newest on kubernetes.io”.
+- Upstream GA of 1.36 or 1.37 does **not** by itself authorize a cert-corpus rewrite.
+- Bump the pin only after web-verified evidence that the Linux Foundation / CNCF exam (or published curriculum PDF) moved.
+
+Look for the inline target callouts already used in cert part-0 modules (for example CKA exam strategy). Prefer linking here rather than inventing a second story per lesson.
+
+## Track B — Latest-stable (Release Radar)
+
+| Field | Value |
+|-------|-------|
+| Supported minors | **1.37, 1.36, 1.35** (upstream three-branch window) |
+| Home | [Release Radar](/k8s/releases/) |
+| Source of truth | `docs/pins/kubernetes.yaml` → `latest_stable_track` |
+
+**Rules**
+
+- Teach **deltas**: Stable graduations, removals, on-by-default betas that change operator behavior.
+- Do **not** clone CKA/CKAD/CKS per minor.
+- When a minor leaves upstream support, archive it on the Release Radar index; keep history, drop “supported now”.
+
+## Shared fundamentals
+
+Pods, Deployments, Services, RBAC, scheduling basics, and troubleshooting method stay in the cert and prerequisites tracks. Release Radar assumes that foundation and shows **what changed**.
+
+## What agents must not do
+
+- Rewrite every cert module on each Kubernetes minor.
+- Treat `busybox:1.36` image tags as a cluster version pin.
+- Document every alpha feature as production guidance.
+- Silently bump `exam_pin` without LF/CNCF verification.
+
+Standing playbook: `docs/release-maintenance/kubernetes-minor-release-playbook.md`.

--- a/src/content/docs/k8s/releases/index.md
+++ b/src/content/docs/k8s/releases/index.md
@@ -1,0 +1,32 @@
+---
+title: "Kubernetes Release Radar"
+sidebar:
+  order: 1
+  label: "Release Radar"
+---
+
+**Track upstream Kubernetes minors without confusing them with your exam pin.**
+
+Upstream currently supports three minors at a time — today that is **1.37, 1.36, and 1.35** ([Kubernetes Releases](https://kubernetes.io/releases/), verified 2026-09-12). KubeDojo teaches those deltas here. Certification lessons (CKA/CKAD/CKS) stay on the **exam pin** until the Linux Foundation / CNCF exam environment moves — see [Exam version policy](/k8s/releases/exam-version-policy/).
+
+## Start here
+
+| Page | Use it when |
+|------|-------------|
+| [Exam version policy](/k8s/releases/exam-version-policy/) | You need the dual-track rules (exam vs latest-stable) |
+| [Kubernetes 1.37 — Garhwal](/k8s/releases/v1.37/) | Newest supported minor (GA 2026-08-26) |
+| [Kubernetes 1.36 — Haru](/k8s/releases/v1.36/) | Middle supported minor |
+| [Kubernetes 1.35 — Timbernetes](/k8s/releases/v1.35/) | Oldest supported minor **and** current exam-pin context |
+| [kind practice matrix](/k8s/releases/practice-kind-matrix/) | Local labs across the three minors |
+
+## How to read a release page
+
+1. **Cert impact** — usually `none` while the exam stays on 1.35.
+2. **Stable table** — learner/operator-visible GA items (not the full CHANGELOG).
+3. **Removals** — break your clusters if ignored (example: `gitRepo` volumes disabled in 1.36).
+4. **Practice** — prefer kind node images from the matrix; diff-only labs over full cert clones.
+5. **Sources** — official release blog + releases page; treat third-party roundups as secondary.
+
+## Agents
+
+Machine pins live in [`docs/pins/kubernetes.yaml`](https://github.com/kube-dojo/kube-dojo.github.io/blob/main/docs/pins/kubernetes.yaml). Standing workflow: [`docs/release-maintenance/kubernetes-minor-release-playbook.md`](https://github.com/kube-dojo/kube-dojo.github.io/blob/main/docs/release-maintenance/kubernetes-minor-release-playbook.md). Workstream: GitHub **#2542** (X06 under epic #2272).

--- a/src/content/docs/k8s/releases/practice-kind-matrix.md
+++ b/src/content/docs/k8s/releases/practice-kind-matrix.md
@@ -1,0 +1,48 @@
+---
+title: "kind practice matrix"
+description: "Local kind node images for Kubernetes 1.35, 1.36, and 1.37 Release Radar labs."
+sidebar:
+  order: 6
+  label: "kind practice matrix"
+---
+
+Use **kind** for Release Radar practice. Keep Killercoda for polished exam-style scenarios; do not treat hosted labs as the version matrix source of truth.
+
+## Node images
+
+Pinned in `docs/pins/kubernetes.yaml` (adjust patch tags when you verify newer kindest publishes):
+
+| Minor | kind node image | Notes |
+|-------|-----------------|-------|
+| 1.35 | `kindest/node:v1.35.0` | Matches current **exam pin** fixtures |
+| 1.36 | `kindest/node:v1.36.1` | Middle supported minor |
+| 1.37 | `kindest/node:v1.37.0` | Newest supported minor (Garhwal) |
+
+Create separate clusters per minor (do not skew control plane vs workers beyond the [version skew policy](https://kubernetes.io/releases/version-skew-policy/)):
+
+```bash
+kind create cluster --name kd-135 --image kindest/node:v1.35.0
+kind create cluster --name kd-136 --image kindest/node:v1.36.1
+kind create cluster --name kd-137 --image kindest/node:v1.37.0
+```
+
+## Diff-only lab pattern
+
+1. Apply a baseline manifest on **1.35**.
+2. Re-apply or patch on **1.36** / **1.37**.
+3. Record the behavioral delta (API accepted, field default changed, removal error, new status).
+4. Do **not** re-teach “what is a Pod?”
+
+Good first drills:
+
+- **1.36:** confirm `gitRepo` volumes are rejected; migrate to initContainer + `git` or git-sync.
+- **1.36:** MutatingAdmissionPolicy / OCI image volumes — exercise GA paths from the [1.36 radar page](/k8s/releases/v1.36/).
+- **1.37:** explore KYAML output (`kubectl` KYAML) and pod-level resource fields on a throwaway Deployment.
+
+## Cleanup
+
+```bash
+kind delete cluster --name kd-135
+kind delete cluster --name kd-136
+kind delete cluster --name kd-137
+```

--- a/src/content/docs/k8s/releases/v1.35.md
+++ b/src/content/docs/k8s/releases/v1.35.md
@@ -1,4 +1,5 @@
 ---
+slug: v1.35
 title: "Kubernetes 1.35 — Timbernetes"
 description: "Release Radar for Kubernetes 1.35: exam-pin baseline, Stable highlights, and practice links."
 sidebar:
@@ -6,8 +7,8 @@ sidebar:
   label: "1.35 Timbernetes"
 ---
 
-> **Cert impact:** `none` for bumping — this **is** the current exam pin. Use Release Radar for delta context; keep CKA/CKAD/CKS lessons on 1.35 until LF moves.  
-> **Upstream status:** Actively supported (oldest of the three-branch window)  
+> **Cert impact:** `none` for bumping — this **is** the current exam pin. Use Release Radar for delta context; keep CKA/CKAD/CKS lessons on 1.35 until LF moves.
+> **Upstream status:** Actively supported (oldest of the three-branch window)
 > **GA:** 2025-12-17 · Theme: **Timbernetes (The World Tree)**
 
 Kubernetes **v1.35** is both (1) the **exam-pinned** curriculum target and (2) still an upstream-supported minor. Official summary: 60 enhancements — **17 Stable**, 19 Beta, 22 Alpha ([release blog](https://kubernetes.io/blog/2025/12/17/kubernetes-v1-35-release/)).

--- a/src/content/docs/k8s/releases/v1.35.md
+++ b/src/content/docs/k8s/releases/v1.35.md
@@ -1,0 +1,52 @@
+---
+title: "Kubernetes 1.35 — Timbernetes"
+description: "Release Radar for Kubernetes 1.35: exam-pin baseline, Stable highlights, and practice links."
+sidebar:
+  order: 5
+  label: "1.35 Timbernetes"
+---
+
+> **Cert impact:** `none` for bumping — this **is** the current exam pin. Use Release Radar for delta context; keep CKA/CKAD/CKS lessons on 1.35 until LF moves.  
+> **Upstream status:** Actively supported (oldest of the three-branch window)  
+> **GA:** 2025-12-17 · Theme: **Timbernetes (The World Tree)**
+
+Kubernetes **v1.35** is both (1) the **exam-pinned** curriculum target and (2) still an upstream-supported minor. Official summary: 60 enhancements — **17 Stable**, 19 Beta, 22 Alpha ([release blog](https://kubernetes.io/blog/2025/12/17/kubernetes-v1-35-release/)).
+
+## Who should read this
+
+| Audience | Why |
+|----------|-----|
+| Cert learners | This is your practice target version |
+| Platform engineers | Baseline before reading 1.36 / 1.37 deltas |
+| Agents | Fixture scripts and kind pins still center on 1.35 |
+
+## Stable / notable highlights (learner-visible)
+
+| Theme | What shipped | Why it matters |
+|-------|----------------|----------------|
+| Scaling | **In-place Pod resource updates** Stable | Change CPU/memory without always recreating Pods |
+| Identity | Pod certificates path matured (beta spotlight in the release blog; **Stable in 1.37**) | Know the trajectory — deep practice on 1.37 radar |
+| UX | **KYAML** entered beta (on by default) in 1.35; **Stable in 1.37** | Safer YAML subset for kubectl |
+| Autoscaling | Configurable HPA tolerance beta in 1.35; **Stable in 1.37** | Track graduation across the window |
+| Ops | Storage version migration moved in-tree (beta) | Less external migrator dependency |
+
+Treat 1.35 pages in cert tracks as the **authoritative how-to**. This radar page is the **version context**, not a second CKA.
+
+## Practice
+
+- kind image: `kindest/node:v1.35.0` — [matrix](/k8s/releases/practice-kind-matrix/)
+- Prefer existing CKA/CKAD Killercoda / module labs on this minor.
+- When comparing features, always run the **same manifest** on 1.35 then on 1.36/1.37.
+
+## Agent checklist
+
+- [ ] `exam_pin.kubernetes_minor` stays `"1.35"` until LF evidence changes
+- [ ] Fixtures (`cka_certificate_fixture`, kind examples) remain 1.35 unless a dedicated bump PR says otherwise
+- [ ] After reading 1.36/1.37 pages, only surgical callout fixes in cert modules — no mass rewrite
+
+## Sources
+
+- [Kubernetes v1.35: Timbernetes](https://kubernetes.io/blog/2025/12/17/kubernetes-v1-35-release/) — official release blog (verified 2026-09-12)
+- [CHANGELOG-1.35.md](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.35.md)
+- [Releases index](https://kubernetes.io/releases/) — support window including 1.35
+- CNCF / LF exam materials — re-verify before any exam-pin bump

--- a/src/content/docs/k8s/releases/v1.36.md
+++ b/src/content/docs/k8s/releases/v1.36.md
@@ -1,4 +1,5 @@
 ---
+slug: v1.36
 title: "Kubernetes 1.36 — Haru"
 description: "Release Radar for Kubernetes 1.36: Stable highlights, removals, cert impact, and practice links."
 sidebar:
@@ -6,8 +7,8 @@ sidebar:
   label: "1.36 Haru"
 ---
 
-> **Cert impact:** `watch` — exam pin still **1.35**, but several items that cert modules called “coming in 1.36” are now Stable. Prefer this page over stale “future GA” callouts.  
-> **Upstream status:** Actively supported  
+> **Cert impact:** `watch` — exam pin still **1.35**, but several items that cert modules called “coming in 1.36” are now Stable. Prefer this page over stale “future GA” callouts.
+> **Upstream status:** Actively supported
 > **GA:** 2026-04-22 · Theme: **ハル (Haru)**
 
 Kubernetes **v1.36** sits in the middle of the supported window. Official summary: ~70 enhancements with **18 Stable** graduations ([release blog](https://kubernetes.io/blog/2026/04/22/kubernetes-v1-36-release/)).

--- a/src/content/docs/k8s/releases/v1.36.md
+++ b/src/content/docs/k8s/releases/v1.36.md
@@ -1,0 +1,54 @@
+---
+title: "Kubernetes 1.36 — Haru"
+description: "Release Radar for Kubernetes 1.36: Stable highlights, removals, cert impact, and practice links."
+sidebar:
+  order: 4
+  label: "1.36 Haru"
+---
+
+> **Cert impact:** `watch` — exam pin still **1.35**, but several items that cert modules called “coming in 1.36” are now Stable. Prefer this page over stale “future GA” callouts.  
+> **Upstream status:** Actively supported  
+> **GA:** 2026-04-22 · Theme: **ハル (Haru)**
+
+Kubernetes **v1.36** sits in the middle of the supported window. Official summary: ~70 enhancements with **18 Stable** graduations ([release blog](https://kubernetes.io/blog/2026/04/22/kubernetes-v1-36-release/)).
+
+## Who should read this
+
+| Audience | Why |
+|----------|-----|
+| Security | User namespaces Stable; fine-grained kubelet authz; mutating admission policies |
+| Storage / backup | Volume group snapshots Stable; SELinux mount labeling Stable |
+| AI / artifacts | **OCI image/artifact volumes** Stable |
+| Everyone operating clusters | **`gitRepo` volumes permanently disabled** |
+
+## Stable highlights (learner-visible)
+
+| Theme | What shipped | Why it matters |
+|-------|----------------|----------------|
+| Isolation | **User namespaces** in Pods Stable (`hostUsers: false`) | Container root ≠ host root |
+| Admission | **MutatingAdmissionPolicy** Stable (CEL, webhook-free mutations) | Replace many mutating webhooks |
+| Volumes | **OCI VolumeSource** (image/artifact volumes) Stable | Mount registry content without baking into the app image |
+| Auth | External ServiceAccount token signing Stable; fine-grained kubelet API authz Stable | Least-privilege kubelet access; external IAM signing |
+| Storage | VolumeGroupSnapshot Stable; faster SELinux volume labeling Stable | Crash-consistent multi-PVC snapshots; faster Pod starts on SELinux |
+| DRA | Admin access + prioritized device lists Stable | Production DRA governance |
+| Observability | NodeLogQuery Stable; PSI metrics Stable | Better node log query + pressure signals |
+
+## Removals / breaking
+
+- **`gitRepo` volume plugin is disabled and cannot be re-enabled** (KEP-5040). Migrate to initContainers or git-sync style tools before upgrading nodes to 1.36+.
+
+## Practice
+
+- kind image: `kindest/node:v1.36.1` — [matrix](/k8s/releases/practice-kind-matrix/)
+- Diff lab idea: apply a Pod with `gitRepo` on 1.35 (if still accepted) vs 1.36 (must fail); document the migration.
+- Diff lab idea: OCI image volume mount vs ConfigMap for a static asset.
+
+## Stale callouts to fix elsewhere
+
+When touching cert modules, replace “Image volume / MutatingAdmissionPolicy will be GA in 1.36” language with **Stable as of 1.36** and link here. Do that surgically — not as a full cert rewrite.
+
+## Sources
+
+- [Kubernetes v1.36: Haru](https://kubernetes.io/blog/2026/04/22/kubernetes-v1-36-release/) — official release blog (verified 2026-09-12)
+- [CHANGELOG-1.36.md](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md)
+- [Releases index](https://kubernetes.io/releases/)

--- a/src/content/docs/k8s/releases/v1.37.md
+++ b/src/content/docs/k8s/releases/v1.37.md
@@ -1,4 +1,5 @@
 ---
+slug: v1.37
 title: "Kubernetes 1.37 — Garhwal"
 description: "Release Radar for Kubernetes 1.37: Stable highlights, cert impact, and practice links."
 sidebar:
@@ -6,8 +7,8 @@ sidebar:
   label: "1.37 Garhwal"
 ---
 
-> **Cert impact:** `none` (exam pin remains **1.35** — [policy](/k8s/releases/exam-version-policy/))  
-> **Upstream status:** Actively supported (newest of the three-branch window)  
+> **Cert impact:** `none` (exam pin remains **1.35** — [policy](/k8s/releases/exam-version-policy/))
+> **Upstream status:** Actively supported (newest of the three-branch window)
 > **GA:** 2026-08-26 · Theme: **Garhwal**
 
 Kubernetes **v1.37** is the newest supported minor as of 2026-09-12. Official summary: 67 enhancements — **16 Stable**, 23 Beta, 27 Alpha, plus deprecation work ([release blog](https://kubernetes.io/blog/2026/08/26/kubernetes-v1-37-release/)).
@@ -26,19 +27,18 @@ Kubernetes **v1.37** is the newest supported minor as of 2026-09-12. Official su
 | Theme | What shipped | Why it matters |
 |-------|----------------|----------------|
 | Workload identity | **Pod certificates** + **ClusterTrustBundles** Stable | Native X.509 + trust anchors without bolting on a full mesh just for certs |
-| Resources | **Pod-level resources** Stable | CPU/memory at the Pod (not only per container) — sidecar-heavy apps |
 | Autoscaling | **Configurable HPA tolerance** Stable | Per-resource tolerance instead of one global knob |
 | UX / API | **KYAML** Stable; **metrics.k8s.io** API definitions Stable | Safer kubectl YAML subset; metrics API leaves permanent-beta territory |
 | DRA | Device taints/tolerations, extended resources via DRA, resource health, NUMA attrs, NIC status | Hardware scheduling closer to node-taint mental models |
 | Ops | **Node declared features**, resilient watch-cache init, Storage Version Migrator in-tree | Safer skew and storage-version migrations |
 
-Beta worth watching (not deep-taught here): HPA scale-to-zero; manifest-based admission config on disk.
+Beta worth watching (not deep-taught here): **Pod-level resource managers** (`PodLevelResourceManagers`, disabled by default); HPA scale-to-zero; manifest-based admission config on disk.
 
 ## Practice
 
 - kind image: `kindest/node:v1.37.0` — [matrix](/k8s/releases/practice-kind-matrix/)
 - Try KYAML output on a known Deployment; compare with classic YAML.
-- Optional: declare pod-level resources on a throwaway Pod and confirm acceptance on 1.37 vs refusal/partial support on older minors.
+- Optional: only with an explicit feature-gated kind config — do **not** treat pod-level resource managers as GA.
 
 ## Agent checklist
 

--- a/src/content/docs/k8s/releases/v1.37.md
+++ b/src/content/docs/k8s/releases/v1.37.md
@@ -1,0 +1,54 @@
+---
+title: "Kubernetes 1.37 — Garhwal"
+description: "Release Radar for Kubernetes 1.37: Stable highlights, cert impact, and practice links."
+sidebar:
+  order: 3
+  label: "1.37 Garhwal"
+---
+
+> **Cert impact:** `none` (exam pin remains **1.35** — [policy](/k8s/releases/exam-version-policy/))  
+> **Upstream status:** Actively supported (newest of the three-branch window)  
+> **GA:** 2026-08-26 · Theme: **Garhwal**
+
+Kubernetes **v1.37** is the newest supported minor as of 2026-09-12. Official summary: 67 enhancements — **16 Stable**, 23 Beta, 27 Alpha, plus deprecation work ([release blog](https://kubernetes.io/blog/2026/08/26/kubernetes-v1-37-release/)).
+
+## Who should read this
+
+| Audience | Why |
+|----------|-----|
+| Platform / AI infra | DRA Stable pieces, pod-level resources, device health |
+| Security / mesh | Pod certificates + ClusterTrustBundles now Stable |
+| App developers | KYAML output, relaxed Service name validation, HPA tolerance |
+| Cert learners | Awareness only — keep practicing on the exam pin |
+
+## Stable highlights (learner-visible)
+
+| Theme | What shipped | Why it matters |
+|-------|----------------|----------------|
+| Workload identity | **Pod certificates** + **ClusterTrustBundles** Stable | Native X.509 + trust anchors without bolting on a full mesh just for certs |
+| Resources | **Pod-level resources** Stable | CPU/memory at the Pod (not only per container) — sidecar-heavy apps |
+| Autoscaling | **Configurable HPA tolerance** Stable | Per-resource tolerance instead of one global knob |
+| UX / API | **KYAML** Stable; **metrics.k8s.io** API definitions Stable | Safer kubectl YAML subset; metrics API leaves permanent-beta territory |
+| DRA | Device taints/tolerations, extended resources via DRA, resource health, NUMA attrs, NIC status | Hardware scheduling closer to node-taint mental models |
+| Ops | **Node declared features**, resilient watch-cache init, Storage Version Migrator in-tree | Safer skew and storage-version migrations |
+
+Beta worth watching (not deep-taught here): HPA scale-to-zero; manifest-based admission config on disk.
+
+## Practice
+
+- kind image: `kindest/node:v1.37.0` — [matrix](/k8s/releases/practice-kind-matrix/)
+- Try KYAML output on a known Deployment; compare with classic YAML.
+- Optional: declare pod-level resources on a throwaway Pod and confirm acceptance on 1.37 vs refusal/partial support on older minors.
+
+## Agent checklist
+
+- [ ] Keep `latest_stable_track.supported_minors` including `1.37`
+- [ ] Do **not** bump `exam_pin`
+- [ ] Prefer official blog + CHANGELOG over third-party roundups when they disagree
+
+## Sources
+
+- [Kubernetes v1.37: Garhwal](https://kubernetes.io/blog/2026/08/26/kubernetes-v1-37-release/) — official release blog (verified 2026-09-12)
+- [Kubernetes 1.37 releases page](https://kubernetes.io/releases/1.37/) — support window / patch dates
+- [CHANGELOG-1.37.md](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.37.md)
+- [Releases index](https://kubernetes.io/releases/) — three-minor support policy


### PR DESCRIPTION
## Summary
Drives **X06 / #2542** so learners and agents can onboard the three upstream-supported minors:

- **1.37 Garhwal** (GA 2026-08-26), **1.36 Haru**, **1.35 Timbernetes**
- Dual-track **exam pin stays 1.35** until LF moves ([policy](/k8s/releases/exam-version-policy/))
- Sidebar **Release Radar** under Certifications + hub callout + What’s New entry
- Machine pins `docs/pins/kubernetes.yaml` (kind `v1.36.1` — `v1.36.0` not on Docker Hub)
- Agent playbook + per-minor template under `docs/release-maintenance/`

Closes the content spine for #2543–#2548 (practice matrix included; deeper diff labs can follow).

## Test plan
- [ ] CI Astro build green (local build OOM’d on this host; rely on Actions)
- [ ] Cross-family review on exact head
- [ ] Spot-check `/k8s/releases/`, `/k8s/releases/v1.37/`, policy page
- [ ] Confirm kind tags: `v1.35.0`, `v1.36.1`, `v1.37.0` resolve


Made with [Cursor](https://cursor.com)