### PR TITLE
feat(cka): runner launch helpers (#2478)

### DIFF
--- a/scripts/cka_certificate_process.sh
+++ b/scripts/cka_certificate_process.sh
@@ -948,7 +948,10 @@ cka_cert_runner_launch_actual() {
   if ! cka_cert_run_read_helper "$deadline" cka_cert_runner_permission "$identity" "$operation" "$binding" supervisor_ready; then
     cka_cert_control_close; return 1
   fi
-  [[ ${CKA_CERT_SUPERVISOR_TERM:-1} == 0 ]] || return 1
+  if [[ ${CKA_CERT_SUPERVISOR_TERM:-1} != 0 ]]; then
+    cka_cert_control_close || return 1
+    return 1
+  fi
   cka_cert_decision_publish "$deadline" "$identity" "$operation" "$expected" "$next" || return $?
   cka_cert_decision_reconcile "$deadline" "$identity" "$operation" "$expected" "$next" || return $?
   [[ $CKA_CERT_DECISION_RESULT == successor ]] || return 1

--- a/scripts/cka_certificate_process.sh
+++ b/scripts/cka_certificate_process.sh
@@ -895,3 +895,80 @@ cka_cert_runner_before() {
       .cancel_ack==false and .cause=="none"' <<< "$observed" >/dev/null || return 1
   cka_cert_process_cancel_read "$1" "$2" && [[ $CKA_CERT_PROCESS_CANCEL == 0 ]]
 }
+
+# Direct live session-leader API. Success acknowledges admission only, not entry.
+# Caller retains FD9, owns group supervision, and must reconcile all failures.
+cka_cert_runner_launch_actual() {
+  local deadline identity operation supervisor before argv next expected runner start binding name result
+  unset CKA_CERT_RUNNER_PID CKA_CERT_RUNNER_BINDING
+  [[ $# -ge 6 && ${CKA_CERT_STATE_OWNS_FD:-0} == 1 && ${CKA_CERT_SUPERVISOR_TERM:-1} == 0 ]] || return 1
+  deadline=$1; identity=$2; operation=$3; supervisor=$4; before=$5; shift 5
+  cka_cert_control_locked "$deadline" || return $?
+  cka_cert_run_read_helper "$deadline" cka_cert_runner_before "$identity" "$operation" "$supervisor" "$before" || return $?
+  cka_cert_capture "$deadline" utility jq -er .pid <<< "$supervisor" || return $?
+  [[ $CKA_CERT_CAPTURED == "$BASHPID" ]] || return 1
+  cka_cert_capture "$deadline" utility jq -er .start_time <<< "$supervisor" || return $?
+  cka_cert_process_self "$BASHPID" "$CKA_CERT_CAPTURED" || return 1
+  cka_cert_capture "$deadline" utility jq -cn --args '$ARGS.positional' -- "$@" || return $?
+  argv=$CKA_CERT_CAPTURED
+  for name in runner-ready runner-admission runner-birth runner-entry command; do
+    [[ ! -e /var/lib/cka-certificate-transaction/$name.json &&
+       ! -L /var/lib/cka-certificate-transaction/$name.json ]] || return 1
+  done
+  [[ ${CKA_CERT_SUPERVISOR_TERM:-1} == 0 ]] || return 1
+  (
+    exec 8>&-
+    unset CKA_CERT_CONTROL_OWNER CKA_CERT_CONTROL_LOCKED CKA_CERT_CONTROL_DELEGATED
+    cka_cert_runner_body "$deadline" "$identity" "$operation" "$supervisor" "$argv" "$@"
+  ) &
+  runner=$!
+  CKA_CERT_RUNNER_PID=$runner
+  cka_cert_control_close || return 1
+  # Independent parent observation; never obtain runner identity from readiness.
+  cka_cert_process_stat "$runner" || return 1
+  [[ $CKA_CERT_PROC_PPID == "$BASHPID" && $CKA_CERT_PROC_SID == "$BASHPID" &&
+     $CKA_CERT_PROC_PGID == "$BASHPID" && $CKA_CERT_PROC_STATE != [ZXx] ]] || return 1
+  start=$CKA_CERT_PROC_START
+  cka_cert_capture "$deadline" utility jq -cn --argjson supervisor "$supervisor" --argjson pid "$runner" \
+    --arg start "$start" --argjson argv "$argv" \
+    '{supervisor:$supervisor,runner:{pid:$pid,start_time:$start},argv:$argv}' || return $?
+  binding=$CKA_CERT_CAPTURED
+  CKA_CERT_RUNNER_BINDING=$binding
+  # ln/unlink publication briefly has two links; existence alone is not readiness.
+  until cka_cert_run_read_helper "$deadline" cka_cert_runner_read "$identity" "$operation" "$binding" ready >/dev/null; do
+    cka_cert_run_read_helper "$deadline" cka_cert_runner_live "$binding" null || return $?
+  done
+  cka_cert_capture "$deadline" utility jq -cn --argjson record "$before" \
+    '{presence:"present",record:$record}' || return $?
+  expected=$CKA_CERT_CAPTURED
+  cka_cert_capture "$deadline" utility jq -c \
+    '.stage="command_launch_committed" | .launch_disposition="command_committed"' <<< "$before" || return $?
+  next=$CKA_CERT_CAPTURED
+  cka_cert_control_open "$deadline" || return $?
+  if ! cka_cert_run_read_helper "$deadline" cka_cert_runner_permission "$identity" "$operation" "$binding" supervisor_ready; then
+    cka_cert_control_close; return 1
+  fi
+  [[ ${CKA_CERT_SUPERVISOR_TERM:-1} == 0 ]] || return 1
+  cka_cert_decision_publish "$deadline" "$identity" "$operation" "$expected" "$next" || return $?
+  cka_cert_decision_reconcile "$deadline" "$identity" "$operation" "$expected" "$next" || return $?
+  [[ $CKA_CERT_DECISION_RESULT == successor ]] || return 1
+  cka_cert_control_open "$deadline" || return $?
+  if cka_cert_run_read_helper "$deadline" cka_cert_runner_permission "$identity" "$operation" "$binding" command_launch_committed &&
+     cka_cert_runner_record "$deadline" "$identity" "$operation" "$binding" admission null &&
+     [[ ${CKA_CERT_SUPERVISOR_TERM:-1} == 0 ]] &&
+     cka_cert_runner_write "$deadline" "$identity" "$operation" "$binding" admission "$CKA_CERT_CAPTURED"; then
+    result=0
+  else result=$?; fi
+  cka_cert_control_close || return 1
+  return "$result"
+}
+
+# Always relinquish this actor's control custody, including pre-fork refusals.
+cka_cert_runner_launch() {
+  local result
+  if cka_cert_runner_launch_actual "$@"; then result=0; else result=$?; fi
+  if [[ ${CKA_CERT_CONTROL_OWNER:-} == "$BASHPID" ]]; then
+    cka_cert_control_close || return 1
+  fi
+  return "$result"
+}

--- a/scripts/tests/test_cka_runner_launch.py
+++ b/scripts/tests/test_cka_runner_launch.py
@@ -1,0 +1,63 @@
+"""Runner launch gate refusals with injected custody; not kind renewal proof."""
+import subprocess
+import unittest
+from pathlib import Path
+
+
+class TestRunnerLaunch(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(__file__).resolve().parents[2]
+
+    def bash(self, script):
+        return subprocess.run(
+            [
+                "bash",
+                "-c",
+                script,
+                "--",
+                str(self.root / "scripts/cka_certificate_state.sh"),
+                str(self.root / "scripts/cka_certificate_process.sh"),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+
+    def test_launch_helpers_defined(self):
+        result = self.bash(
+            r"""
+source "$1"; source "$2"
+declare -F cka_cert_runner_launch_actual >/dev/null
+declare -F cka_cert_runner_launch >/dev/null
+"""
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_launch_actual_refuses_without_custody(self):
+        result = self.bash(
+            r"""
+source "$1"; source "$2"
+unset CKA_CERT_STATE_OWNS_FD
+CKA_CERT_SUPERVISOR_TERM=0
+# argc>=6 but no FD ownership
+if cka_cert_runner_launch_actual 10000 id op '{}' '{}' /bin/true; then exit 1; fi
+"""
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_launch_wrapper_closes_control_on_refusal(self):
+        result = self.bash(
+            r"""
+source "$1"; source "$2"
+CKA_CERT_STATE_OWNS_FD=1
+CKA_CERT_SUPERVISOR_TERM=0
+CKA_CERT_CONTROL_OWNER=$BASHPID
+closed=0
+cka_cert_control_close() { closed=1; return 0; }
+cka_cert_runner_launch_actual() { return 7; }
+cka_cert_runner_launch 10000 id op '{}' '{}' /bin/true
+[[ $? == 7 && $closed == 1 ]]
+"""
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)

--- a/scripts/tests/test_cka_runner_launch.py
+++ b/scripts/tests/test_cka_runner_launch.py
@@ -61,3 +61,51 @@ cka_cert_runner_launch 10000 id op '{}' '{}' /bin/true
 """
         )
         self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_launch_actual_closes_on_term_after_open(self):
+        """Post-open SUPERVISOR_TERM refusal must release FD8 custody."""
+        result = self.bash(
+            r"""
+source "$1"; source "$2"
+CKA_CERT_STATE_OWNS_FD=1
+CKA_CERT_SUPERVISOR_TERM=0
+close_count=0
+cka_cert_control_locked() { return 0; }
+cka_cert_run_read_helper() {
+  # before + ready wait + live + supervisor_ready permission
+  return 0
+}
+cka_cert_capture() {
+  case $3 in
+    jq)
+      shift 3
+      if [[ $* == *--args* ]]; then CKA_CERT_CAPTURED='["/bin/true"]'
+      elif [[ $* == *.pid* ]]; then CKA_CERT_CAPTURED=$BASHPID
+      elif [[ $* == *.start_time* ]]; then CKA_CERT_CAPTURED=1
+      elif [[ $* == *supervisor* && $* == *runner* ]]; then
+        CKA_CERT_CAPTURED="{\"supervisor\":{\"pid\":$BASHPID},\"runner\":{\"pid\":1,\"start_time\":\"1\"},\"argv\":[\"/bin/true\"]}"
+      elif [[ $* == *presence* ]]; then CKA_CERT_CAPTURED='{"presence":"present"}'
+      elif [[ $* == *command_launch_committed* ]]; then CKA_CERT_CAPTURED='{"stage":"command_launch_committed"}'
+      else CKA_CERT_CAPTURED=1; fi
+      return 0
+      ;;
+    *) return 1 ;;
+  esac
+}
+cka_cert_process_self() { return 0; }
+cka_cert_process_stat() {
+  CKA_CERT_PROC_PPID=$BASHPID; CKA_CERT_PROC_SID=$BASHPID
+  CKA_CERT_PROC_PGID=$BASHPID; CKA_CERT_PROC_STATE=S; CKA_CERT_PROC_START=1
+}
+cka_cert_control_close() { close_count=$((close_count + 1)); unset CKA_CERT_CONTROL_OWNER; return 0; }
+cka_cert_control_open() { CKA_CERT_CONTROL_OWNER=$BASHPID; CKA_CERT_SUPERVISOR_TERM=1; return 0; }
+cka_cert_runner_body() { sleep 0.05; }
+# Avoid waiting on ready forever: make ready read succeed immediately via run_read_helper.
+if cka_cert_runner_launch_actual 10000 id op "{\"pid\":$BASHPID,\"start_time\":\"1\"}" '{}' /bin/true; then
+  echo unexpected-success; exit 1
+fi
+[[ $close_count -ge 1 && -z ${CKA_CERT_CONTROL_OWNER:-} ]]
+"""
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+


### PR DESCRIPTION
## Summary
- Completes tip runner stack: `cka_cert_runner_launch_actual` + `cka_cert_runner_launch`
- Unit tests for definition, custody refusal, and control-close on wrapper failure
- **Still not issue-complete:** isolated kind apiserver renewal evidence remains

Parent #2280 / epic #2272.

## Test plan
- [x] ruff + pytest
- [ ] CI + CF on exact head


Made with [Cursor](https://cursor.com)