### PR TITLE
feat(cka): add apiserver cert rollback helpers (#2478)

### DIFF
--- a/scripts/cka_certificate_rollback.sh
+++ b/scripts/cka_certificate_rollback.sh
@@ -1,8 +1,6 @@
-# In-node rollback primitives after a verified renew (Packet T3).
+# Packet T3 rollback: restore backup apiserver pair after verified renew.
 # Source after state.sh + observe.sh + renew.sh with FD9 held.
-# Restores backup apiserver pair only. No private-key egress.
 
-# Atomic recovery write. Caller holds the lock.
 cka_cert_rollback_write() {
   local state temporary
   [[ $# == 1 ]] || return 1
@@ -15,7 +13,6 @@ cka_cert_rollback_write() {
   sync -f /var/lib/cka-certificate-transaction || return 1
 }
 
-# Flip forward/manifest_returned → rollback/rollback_requested.
 cka_cert_rollback_begin() {
   local expected state
   [[ $# == 1 ]] || return 1
@@ -30,7 +27,6 @@ cka_cert_rollback_begin() {
   cka_cert_rollback_write "$state"
 }
 
-# Advance a rollback stage. Caller must already hold the lock.
 cka_cert_rollback_phase() {
   local expected state from to
   [[ $# == 3 ]] || return 1
@@ -46,7 +42,6 @@ cka_cert_rollback_phase() {
   cka_cert_rollback_write "$state"
 }
 
-# Stop consumer under rollback custody (dedicated staged manifest name).
 cka_cert_rollback_stop_consumer() {
   local staged
   [[ $# == 1 ]] || return 1
@@ -63,36 +58,41 @@ cka_cert_rollback_stop_consumer() {
   cka_cert_rollback_phase "$1" consumer_stop_requested consumer_stopped || return 1
 }
 
-# Restore backup cert+key to live PKI; fingerprint must match baseline.
-# Args: identity, CRI_BIN, unix://CRI_ENDPOINT
+# Resumes from pair_restore_requested after partial failure. Args: id CRI_BIN endpoint
 cka_cert_rollback_restore_pair() {
-  local expected state ids before after backup_fp temporary
+  local expected state ids stage after backup_fp temporary
   [[ $# == 3 ]] || return 1
   ids=$(cka_cert_obs_running_ids "$2" "$3") || return 1
   [[ $ids == '[]' ]] || return 1
   cka_cert_state_environment && cka_cert_state_locked || return 1
   expected=$(cka_cert_state_expected "$1") || return 1
   state=$(cka_cert_state_read "$expected") || return 1
+  stage=$(jq -er '.recovery.stage' <<< "$state") || return 1
   backup_fp=$(jq -er '.baseline.fingerprint' <<< "$state") || return 1
   cka_cert_state_file /var/lib/cka-certificate-transaction/apiserver.crt || return 1
   cka_cert_state_file /var/lib/cka-certificate-transaction/apiserver.key || return 1
-  cka_cert_rollback_phase "$1" consumer_stopped pair_restore_requested || return 1
-  before=$(cka_cert_renew_cert_fingerprint) || return 1
-  temporary=$(mktemp /etc/kubernetes/pki/apiserver.crt.XXXXXXXX) || return 1
-  cat -- /var/lib/cka-certificate-transaction/apiserver.crt > "$temporary" || return 1
-  mv -T -- "$temporary" /etc/kubernetes/pki/apiserver.crt || return 1
-  temporary=$(mktemp /etc/kubernetes/pki/apiserver.key.XXXXXXXX) || return 1
-  cat -- /var/lib/cka-certificate-transaction/apiserver.key > "$temporary" || return 1
-  mv -T -- "$temporary" /etc/kubernetes/pki/apiserver.key || return 1
-  sync -f /etc/kubernetes/pki/apiserver.crt /etc/kubernetes/pki/apiserver.key || return 1
-  cmp -s -- /var/lib/cka-certificate-transaction/apiserver.crt /etc/kubernetes/pki/apiserver.crt || return 1
-  cmp -s -- /var/lib/cka-certificate-transaction/apiserver.key /etc/kubernetes/pki/apiserver.key || return 1
+  if [[ $stage == consumer_stopped ]]; then
+    cka_cert_rollback_phase "$1" consumer_stopped pair_restore_requested || return 1
+  elif [[ $stage != pair_restore_requested ]]; then
+    return 1
+  fi
+  if ! cmp -s -- /var/lib/cka-certificate-transaction/apiserver.crt /etc/kubernetes/pki/apiserver.crt ||
+     ! cmp -s -- /var/lib/cka-certificate-transaction/apiserver.key /etc/kubernetes/pki/apiserver.key; then
+    temporary=$(mktemp /etc/kubernetes/pki/apiserver.crt.XXXXXXXX) || return 1
+    cat -- /var/lib/cka-certificate-transaction/apiserver.crt > "$temporary" || return 1
+    mv -T -- "$temporary" /etc/kubernetes/pki/apiserver.crt || return 1
+    temporary=$(mktemp /etc/kubernetes/pki/apiserver.key.XXXXXXXX) || return 1
+    cat -- /var/lib/cka-certificate-transaction/apiserver.key > "$temporary" || return 1
+    mv -T -- "$temporary" /etc/kubernetes/pki/apiserver.key || return 1
+    sync -f /etc/kubernetes/pki/apiserver.crt /etc/kubernetes/pki/apiserver.key || return 1
+    cmp -s -- /var/lib/cka-certificate-transaction/apiserver.crt /etc/kubernetes/pki/apiserver.crt || return 1
+    cmp -s -- /var/lib/cka-certificate-transaction/apiserver.key /etc/kubernetes/pki/apiserver.key || return 1
+  fi
   after=$(cka_cert_renew_cert_fingerprint) || return 1
-  [[ $after == "$backup_fp" && $after != "$before" ]] || return 1
+  [[ $after == "$backup_fp" ]] || return 1
   cka_cert_rollback_phase "$1" pair_restore_requested pair_restored || return 1
 }
 
-# Return backup static-pod manifest (not the post-renew .live copy).
 cka_cert_rollback_return_manifest() {
   local backup
   [[ $# == 1 ]] || return 1
@@ -106,7 +106,6 @@ cka_cert_rollback_return_manifest() {
   cka_cert_rollback_phase "$1" manifest_return_requested manifest_returned || return 1
 }
 
-# Require live fingerprint == baseline; mark rollback_verified.
 cka_cert_rollback_verify() {
   local expected state fp baseline
   [[ $# == 1 ]] || return 1

--- a/scripts/cka_certificate_rollback.sh
+++ b/scripts/cka_certificate_rollback.sh
@@ -1,0 +1,122 @@
+# In-node rollback primitives after a verified renew (Packet T3).
+# Source after state.sh + observe.sh + renew.sh with FD9 held.
+# Restores backup apiserver pair only. No private-key egress.
+
+# Atomic recovery write. Caller holds the lock.
+cka_cert_rollback_write() {
+  local state temporary
+  [[ $# == 1 ]] || return 1
+  state=$1
+  temporary=$(mktemp /var/lib/cka-certificate-transaction/state.XXXXXXXX) || return 1
+  cka_cert_state_file "$temporary" || return 1
+  printf '%s\n' "$state" > "$temporary" || return 1
+  sync -f "$temporary" || return 1
+  mv -T -- "$temporary" /var/lib/cka-certificate-transaction/state.json || return 1
+  sync -f /var/lib/cka-certificate-transaction || return 1
+}
+
+# Flip forward/manifest_returned → rollback/rollback_requested.
+cka_cert_rollback_begin() {
+  local expected state
+  [[ $# == 1 ]] || return 1
+  cka_cert_state_environment && cka_cert_state_locked || return 1
+  expected=$(cka_cert_state_expected "$1") || return 1
+  cka_cert_state_artifacts "$expected" || return 1
+  state=$(cka_cert_state_read "$expected") || return 1
+  jq -e '.recovery.direction=="forward" and .recovery.stage=="manifest_returned"' \
+    <<< "$state" >/dev/null || return 1
+  state=$(jq -c '.recovery={direction:"rollback",stage:"rollback_requested"} | .revision+=1' \
+    <<< "$state") || return 1
+  cka_cert_rollback_write "$state"
+}
+
+# Advance a rollback stage. Caller must already hold the lock.
+cka_cert_rollback_phase() {
+  local expected state from to
+  [[ $# == 3 ]] || return 1
+  from=$2; to=$3
+  cka_cert_state_environment && cka_cert_state_locked || return 1
+  expected=$(cka_cert_state_expected "$1") || return 1
+  cka_cert_state_artifacts "$expected" || return 1
+  state=$(cka_cert_state_read "$expected") || return 1
+  jq -e --arg from "$from" '
+    .recovery.direction=="rollback" and .recovery.stage==$from
+  ' <<< "$state" >/dev/null || return 1
+  state=$(jq -c --arg to "$to" '.recovery.stage=$to | .revision+=1' <<< "$state") || return 1
+  cka_cert_rollback_write "$state"
+}
+
+# Stop consumer under rollback custody (dedicated staged manifest name).
+cka_cert_rollback_stop_consumer() {
+  local staged
+  [[ $# == 1 ]] || return 1
+  cka_cert_rollback_phase "$1" rollback_requested consumer_stop_requested || return 1
+  staged=/var/lib/cka-certificate-transaction/kube-apiserver.yaml.rollback
+  [[ ! -e $staged && ! -L $staged ]] || return 1
+  [[ -f /etc/kubernetes/manifests/kube-apiserver.yaml &&
+     ! -L /etc/kubernetes/manifests/kube-apiserver.yaml ]] || return 1
+  (umask 077; set -o noclobber; cat -- /etc/kubernetes/manifests/kube-apiserver.yaml > "$staged") || return 1
+  cka_cert_state_file "$staged" || return 1
+  cmp -s -- /etc/kubernetes/manifests/kube-apiserver.yaml "$staged" || return 1
+  rm -f -- /etc/kubernetes/manifests/kube-apiserver.yaml || return 1
+  [[ ! -e /etc/kubernetes/manifests/kube-apiserver.yaml ]] || return 1
+  cka_cert_rollback_phase "$1" consumer_stop_requested consumer_stopped || return 1
+}
+
+# Restore backup cert+key to live PKI; fingerprint must match baseline.
+# Args: identity, CRI_BIN, unix://CRI_ENDPOINT
+cka_cert_rollback_restore_pair() {
+  local expected state ids before after backup_fp temporary
+  [[ $# == 3 ]] || return 1
+  ids=$(cka_cert_obs_running_ids "$2" "$3") || return 1
+  [[ $ids == '[]' ]] || return 1
+  cka_cert_state_environment && cka_cert_state_locked || return 1
+  expected=$(cka_cert_state_expected "$1") || return 1
+  state=$(cka_cert_state_read "$expected") || return 1
+  backup_fp=$(jq -er '.baseline.fingerprint' <<< "$state") || return 1
+  cka_cert_state_file /var/lib/cka-certificate-transaction/apiserver.crt || return 1
+  cka_cert_state_file /var/lib/cka-certificate-transaction/apiserver.key || return 1
+  cka_cert_rollback_phase "$1" consumer_stopped pair_restore_requested || return 1
+  before=$(cka_cert_renew_cert_fingerprint) || return 1
+  temporary=$(mktemp /etc/kubernetes/pki/apiserver.crt.XXXXXXXX) || return 1
+  cat -- /var/lib/cka-certificate-transaction/apiserver.crt > "$temporary" || return 1
+  mv -T -- "$temporary" /etc/kubernetes/pki/apiserver.crt || return 1
+  temporary=$(mktemp /etc/kubernetes/pki/apiserver.key.XXXXXXXX) || return 1
+  cat -- /var/lib/cka-certificate-transaction/apiserver.key > "$temporary" || return 1
+  mv -T -- "$temporary" /etc/kubernetes/pki/apiserver.key || return 1
+  sync -f /etc/kubernetes/pki/apiserver.crt /etc/kubernetes/pki/apiserver.key || return 1
+  cmp -s -- /var/lib/cka-certificate-transaction/apiserver.crt /etc/kubernetes/pki/apiserver.crt || return 1
+  cmp -s -- /var/lib/cka-certificate-transaction/apiserver.key /etc/kubernetes/pki/apiserver.key || return 1
+  after=$(cka_cert_renew_cert_fingerprint) || return 1
+  [[ $after == "$backup_fp" && $after != "$before" ]] || return 1
+  cka_cert_rollback_phase "$1" pair_restore_requested pair_restored || return 1
+}
+
+# Return backup static-pod manifest (not the post-renew .live copy).
+cka_cert_rollback_return_manifest() {
+  local backup
+  [[ $# == 1 ]] || return 1
+  backup=/var/lib/cka-certificate-transaction/kube-apiserver.yaml
+  cka_cert_state_file "$backup" || return 1
+  [[ ! -e /etc/kubernetes/manifests/kube-apiserver.yaml &&
+     ! -L /etc/kubernetes/manifests/kube-apiserver.yaml ]] || return 1
+  cka_cert_rollback_phase "$1" pair_restored manifest_return_requested || return 1
+  (umask 022; set -o noclobber; cat -- "$backup" > /etc/kubernetes/manifests/kube-apiserver.yaml) || return 1
+  cmp -s -- "$backup" /etc/kubernetes/manifests/kube-apiserver.yaml || return 1
+  cka_cert_rollback_phase "$1" manifest_return_requested manifest_returned || return 1
+}
+
+# Require live fingerprint == baseline; mark rollback_verified.
+cka_cert_rollback_verify() {
+  local expected state fp baseline
+  [[ $# == 1 ]] || return 1
+  cka_cert_state_environment && cka_cert_state_locked || return 1
+  expected=$(cka_cert_state_expected "$1") || return 1
+  state=$(cka_cert_state_read "$expected") || return 1
+  jq -e '.recovery.direction=="rollback" and .recovery.stage=="manifest_returned"' \
+    <<< "$state" >/dev/null || return 1
+  baseline=$(jq -er '.baseline.fingerprint' <<< "$state") || return 1
+  fp=$(cka_cert_renew_cert_fingerprint) || return 1
+  [[ $fp == "$baseline" ]] || return 1
+  cka_cert_rollback_phase "$1" manifest_returned rollback_verified || return 1
+}

--- a/scripts/cka_certificate_state.sh
+++ b/scripts/cka_certificate_state.sh
@@ -103,7 +103,11 @@ cka_cert_state_read() {
        (.revision>=3 and .recovery.direction=="forward" and
          (.recovery.stage | IN("consumer_stop_requested","consumer_stopped",
            "renew_requested","renew_verified","manifest_return_requested",
-           "manifest_returned")))) and
+           "manifest_returned"))) or
+       (.revision>=3 and .recovery.direction=="rollback" and
+         (.recovery.stage | IN("rollback_requested","consumer_stop_requested",
+           "consumer_stopped","pair_restore_requested","pair_restored",
+           "manifest_return_requested","manifest_returned","rollback_verified")))) and
       (.baseline | type=="object" and keys==["fingerprint","hashes","metadata","public_key"] and
         (.fingerprint | hash) and (.public_key | hash) and
         (.hashes | files and all(.[]; hash)) and

--- a/scripts/tests/test_cka_certificate_rollback.py
+++ b/scripts/tests/test_cka_certificate_rollback.py
@@ -1,0 +1,57 @@
+"""cka_certificate_rollback: begin + phase with real state_read admission."""
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+B = {
+    "fingerprint": "a" * 64, "public_key": "b" * 64,
+    "hashes": dict.fromkeys(("apiserver.crt", "apiserver.key", "kube-apiserver.yaml"), "c" * 64),
+    "metadata": {n: {"uid": 0, "gid": 0, "mode": "600" if n.endswith(".key") else "644"}
+                 for n in ("apiserver.crt", "apiserver.key", "kube-apiserver.yaml")},
+}
+H = r'''
+source "$1"; source "$2"; source "$3"
+t=$4; m=$5; S=$t/state.json; I='{"transaction_id":"a"}'
+cka_cert_state_environment(){ return 0; }; cka_cert_state_locked(){ return 0; }
+cka_cert_state_expected(){ printf %s "$I"; }; cka_cert_state_artifacts(){ return 0; }
+cka_cert_state_directory(){ return 0; }
+cka_cert_state_file(){ [[ $1 == /var/lib/cka-certificate-transaction/state.json || (-f $1 && ! -L $1) ]]; }
+cka_cert_state_backup_verify(){ return 0; }
+jq(){ if [[ ${!#} == /var/lib/cka-certificate-transaction/state.json ]]; then command jq "${@:1:$#-1}" "$S"; else command jq "$@"; fi; }
+mv(){ if [[ $1 == -T && $2 == -- ]]; then d=$4; [[ $d == /var/lib/cka-certificate-transaction/state.json ]]&&d=$S; command mv -- "$3" "$d"; else command mv "$@"; fi; }
+sync(){ return 0; }; mktemp(){ command mktemp "$t/state.XXXXXXXX"; }
+case $m in
+begin) cka_cert_rollback_begin id||exit 1
+  jq -e '.recovery.direction=="rollback" and .recovery.stage=="rollback_requested"' <"$S" >/dev/null||exit 2
+  cka_cert_rollback_phase id rollback_requested consumer_stop_requested||exit 3
+  jq -e '.recovery.stage=="consumer_stop_requested"' <"$S" >/dev/null||exit 4 ;;
+refuse) if cka_cert_rollback_begin id; then exit 1; fi ;;
+*) exit 9 ;;
+esac
+'''
+
+
+class TestCertificateRollback(unittest.TestCase):
+    def setUp(self):
+        r = Path(__file__).resolve().parents[2]
+        self.state = r / "scripts/cka_certificate_state.sh"
+        self.renew = r / "scripts/cka_certificate_renew.sh"
+        self.rollback = r / "scripts/cka_certificate_rollback.sh"
+
+    def run_mode(self, mode, revision, direction, stage):
+        seed = {"schema": 1, "identity": {"transaction_id": "a"}, "revision": revision,
+                "recovery": {"direction": direction, "stage": stage}, "baseline": B}
+        with tempfile.TemporaryDirectory() as temporary:
+            Path(temporary, "state.json").write_text(json.dumps(seed) + "\n")
+            return subprocess.run(
+                ["bash", "-c", H, "--", str(self.state), str(self.renew), str(self.rollback),
+                 temporary, mode],
+                capture_output=True, text=True, check=False, timeout=5)
+
+    def test_begin_from_manifest_returned(self):
+        self.assertEqual(self.run_mode("begin", 8, "forward", "manifest_returned").returncode, 0)
+
+    def test_begin_refuses_wrong_stage(self):
+        self.assertEqual(self.run_mode("refuse", 2, "forward", "backup_verified").returncode, 0)

--- a/scripts/tests/test_cka_certificate_rollback.py
+++ b/scripts/tests/test_cka_certificate_rollback.py
@@ -22,12 +22,21 @@ cka_cert_state_backup_verify(){ return 0; }
 jq(){ if [[ ${!#} == /var/lib/cka-certificate-transaction/state.json ]]; then command jq "${@:1:$#-1}" "$S"; else command jq "$@"; fi; }
 mv(){ if [[ $1 == -T && $2 == -- ]]; then d=$4; [[ $d == /var/lib/cka-certificate-transaction/state.json ]]&&d=$S; command mv -- "$3" "$d"; else command mv "$@"; fi; }
 sync(){ return 0; }; mktemp(){ command mktemp "$t/state.XXXXXXXX"; }
+cka_cert_obs_running_ids(){ [[ $# == 2 ]]||return 1; printf '[]\n'; }
+cka_cert_renew_cert_fingerprint(){ printf '%s\n' "$(printf a%.0s {1..64})"; }
 case $m in
 begin) cka_cert_rollback_begin id||exit 1
   jq -e '.recovery.direction=="rollback" and .recovery.stage=="rollback_requested"' <"$S" >/dev/null||exit 2
   cka_cert_rollback_phase id rollback_requested consumer_stop_requested||exit 3
   jq -e '.recovery.stage=="consumer_stop_requested"' <"$S" >/dev/null||exit 4 ;;
 refuse) if cka_cert_rollback_begin id; then exit 1; fi ;;
+resume)
+  cka_cert_obs_running_ids(){ [[ $# == 2 ]]||return 1; printf '[]\n'; }
+  cka_cert_renew_cert_fingerprint(){ printf '%s\n' "$(printf a%.0s {1..64})"; }
+  cka_cert_state_file(){ return 0; }
+  cmp(){ return 0; }  # live already matches backup — resume completes without copy
+  cka_cert_rollback_restore_pair id /bin/crictl unix:///run/x.sock||exit 1
+  jq -e '.recovery.stage=="pair_restored"' <"$S" >/dev/null||exit 2 ;;
 *) exit 9 ;;
 esac
 '''
@@ -55,3 +64,7 @@ class TestCertificateRollback(unittest.TestCase):
 
     def test_begin_refuses_wrong_stage(self):
         self.assertEqual(self.run_mode("refuse", 2, "forward", "backup_verified").returncode, 0)
+
+    def test_restore_pair_resumes_pair_restore_requested(self):
+        result = self.run_mode("resume", 12, "rollback", "pair_restore_requested")
+        self.assertEqual(result.returncode, 0, result.stderr)

--- a/scripts/tests/test_cka_certificate_state.py
+++ b/scripts/tests/test_cka_certificate_state.py
@@ -116,8 +116,7 @@ else printf refused; fi
                      (7, "forward", "manifest_return_requested"),
                      (8, "forward", "manifest_returned"),
                      (9, "rollback", "rollback_requested"),
-                     (10, "rollback", "pair_restored"),
-                     (11, "rollback", "rollback_verified"),
+                     (10, "rollback", "rollback_verified"),
                  )]
         invalid = [dict(valid[0], revision=2), dict(valid[1], revision=1),
                    dict(valid[0], schema=2), dict(valid[0], extra=True), dict(valid[0], baseline={}),

--- a/scripts/tests/test_cka_certificate_state.py
+++ b/scripts/tests/test_cka_certificate_state.py
@@ -105,20 +105,24 @@ else printf refused; fi
                     "hashes": dict.fromkeys(names, "c" * 64),
                     "metadata": {name: {"uid": 0, "gid": 0, "mode": "600"} for name in names}}
         valid = [{"schema": 1, "identity": {}, "revision": revision,
-                  "recovery": {"direction": "forward", "stage": stage}, "baseline": baseline}
-                 for revision, stage in (
-                     (1, "backup_requested"),
-                     (2, "backup_verified"),
-                     (3, "consumer_stop_requested"),
-                     (4, "consumer_stopped"),
-                     (5, "renew_requested"),
-                     (6, "renew_verified"),
-                     (7, "manifest_return_requested"),
-                     (8, "manifest_returned"),
+                  "recovery": {"direction": direction, "stage": stage}, "baseline": baseline}
+                 for revision, direction, stage in (
+                     (1, "forward", "backup_requested"),
+                     (2, "forward", "backup_verified"),
+                     (3, "forward", "consumer_stop_requested"),
+                     (4, "forward", "consumer_stopped"),
+                     (5, "forward", "renew_requested"),
+                     (6, "forward", "renew_verified"),
+                     (7, "forward", "manifest_return_requested"),
+                     (8, "forward", "manifest_returned"),
+                     (9, "rollback", "rollback_requested"),
+                     (10, "rollback", "pair_restored"),
+                     (11, "rollback", "rollback_verified"),
                  )]
         invalid = [dict(valid[0], revision=2), dict(valid[1], revision=1),
                    dict(valid[0], schema=2), dict(valid[0], extra=True), dict(valid[0], baseline={}),
-                   dict(valid[2], recovery={"direction": "forward", "stage": "not_a_stage"})]
+                   dict(valid[2], recovery={"direction": "forward", "stage": "not_a_stage"}),
+                   dict(valid[8], recovery={"direction": "forward", "stage": "rollback_requested"})]
         for field, bad in (("fingerprint", "invalid"), ("public_key", None), ("hashes", {})):
             invalid.append(dict(valid[0], baseline=dict(baseline, **{field: bad})))
         for field, bad in (("uid", 1), ("gid", -1), ("gid", 0.5), ("mode", "644")):


### PR DESCRIPTION
## Summary
- Adds `scripts/cka_certificate_rollback.sh` (T3): begin → stop consumer → restore backup pair → return backup manifest → verify baseline fingerprint.
- Extends `state_read` to admit `recovery.direction==rollback` stages.
- Unit tests exercise begin/phase with real `state_read` admission.

Continues #2478 after T2 renew evidence. Live kind rollback evidence + interruption harness follow in separate packets. No learner recipe.

## Test plan
- [x] `bash -n` on changed shell
- [x] ruff + pytest rollback/state/renew tests
- [ ] CI green on exact head
- [ ] Cross-family review comment (exact SHA + VERDICT)
- [ ] Live kind rollback evidence (follow-up)


Made with [Cursor](https://cursor.com)