### PR TITLE
docs(cka): pin etcd restore topology contract (#2479)

### DIFF
--- a/docs/pins/etcd.yaml
+++ b/docs/pins/etcd.yaml
@@ -1,0 +1,29 @@
+# KubeDojo etcd recovery pins (#2479 under epic #2272).
+# Agents: do not publish learner snapshot/restore recipes until E2–E3 evidence exists.
+# Bump only with verified tool/image compatibility on an owned disposable fixture.
+
+kubernetes:
+  exam_pin_minor: "1.35"
+  kind_node_image: "kindest/node:v1.35.0"
+  # Digest pin used by scripts/cka_certificate_fixture.py (reuse for etcd fixture until split).
+  kind_node_digest: "sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661"
+  verified_date: "2026-09-13"
+
+etcd:
+  # kubeadm kind 1.35 ships etcd in-tree; confirm exact binary at fixture inspect time.
+  expected_major_minor: "3.5"
+  endpoint: "https://127.0.0.1:2379"
+  # Paths on the control-plane node (kubeadm layout).
+  data_dir: "/var/lib/etcd"
+  pki_dir: "/etc/kubernetes/pki/etcd"
+  verified_note: "Exact etcd version string must be captured from the owned node before restore work."
+
+tools:
+  etcdctl: "must speak TLS to the local endpoint with etcd CA/cert/key"
+  etcdutl: "offline restore into a clean target directory (never in-place over live data)"
+  ownership: "fixture cluster name cert-fixture-* style private run dirs; no shared/live clusters"
+
+forbidden_until_evidence:
+  - "learner-facing snapshot/restore command recipes in module-5.3"
+  - "endpoint health alone as proof of Kubernetes state restore"
+  - "mutating shared or persistent fixtures"

--- a/docs/release-maintenance/etcd-snapshot-restore-playbook.md
+++ b/docs/release-maintenance/etcd-snapshot-restore-playbook.md
@@ -1,0 +1,30 @@
+# Etcd snapshot restore — standing playbook (#2479)
+
+AI-facing workflow. Human operators may follow the same steps. **No learner mutation recipe** until E2–E3 evidence is accepted on #2479.
+
+## Pins
+
+See [`docs/pins/etcd.yaml`](../pins/etcd.yaml). Reuse the disposable kind ownership pattern from the CKA certificate fixture (`scripts/cka_certificate_fixture.py`) unless a measured split requires a dedicated etcd fixture module.
+
+## Packet order (≤200 LOC / PR)
+
+| Packet | Deliverable |
+|--------|-------------|
+| **E0** | This playbook + pins (topology/tool contract) |
+| **E1** | Fixture create/inspect/delete ownership for etcd work (reuse or thin wrapper) |
+| **E2** | Snapshot + marker in snapshot + separately observed post-snapshot mutation |
+| **E3** | Offline restore to clean dirs, verify marker + API/controller behavior; labelled interrupt/rollback |
+| **E4** | ≤80-line lesson link on module-5.3 only after E2–E3 accepted |
+
+## Acceptance rules
+
+1. Unique private run directory; collision refusal; retain originals.
+2. Authenticated baseline before snapshot; marker captured by the snapshot.
+3. Post-snapshot mutation observed separately from restore success.
+4. `endpoint health` is **not** proof of Kubernetes contents restored.
+5. Interruptions leave fixture preserved until reconciliation.
+
+## Sources
+
+- [etcd 3.6 recovery](https://etcd.io/docs/v3.6/op-guide/recovery/) (confirm version against the owned node)
+- Kubernetes kubeadm etcd backup notes for the exam pin minor in `docs/pins/kubernetes.yaml`


### PR DESCRIPTION
## Summary
- Adds `docs/pins/etcd.yaml` and standing E0–E4 playbook.
- No executable restore; no learner mutation recipe.

## Test plan
- [ ] CF on exact head
- [ ] CI green


Made with [Cursor](https://cursor.com)