### PR TITLE
feat(cka): add etcd fixture wrapper over owned kind lifecycle (#2479)

### DIFF
--- a/scripts/cka_etcd_fixture.py
+++ b/scripts/cka_etcd_fixture.py
@@ -1,0 +1,107 @@
+"""Owned disposable etcd fixture helpers; lifecycle reuses certificate Fixture. No restore."""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import signal
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "cka_certificate_fixture", ROOT / "scripts/cka_certificate_fixture.py"
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+Fixture = _mod.Fixture
+
+ETCD_ENDPOINT = "https://127.0.0.1:2379"
+ETCD_PKI = "/etc/kubernetes/pki/etcd"
+ETCD_DATA = "/var/lib/etcd"
+
+
+class EtcdFixture:
+    """Compose the owned kind fixture; add etcd topology capture only."""
+
+    def __init__(self, directory, create=False):
+        self.inner = Fixture(directory, create=create)
+
+    def __getattr__(self, name):
+        return getattr(self.inner, name)
+
+    def etcd_inspect(self):
+        self.inner.verify()
+        self.inner.inspect()
+        node_id = self.inner.state["node"]["id"]
+        inventory = self.inner.run(
+            "docker",
+            "exec",
+            node_id,
+            "sh",
+            "-c",
+            "command -v etcdctl; command -v etcdutl; "
+            f"test -d {ETCD_DATA} && test -d {ETCD_PKI} && echo paths_ok",
+        )
+        version = self.inner.run(
+            "docker",
+            "exec",
+            node_id,
+            "sh",
+            "-c",
+            "etcdctl version 2>/dev/null | head -1 || true",
+        )
+        if version and not re.search(r"etcdctl\s+version:\s*3\.", version):
+            # Fall back to recording raw output; refuse empty inventry.
+            pass
+        if "paths_ok" not in inventory:
+            raise RuntimeError("etcd data/pki paths missing on owned node")
+        self.inner.state["etcd"] = {
+            "endpoint": ETCD_ENDPOINT,
+            "data_dir": ETCD_DATA,
+            "pki_dir": ETCD_PKI,
+            "tool_inventory": inventory,
+            "etcdctl_version_line": version,
+            "restore_executed": False,
+        }
+        self.inner.save()
+        return self.inner.state["etcd"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("create", "inspect", "etcd-inspect", "delete"))
+    parser.add_argument("run_dir")
+    args = parser.parse_args()
+    fixture = None
+
+    def interrupted(signum, _frame):
+        raise InterruptedError(
+            f"Signal {signum}; client cancellation does not prove node work stopped"
+        )
+
+    signal.signal(signal.SIGINT, interrupted)
+    signal.signal(signal.SIGTERM, interrupted)
+    try:
+        fixture = EtcdFixture(args.run_dir, create=args.action == "create")
+        if args.action == "etcd-inspect":
+            print(json.dumps(fixture.etcd_inspect(), indent=2))
+        elif args.action == "create":
+            fixture.create()
+        elif args.action == "inspect":
+            fixture.inspect()
+        else:
+            fixture.delete()
+    except (OSError, ValueError, RuntimeError, KeyError, TypeError, subprocess.SubprocessError) as error:
+        if fixture is not None:
+            fixture.inner.state["error"] = str(error)
+            fixture.inner.save()
+        raise SystemExit(str(error)) from None
+    finally:
+        if fixture is not None:
+            fixture.inner.lock.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cka_etcd_fixture.py
+++ b/scripts/cka_etcd_fixture.py
@@ -44,19 +44,23 @@ class EtcdFixture:
             "command -v etcdctl; command -v etcdutl; "
             f"test -d {ETCD_DATA} && test -d {ETCD_PKI} && echo paths_ok",
         )
+        if "etcdctl" not in inventory or "etcdutl" not in inventory:
+            raise RuntimeError("etcdctl/etcdutl missing on owned node")
+        if "paths_ok" not in inventory:
+            raise RuntimeError("etcd data/pki paths missing on owned node")
         version = self.inner.run(
             "docker",
             "exec",
             node_id,
             "sh",
             "-c",
-            "etcdctl version 2>/dev/null | head -1 || true",
-        )
-        if version and not re.search(r"etcdctl\s+version:\s*3\.", version):
-            # Fall back to recording raw output; refuse empty inventry.
-            pass
-        if "paths_ok" not in inventory:
-            raise RuntimeError("etcd data/pki paths missing on owned node")
+            "etcdctl version 2>/dev/null | head -1",
+        ).strip()
+        if not version or not re.search(r"etcdctl\s+version:\s*3\.", version):
+            raise RuntimeError(
+                "etcdctl version line missing or not etcd 3.x: "
+                f"{version!r}"
+            )
         self.inner.state["etcd"] = {
             "endpoint": ETCD_ENDPOINT,
             "data_dir": ETCD_DATA,

--- a/scripts/tests/test_cka_etcd_fixture.py
+++ b/scripts/tests/test_cka_etcd_fixture.py
@@ -1,6 +1,5 @@
 """cka_etcd_fixture: composition + refuse restore claims without live kind."""
 import importlib.util
-import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -21,22 +20,21 @@ class TestEtcdFixture(unittest.TestCase):
         self.assertIn("etcd", self.mod.ETCD_PKI)
 
     def test_etcd_inspect_records_no_restore(self):
-        with tempfile.TemporaryDirectory() as temporary:
-            # Avoid real Fixture ctor (needs 0700 owned dir + tools).
-            fake = mock.Mock()
-            fake.state = {"node": {"id": "abc"}, "etcd": {}}
-            fake.verify = mock.Mock()
-            fake.inspect = mock.Mock()
-            fake.run = mock.Mock(
-                side_effect=[
-                    "/usr/local/bin/etcdctl\n/usr/local/bin/etcdutl\npaths_ok",
-                    "etcdctl version: 3.5.16",
-                ]
-            )
-            fake.save = mock.Mock()
-            wrapper = self.mod.EtcdFixture.__new__(self.mod.EtcdFixture)
-            wrapper.inner = fake
-            result = wrapper.etcd_inspect()
-            self.assertFalse(result["restore_executed"])
-            self.assertEqual(result["endpoint"], self.mod.ETCD_ENDPOINT)
-            self.assertIn("3.5", result["etcdctl_version_line"])
+        # Avoid real Fixture ctor (needs 0700 owned dir + tools).
+        fake = mock.Mock()
+        fake.state = {"node": {"id": "abc"}, "etcd": {}}
+        fake.verify = mock.Mock()
+        fake.inspect = mock.Mock()
+        fake.run = mock.Mock(
+            side_effect=[
+                "/usr/local/bin/etcdctl\n/usr/local/bin/etcdutl\npaths_ok",
+                "etcdctl version: 3.5.16",
+            ]
+        )
+        fake.save = mock.Mock()
+        wrapper = self.mod.EtcdFixture.__new__(self.mod.EtcdFixture)
+        wrapper.inner = fake
+        result = wrapper.etcd_inspect()
+        self.assertFalse(result["restore_executed"])
+        self.assertEqual(result["endpoint"], self.mod.ETCD_ENDPOINT)
+        self.assertIn("3.5", result["etcdctl_version_line"])

--- a/scripts/tests/test_cka_etcd_fixture.py
+++ b/scripts/tests/test_cka_etcd_fixture.py
@@ -1,0 +1,42 @@
+"""cka_etcd_fixture: composition + refuse restore claims without live kind."""
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+class TestEtcdFixture(unittest.TestCase):
+    def setUp(self):
+        root = Path(__file__).resolve().parents[2]
+        spec = importlib.util.spec_from_file_location(
+            "cka_etcd_fixture", root / "scripts/cka_etcd_fixture.py"
+        )
+        self.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.mod)
+
+    def test_constants_match_pins(self):
+        self.assertEqual(self.mod.ETCD_ENDPOINT, "https://127.0.0.1:2379")
+        self.assertTrue(self.mod.ETCD_DATA.startswith("/var/lib/"))
+        self.assertIn("etcd", self.mod.ETCD_PKI)
+
+    def test_etcd_inspect_records_no_restore(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            # Avoid real Fixture ctor (needs 0700 owned dir + tools).
+            fake = mock.Mock()
+            fake.state = {"node": {"id": "abc"}, "etcd": {}}
+            fake.verify = mock.Mock()
+            fake.inspect = mock.Mock()
+            fake.run = mock.Mock(
+                side_effect=[
+                    "/usr/local/bin/etcdctl\n/usr/local/bin/etcdutl\npaths_ok",
+                    "etcdctl version: 3.5.16",
+                ]
+            )
+            fake.save = mock.Mock()
+            wrapper = self.mod.EtcdFixture.__new__(self.mod.EtcdFixture)
+            wrapper.inner = fake
+            result = wrapper.etcd_inspect()
+            self.assertFalse(result["restore_executed"])
+            self.assertEqual(result["endpoint"], self.mod.ETCD_ENDPOINT)
+            self.assertIn("3.5", result["etcdctl_version_line"])

--- a/scripts/tests/test_cka_etcd_fixture.py
+++ b/scripts/tests/test_cka_etcd_fixture.py
@@ -19,22 +19,44 @@ class TestEtcdFixture(unittest.TestCase):
         self.assertTrue(self.mod.ETCD_DATA.startswith("/var/lib/"))
         self.assertIn("etcd", self.mod.ETCD_PKI)
 
-    def test_etcd_inspect_records_no_restore(self):
-        # Avoid real Fixture ctor (needs 0700 owned dir + tools).
+    def _wrapper(self, runs):
         fake = mock.Mock()
         fake.state = {"node": {"id": "abc"}, "etcd": {}}
         fake.verify = mock.Mock()
         fake.inspect = mock.Mock()
-        fake.run = mock.Mock(
-            side_effect=[
+        fake.run = mock.Mock(side_effect=runs)
+        fake.save = mock.Mock()
+        wrapper = self.mod.EtcdFixture.__new__(self.mod.EtcdFixture)
+        wrapper.inner = fake
+        return wrapper, fake
+
+    def test_etcd_inspect_records_no_restore(self):
+        # Avoid real Fixture ctor (needs 0700 owned dir + tools).
+        wrapper, fake = self._wrapper(
+            [
                 "/usr/local/bin/etcdctl\n/usr/local/bin/etcdutl\npaths_ok",
                 "etcdctl version: 3.5.16",
             ]
         )
-        fake.save = mock.Mock()
-        wrapper = self.mod.EtcdFixture.__new__(self.mod.EtcdFixture)
-        wrapper.inner = fake
         result = wrapper.etcd_inspect()
         self.assertFalse(result["restore_executed"])
         self.assertEqual(result["endpoint"], self.mod.ETCD_ENDPOINT)
         self.assertIn("3.5", result["etcdctl_version_line"])
+        fake.save.assert_called_once()
+
+    def test_etcd_inspect_rejects_missing_tools(self):
+        wrapper, fake = self._wrapper(["paths_ok"])
+        with self.assertRaisesRegex(RuntimeError, "etcdctl/etcdutl missing"):
+            wrapper.etcd_inspect()
+        fake.save.assert_not_called()
+
+    def test_etcd_inspect_rejects_empty_version(self):
+        wrapper, fake = self._wrapper(
+            [
+                "/usr/local/bin/etcdctl\n/usr/local/bin/etcdutl\npaths_ok",
+                "",
+            ]
+        )
+        with self.assertRaisesRegex(RuntimeError, "version line missing"):
+            wrapper.etcd_inspect()
+        fake.save.assert_not_called()


### PR DESCRIPTION
## Summary
- E1: `scripts/cka_etcd_fixture.py` composes the owned kind Fixture and adds `etcd-inspect` (paths/tools/version).
- Records `restore_executed: false` — no snapshot/restore yet.
- Unit tests with mocked inner fixture.

## Test plan
- [x] ruff + pytest
- [ ] CF + CI
- [ ] Optional later: live etcd-inspect on disposable kind


Made with [Cursor](https://cursor.com)