### PR TITLE
feat(cka): etcd snapshot + marker + post-mutation observe (#2479)

### DIFF
--- a/scripts/cka_etcd_fixture.py
+++ b/scripts/cka_etcd_fixture.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import importlib.util
 import json
 import re
+import shlex
 import signal
 import subprocess
+import uuid
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -20,6 +23,8 @@ Fixture = _mod.Fixture
 ETCD_ENDPOINT = "https://127.0.0.1:2379"
 ETCD_PKI = "/etc/kubernetes/pki/etcd"
 ETCD_DATA = "/var/lib/etcd"
+MARKER_NAME = "snapshot-marker"
+SNAPSHOT_FILE = "etcd-snapshot.db"
 
 
 class EtcdFixture:
@@ -31,10 +36,43 @@ class EtcdFixture:
     def __getattr__(self, name):
         return getattr(self.inner, name)
 
+    def _node_id(self):
+        return self.inner.state["node"]["id"]
+
+    def _ensure_etcd(self):
+        if not self.inner.state.get("etcd"):
+            self.etcd_inspect()
+        return self.inner.state["etcd"]
+
+    def _etcdctl(self, *args):
+        pki = ETCD_PKI
+        cmd = [
+            "etcdctl",
+            f"--endpoints={ETCD_ENDPOINT}",
+            f"--cacert={pki}/ca.crt",
+            f"--cert={pki}/server.crt",
+            f"--key={pki}/server.key",
+            *args,
+        ]
+        return self.inner.run(
+            "docker", "exec", self._node_id(), "sh", "-c", " ".join(shlex.quote(a) for a in cmd)
+        )
+
+    def _refuse_unauthenticated(self):
+        probe = f"etcdctl --endpoints={ETCD_ENDPOINT} endpoint status -w json"
+        try:
+            self.inner.run("docker", "exec", self._node_id(), "sh", "-c", probe)
+        except RuntimeError:
+            return
+        raise RuntimeError("Unauthenticated etcdctl succeeded; refusing")
+
+    def _marker_cm(self, namespace, name):
+        return json.loads(self.inner.api("-n", namespace, "get", "configmap", name, "-o", "json"))
+
     def etcd_inspect(self):
         self.inner.verify()
         self.inner.inspect()
-        node_id = self.inner.state["node"]["id"]
+        node_id = self._node_id()
         inventory = self.inner.run(
             "docker",
             "exec",
@@ -72,10 +110,103 @@ class EtcdFixture:
         self.inner.save()
         return self.inner.state["etcd"]
 
+    def ensure_marker(self):
+        self.inner.verify()
+        marker = self.inner.state.get("etcd_marker")
+        if marker:
+            observed = self._marker_cm(marker["namespace"], marker["name"])
+            if observed["metadata"]["uid"] != marker["uid"]:
+                raise RuntimeError("Marker object identity changed")
+            if observed["data"]["value"] != marker["value"]:
+                raise RuntimeError("Marker value drifted before snapshot")
+            return marker
+        namespace = "etcd-marker-" + uuid.uuid4().hex
+        value = uuid.uuid4().hex
+        self.inner.api("create", "namespace", namespace)
+        self.inner.api("-n", namespace, "create", "configmap", MARKER_NAME, "--from-literal=value=" + value)
+        observed = self._marker_cm(namespace, MARKER_NAME)
+        marker = {"namespace": namespace, "name": MARKER_NAME, "uid": observed["metadata"]["uid"], "value": value}
+        self.inner.state["etcd_marker"] = marker
+        self.inner.save()
+        return marker
+
+    def etcd_baseline(self):
+        self._ensure_etcd()
+        self._refuse_unauthenticated()
+        marker = self.ensure_marker()
+        status = json.loads(self._etcdctl("endpoint", "status", "-w", "json"))[0]["Status"]
+        revision = status["header"]["revision"]
+        etcd_key = f"/registry/configmaps/{marker['namespace']}/{marker['name']}"
+        if not self._etcdctl("get", etcd_key):
+            raise RuntimeError("Marker key missing in etcd")
+        baseline = {"revision": revision, "marker_etcd_key": etcd_key, "authenticated": True}
+        self.inner.state["etcd_baseline"] = baseline
+        self.inner.state["etcd"]["restore_executed"] = False
+        self.inner.save()
+        return baseline
+
+    def snapshot_save(self):
+        etcd = self._ensure_etcd()
+        baseline = self.inner.state.get("etcd_baseline")
+        if not baseline:
+            raise RuntimeError("etcd baseline required before snapshot")
+        snap_path = self.inner.directory / SNAPSHOT_FILE
+        if self.inner.state.get("snapshot") or snap_path.exists():
+            raise RuntimeError("Refusing to overwrite existing snapshot")
+        node_snap = "/tmp/etcd-snapshot-" + uuid.uuid4().hex + ".db"
+        self._etcdctl("snapshot", "save", node_snap)
+        status = json.loads(
+            self.inner.run(
+                "docker", "exec", self._node_id(), "etcdutl", "snapshot", "status", node_snap, "-w", "json"
+            )
+        )
+        snap_revision = status.get("revision", status.get("Revision"))
+        if snap_revision is None or snap_revision < baseline["revision"]:
+            raise RuntimeError("Snapshot revision does not cover baseline")
+        self.inner.run("docker", "cp", f"{self._node_id()}:{node_snap}", str(snap_path))
+        digest = hashlib.sha256(snap_path.read_bytes()).hexdigest()
+        self.inner.state["snapshot"] = {
+            "path": str(snap_path),
+            "sha256": digest,
+            "status": status,
+            "node_temp_path": node_snap,
+        }
+        etcd["restore_executed"] = False
+        self.inner.save()
+        return self.inner.state["snapshot"]
+
+    def post_snapshot_mutate(self):
+        marker = self.inner.state.get("etcd_marker")
+        snapshot = self.inner.state.get("snapshot")
+        if not marker or not snapshot:
+            raise RuntimeError("Snapshot and marker required before post-snapshot mutation")
+        patch = json.dumps({"data": {"value": uuid.uuid4().hex}})
+        self.inner.api("-n", marker["namespace"], "patch", "configmap", marker["name"], "--type", "merge", "-p", patch)
+        observed = self._marker_cm(marker["namespace"], marker["name"])
+        self.inner.state["post_snapshot_mutation"] = {
+            "value": observed["data"]["value"],
+            "uid": observed["metadata"]["uid"],
+        }
+        digest = hashlib.sha256(Path(snapshot["path"]).read_bytes()).hexdigest()
+        if digest != snapshot["sha256"]:
+            raise RuntimeError("Snapshot file hash changed after mutation")
+        self.inner.state["etcd"]["restore_executed"] = False
+        self.inner.save()
+        return self.inner.state["post_snapshot_mutation"]
+
+    def snapshot_observe(self):
+        self.etcd_baseline()
+        self.snapshot_save()
+        self.post_snapshot_mutate()
+        return self.inner.state
+
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("action", choices=("create", "inspect", "etcd-inspect", "delete"))
+    parser.add_argument(
+        "action",
+        choices=("create", "inspect", "etcd-inspect", "snapshot-observe", "delete"),
+    )
     parser.add_argument("run_dir")
     args = parser.parse_args()
     fixture = None
@@ -91,6 +222,8 @@ def main():
         fixture = EtcdFixture(args.run_dir, create=args.action == "create")
         if args.action == "etcd-inspect":
             print(json.dumps(fixture.etcd_inspect(), indent=2))
+        elif args.action == "snapshot-observe":
+            print(json.dumps(fixture.snapshot_observe(), indent=2, default=str))
         elif args.action == "create":
             fixture.create()
         elif args.action == "inspect":

--- a/scripts/tests/test_cka_etcd_fixture.py
+++ b/scripts/tests/test_cka_etcd_fixture.py
@@ -1,5 +1,7 @@
-"""cka_etcd_fixture: composition + refuse restore claims without live kind."""
+"""cka_etcd_fixture: composition + snapshot observe without live kind."""
 import importlib.util
+import json
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -19,19 +21,19 @@ class TestEtcdFixture(unittest.TestCase):
         self.assertTrue(self.mod.ETCD_DATA.startswith("/var/lib/"))
         self.assertIn("etcd", self.mod.ETCD_PKI)
 
-    def _wrapper(self, runs):
+    def _wrapper(self, runs, directory=None, state=None):
         fake = mock.Mock()
-        fake.state = {"node": {"id": "abc"}, "etcd": {}}
+        fake.state = state or {"node": {"id": "abc"}, "etcd": {}}
         fake.verify = mock.Mock()
         fake.inspect = mock.Mock()
         fake.run = mock.Mock(side_effect=runs)
         fake.save = mock.Mock()
+        fake.directory = directory or Path("/tmp/etcd-fixture-run")
         wrapper = self.mod.EtcdFixture.__new__(self.mod.EtcdFixture)
         wrapper.inner = fake
         return wrapper, fake
 
     def test_etcd_inspect_records_no_restore(self):
-        # Avoid real Fixture ctor (needs 0700 owned dir + tools).
         wrapper, fake = self._wrapper(
             [
                 "/usr/local/bin/etcdctl\n/usr/local/bin/etcdutl\npaths_ok",
@@ -42,7 +44,7 @@ class TestEtcdFixture(unittest.TestCase):
         self.assertFalse(result["restore_executed"])
         self.assertEqual(result["endpoint"], self.mod.ETCD_ENDPOINT)
         self.assertIn("3.5", result["etcdctl_version_line"])
-        fake.save.assert_called_once()
+        fake.save.assert_called()
 
     def test_etcd_inspect_rejects_missing_tools(self):
         wrapper, fake = self._wrapper(["paths_ok"])
@@ -60,3 +62,57 @@ class TestEtcdFixture(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "version line missing"):
             wrapper.etcd_inspect()
         fake.save.assert_not_called()
+
+    def test_snapshot_observe_success(self):
+        tmp_path = Path(tempfile.mkdtemp())
+        status_json = json.dumps({"revision": 42, "totalSize": 4})
+        cm = lambda value, uid: json.dumps({"metadata": {"uid": uid}, "data": {"value": value}})
+
+        def run(tool, *args):
+            shell = args[-1] if args and isinstance(args[-1], str) else ""
+            if tool == "docker" and args[0] == "exec" and len(args) > 2 and args[2] == "etcdutl":
+                return status_json
+            if tool == "docker" and args[0] == "exec" and "endpoint status" in shell:
+                if "--cacert=" not in shell:
+                    raise RuntimeError("unauth")
+                return json.dumps([{"Status": {"header": {"revision": 40}}}])
+            if tool == "docker" and args[0] == "exec" and "etcdctl version" in shell:
+                return "etcdctl version: 3.5.16"
+            if tool == "docker" and args[0] == "exec" and "command -v" in shell:
+                return "/usr/local/bin/etcdctl\n/usr/local/bin/etcdutl\npaths_ok"
+            if tool == "docker" and args[0] == "exec" and shell.startswith("etcdctl"):
+                return "" if "snapshot save" in shell else "present"
+            if tool == "docker" and args[0] == "cp":
+                Path(args[2]).write_bytes(b"snap")
+                return ""
+            raise AssertionError(args)
+
+        wrapper, fake = self._wrapper([], directory=tmp_path)
+        fake.state = {"node": {"id": "node-abc"}}
+        fake.run = mock.Mock(side_effect=run)
+        fake.api = mock.Mock(side_effect=[None, None, cm("one", "u1"), None, cm("two", "u2")])
+        state = wrapper.snapshot_observe()
+        self.assertFalse(state["etcd"]["restore_executed"])
+        self.assertGreaterEqual(state["snapshot"]["status"]["revision"], state["etcd_baseline"]["revision"])
+        self.assertEqual(state["post_snapshot_mutation"]["value"], "two")
+        self.assertTrue((tmp_path / self.mod.SNAPSHOT_FILE).exists())
+
+    def test_snapshot_refuse_overwrite(self):
+        tmp_path = Path(tempfile.mkdtemp())
+        snap_path = tmp_path / self.mod.SNAPSHOT_FILE
+        snap_path.write_bytes(b"existing")
+        wrapper, fake = self._wrapper([], directory=tmp_path)
+        fake.state = {
+            "node": {"id": "node-abc"},
+            "etcd": {"restore_executed": False},
+            "etcd_baseline": {"revision": 1, "marker_etcd_key": "/registry/x", "authenticated": True},
+            "snapshot": {"path": str(snap_path), "sha256": "deadbeef"},
+        }
+        with self.assertRaisesRegex(RuntimeError, "overwrite"):
+            wrapper.snapshot_save()
+
+    def test_snapshot_observe_refuses_missing_tools(self):
+        wrapper, fake = self._wrapper(["paths_ok"])
+        fake.state = {"node": {"id": "abc"}}
+        with self.assertRaisesRegex(RuntimeError, "etcdctl/etcdutl missing"):
+            wrapper.snapshot_observe()


### PR DESCRIPTION
## Summary
- E2 (#2479): extend `scripts/cka_etcd_fixture.py` with marker placement, authenticated etcd baseline, `etcdctl snapshot save`, snapshot hash/status recording, and post-snapshot ConfigMap mutation observation.
- New CLI action `snapshot-observe` orchestrates baseline → snapshot → mutation; `restore_executed` remains `false`.
- Mocked unit tests cover success path, snapshot overwrite refusal, and missing-tool failure (no live kind required).

## Test plan
- [x] `/Users/krisztiankoos/projects/kubedojo/.venv/bin/ruff check scripts/cka_etcd_fixture.py scripts/tests/test_cka_etcd_fixture.py`
- [x] `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python -m pytest scripts/tests/test_cka_etcd_fixture.py -q` (7 passed)
- [ ] CI
- [ ] Optional later: live `snapshot-observe` on disposable kind fixture


Made with [Cursor](https://cursor.com)