### PR TITLE
feat(cka): offline etcd restore with staged resume (#2479 E3)

### DIFF
--- a/scripts/cka_etcd_fixture.py
+++ b/scripts/cka_etcd_fixture.py
@@ -245,11 +245,15 @@ class EtcdFixture:
         )
         params = {}
         for line in manifest_text.splitlines():
-            stripped = line.strip().lstrip("- ").strip()
-            for key in keys:
-                prefix = f"--{key}="
-                if stripped.startswith(prefix):
-                    params[key] = stripped[len(prefix) :].strip().strip("\"'")
+            match = re.search(
+                r"--(name|initial-cluster|initial-advertise-peer-urls|initial-cluster-token)=(\S+)",
+                line,
+            )
+            if not match:
+                continue
+            key, value = match.group(1), match.group(2).strip("\"'")
+            if key in keys:
+                params[key] = value
         return params
 
     def _etcd_restore_params(self):

--- a/scripts/cka_etcd_fixture.py
+++ b/scripts/cka_etcd_fixture.py
@@ -1,4 +1,4 @@
-"""Owned disposable etcd fixture helpers; lifecycle reuses certificate Fixture. No restore."""
+"""Owned disposable etcd fixture helpers; lifecycle reuses certificate Fixture."""
 from __future__ import annotations
 
 import argparse
@@ -9,6 +9,7 @@ import re
 import shlex
 import signal
 import subprocess
+import time
 import uuid
 from pathlib import Path
 
@@ -23,6 +24,8 @@ Fixture = _mod.Fixture
 ETCD_ENDPOINT = "https://127.0.0.1:2379"
 ETCD_PKI = "/etc/kubernetes/pki/etcd"
 ETCD_DATA = "/var/lib/etcd"
+ETCD_MANIFEST = "/etc/kubernetes/manifests/etcd.yaml"
+RESTORE_TXN = "/var/lib/etcd-fixture-transaction"
 MARKER_NAME = "snapshot-marker"
 SNAPSHOT_FILE = "etcd-snapshot.db"
 
@@ -200,12 +203,194 @@ class EtcdFixture:
         self.post_snapshot_mutate()
         return self.inner.state
 
+    def _node_sh(self, script):
+        return self.inner.run("docker", "exec", self._node_id(), "sh", "-c", script)
+
+    def _restore_rec(self):
+        etcd = self._ensure_etcd()
+        return etcd.setdefault("restore", {"direction": "restore", "stage": None})
+
+    def _require_restore_inputs(self):
+        marker = self.inner.state.get("etcd_marker")
+        baseline = self.inner.state.get("etcd_baseline")
+        snapshot = self.inner.state.get("snapshot")
+        etcd = self._ensure_etcd()
+        if not marker or not baseline or not snapshot:
+            raise RuntimeError("snapshot, etcd_marker, and etcd_baseline required before restore")
+        if etcd.get("restore_executed"):
+            raise RuntimeError("Restore already executed")
+        if not Path(snapshot["path"]).is_file():
+            raise RuntimeError("Snapshot file missing")
+        return marker, snapshot
+
+    def _advance_restore(self, expected, nxt):
+        rec = self._restore_rec()
+        stage = rec.get("stage")
+        if stage is None and expected == "restore_requested":
+            rec["stage"] = expected
+            self.inner.save()
+            stage = expected
+        if stage != expected:
+            raise RuntimeError(f"Restore stage {stage!r} != expected {expected!r}")
+        rec["stage"] = nxt
+        self.inner.state["etcd"]["restore_executed"] = False
+        self.inner.save()
+
+    def _etcd_restore_params(self):
+        rec = self._restore_rec()
+        if rec.get("restore_params"):
+            return rec["restore_params"]
+        staged = f"{RESTORE_TXN}/etcd.yaml.staged"
+        grep = (
+            "grep -oE '--(name|initial-cluster|initial-advertise-peer-urls|initial-cluster-token)="
+            "[^ \"'\"']+' $M"
+        )
+        script = f"M={ETCD_MANIFEST}; [ -f $M ] || M={staged}; {grep}"
+        params = {}
+        for line in self._node_sh(script).splitlines():
+            key, _, value = line[2:].partition("=")
+            params[key] = value
+        if not params.get("name"):
+            raise RuntimeError("Could not parse etcd restore params from manifest")
+        rec["restore_params"] = params
+        self.inner.save()
+        return params
+
+    def restore_begin(self):
+        marker, _snapshot = self._require_restore_inputs()
+        rec = self._restore_rec()
+        if rec.get("stage") is None:
+            rec["stage"] = "restore_requested"
+            rec["expected_marker_value"] = marker["value"]
+            self.inner.state["etcd"]["restore_executed"] = False
+            self.inner.save()
+        return self.inner.state
+
+    def _stop_etcd_pod(self):
+        rec = self._restore_rec()
+        staged = f"{RESTORE_TXN}/etcd.yaml.staged"
+        stage = rec.get("stage")
+        if stage == "restore_requested":
+            self._advance_restore("restore_requested", "etcd_stop_requested")
+        elif stage != "etcd_stop_requested":
+            return
+        self._etcd_restore_params()
+        self._node_sh(f"mkdir -p {RESTORE_TXN}")
+        if "stopped" not in self._node_sh(
+            f"! test -f {ETCD_MANIFEST} && test -f {staged} && echo stopped"
+        ):
+            self._node_sh(
+                f"if [ -f {ETCD_MANIFEST} ] && [ ! -f {staged} ]; then "
+                f"cp -a {ETCD_MANIFEST} {staged} && rm -f {ETCD_MANIFEST}; fi"
+            )
+            for _ in range(30):
+                try:
+                    self._etcdctl("endpoint", "health")
+                except RuntimeError:
+                    break
+                time.sleep(1)
+            else:
+                raise RuntimeError("etcd did not stop")
+        self._advance_restore("etcd_stop_requested", "etcd_stopped")
+
+    def _offline_restore(self, snapshot):
+        rec = self._restore_rec()
+        stage = rec.get("stage")
+        if stage == "etcd_stopped":
+            self._advance_restore("etcd_stopped", "offline_restore_requested")
+        elif stage != "offline_restore_requested":
+            return
+        moved = rec.setdefault("live_data_moved", f"/var/lib/etcd-pre-{uuid.uuid4().hex[:8]}")
+        restore_dir = rec.setdefault("restore_data_dir", f"/var/lib/etcd-restored-{uuid.uuid4().hex[:8]}")
+        self.inner.save()
+        if "ready" not in self._node_sh(
+            f"test -d {ETCD_DATA} && test -d {moved} && echo ready"
+        ):
+            self._node_sh(f"test ! -d {restore_dir}")
+            self._node_sh(
+                f"if [ -d {ETCD_DATA} ]; then mv {ETCD_DATA} {moved}; fi; mkdir -p {restore_dir}"
+            )
+            node_snap = f"/tmp/etcd-restore-{uuid.uuid4().hex}.db"
+            self.inner.run("docker", "cp", snapshot["path"], f"{self._node_id()}:{node_snap}")
+            params = self._etcd_restore_params()
+            flags = " ".join(f"--{k}={shlex.quote(params[k])}" for k in sorted(params))
+            self._node_sh(f"etcdutl snapshot restore {node_snap} --data-dir={restore_dir} {flags}")
+            self._node_sh(f"rm -rf {ETCD_DATA} && mv {restore_dir} {ETCD_DATA}")
+        self._advance_restore("offline_restore_requested", "offline_restored")
+
+    def _return_etcd_pod(self):
+        rec = self._restore_rec()
+        staged = f"{RESTORE_TXN}/etcd.yaml.staged"
+        stage = rec.get("stage")
+        if stage == "offline_restored":
+            self._advance_restore("offline_restored", "etcd_return_requested")
+        elif stage != "etcd_return_requested":
+            return
+        if "ok" not in self._node_sh(
+            f"test -f {ETCD_MANIFEST} && test -f {staged} && cmp -s {ETCD_MANIFEST} {staged} && echo ok"
+        ):
+            self._node_sh(f"test -f {staged} && cp -a {staged} {ETCD_MANIFEST}")
+        for _ in range(60):
+            try:
+                if self.inner.api("get", "--raw=/readyz") == "ok":
+                    break
+            except RuntimeError:
+                pass
+            time.sleep(2)
+        else:
+            raise RuntimeError("API not ready after restore")
+        self._advance_restore("etcd_return_requested", "etcd_returned")
+
+    def _verify_restored_marker(self):
+        marker, _snapshot = self._require_restore_inputs()
+        rec = self._restore_rec()
+        observed = self._marker_cm(marker["namespace"], marker["name"])
+        if observed["data"]["value"] != marker["value"]:
+            raise RuntimeError("Restored marker value does not match snapshot-era marker")
+        rec["observed_marker_uid"] = observed["metadata"]["uid"]
+        rec["marker_uid_may_differ"] = observed["metadata"]["uid"] != marker["uid"]
+        self._advance_restore("etcd_returned", "restore_verified")
+        self.inner.state["etcd"]["restore_executed"] = True
+        self.inner.save()
+
+    def restore_continue(self):
+        self.inner.verify()
+        rec = self._restore_rec()
+        stage = rec.get("stage")
+        if stage is None:
+            self.restore_begin()
+            stage = rec.get("stage")
+        if stage in ("restore_requested", "etcd_stop_requested"):
+            self._stop_etcd_pod()
+        elif stage in ("etcd_stopped", "offline_restore_requested"):
+            self._offline_restore(self.inner.state["snapshot"])
+        elif stage in ("offline_restored", "etcd_return_requested"):
+            self._return_etcd_pod()
+        elif stage == "etcd_returned":
+            self._verify_restored_marker()
+        elif stage != "restore_verified":
+            raise RuntimeError(f"Unknown restore stage {stage!r}")
+        return self.inner.state
+
+    def restore_execute(self):
+        while self._restore_rec().get("stage") != "restore_verified":
+            self.restore_continue()
+        return self.inner.state
+
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "action",
-        choices=("create", "inspect", "etcd-inspect", "snapshot-observe", "delete"),
+        choices=(
+            "create",
+            "inspect",
+            "etcd-inspect",
+            "snapshot-observe",
+            "restore",
+            "restore-continue",
+            "delete",
+        ),
     )
     parser.add_argument("run_dir")
     args = parser.parse_args()
@@ -224,6 +409,10 @@ def main():
             print(json.dumps(fixture.etcd_inspect(), indent=2))
         elif args.action == "snapshot-observe":
             print(json.dumps(fixture.snapshot_observe(), indent=2, default=str))
+        elif args.action == "restore":
+            print(json.dumps(fixture.restore_execute(), indent=2, default=str))
+        elif args.action == "restore-continue":
+            print(json.dumps(fixture.restore_continue(), indent=2, default=str))
         elif args.action == "create":
             fixture.create()
         elif args.action == "inspect":

--- a/scripts/cka_etcd_fixture.py
+++ b/scripts/cka_etcd_fixture.py
@@ -292,7 +292,7 @@ class EtcdFixture:
         self._etcd_restore_params()
         self._node_sh(f"mkdir -p {RESTORE_TXN}")
         if "stopped" not in self._node_sh(
-            f"! test -f {ETCD_MANIFEST} && test -f {staged} && echo stopped"
+            f"if [ ! -f {ETCD_MANIFEST} ] && [ -f {staged} ]; then echo stopped; fi"
         ):
             self._node_sh(
                 f"if [ -f {ETCD_MANIFEST} ] && [ ! -f {staged} ]; then "
@@ -318,17 +318,21 @@ class EtcdFixture:
         moved = rec.setdefault("live_data_moved", f"/var/lib/etcd-pre-{uuid.uuid4().hex[:8]}")
         restore_dir = rec.setdefault("restore_data_dir", f"/var/lib/etcd-restored-{uuid.uuid4().hex[:8]}")
         self.inner.save()
-        if "ready" in self._node_sh(f"test -d {ETCD_DATA} && test -d {moved} && echo ready"):
+        if "ready" in self._node_sh(
+            f"if [ -d {ETCD_DATA} ] && [ -d {moved} ]; then echo ready; fi"
+        ):
             self._advance_restore("offline_restore_requested", "offline_restored")
             return
-        if "aside" not in self._node_sh(f"test -d {moved} && echo aside"):
+        if "aside" not in self._node_sh(f"if [ -d {moved} ]; then echo aside; fi"):
             self._node_sh(
                 f"if [ -d {restore_dir} ]; then rm -rf {restore_dir}; fi; "
                 f"if [ -d {ETCD_DATA} ]; then mv {ETCD_DATA} {moved}; fi"
             )
             rec["offline_substage"] = "live_data_aside"
             self.inner.save()
-        if "restored" not in self._node_sh(f"test -d {restore_dir}/member && echo restored"):
+        if "restored" not in self._node_sh(
+            f"if [ -d {restore_dir}/member ]; then echo restored; fi"
+        ):
             self._node_sh(f"rm -rf {restore_dir}; mkdir -p {restore_dir}")
             node_snap = f"/tmp/etcd-restore-{uuid.uuid4().hex}.db"
             self.inner.run("docker", "cp", snapshot["path"], f"{self._node_id()}:{node_snap}")
@@ -354,7 +358,8 @@ class EtcdFixture:
         elif stage != "etcd_return_requested":
             return
         if "ok" not in self._node_sh(
-            f"test -f {ETCD_MANIFEST} && test -f {staged} && cmp -s {ETCD_MANIFEST} {staged} && echo ok"
+            f"if [ -f {ETCD_MANIFEST} ] && [ -f {staged} ] && cmp -s {ETCD_MANIFEST} {staged}; "
+            f"then echo ok; fi"
         ):
             self._node_sh(f"test -f {staged} && cp -a {staged} {ETCD_MANIFEST}")
         for _ in range(60):

--- a/scripts/cka_etcd_fixture.py
+++ b/scripts/cka_etcd_fixture.py
@@ -236,20 +236,31 @@ class EtcdFixture:
         self.inner.state["etcd"]["restore_executed"] = False
         self.inner.save()
 
+    def _parse_etcd_restore_params(self, manifest_text):
+        keys = (
+            "name",
+            "initial-cluster",
+            "initial-advertise-peer-urls",
+            "initial-cluster-token",
+        )
+        params = {}
+        for line in manifest_text.splitlines():
+            stripped = line.strip().lstrip("- ").strip()
+            for key in keys:
+                prefix = f"--{key}="
+                if stripped.startswith(prefix):
+                    params[key] = stripped[len(prefix) :].strip().strip("\"'")
+        return params
+
     def _etcd_restore_params(self):
         rec = self._restore_rec()
         if rec.get("restore_params"):
             return rec["restore_params"]
         staged = f"{RESTORE_TXN}/etcd.yaml.staged"
-        grep = (
-            "grep -oE '--(name|initial-cluster|initial-advertise-peer-urls|initial-cluster-token)="
-            "[^ \"'\"']+' $M"
+        text = self._node_sh(
+            f'M={shlex.quote(ETCD_MANIFEST)}; [ -f "$M" ] || M={shlex.quote(staged)}; cat "$M"'
         )
-        script = f"M={ETCD_MANIFEST}; [ -f $M ] || M={staged}; {grep}"
-        params = {}
-        for line in self._node_sh(script).splitlines():
-            key, _, value = line[2:].partition("=")
-            params[key] = value
+        params = self._parse_etcd_restore_params(text)
         if not params.get("name"):
             raise RuntimeError("Could not parse etcd restore params from manifest")
         rec["restore_params"] = params
@@ -303,19 +314,31 @@ class EtcdFixture:
         moved = rec.setdefault("live_data_moved", f"/var/lib/etcd-pre-{uuid.uuid4().hex[:8]}")
         restore_dir = rec.setdefault("restore_data_dir", f"/var/lib/etcd-restored-{uuid.uuid4().hex[:8]}")
         self.inner.save()
-        if "ready" not in self._node_sh(
-            f"test -d {ETCD_DATA} && test -d {moved} && echo ready"
-        ):
-            self._node_sh(f"test ! -d {restore_dir}")
+        if "ready" in self._node_sh(f"test -d {ETCD_DATA} && test -d {moved} && echo ready"):
+            self._advance_restore("offline_restore_requested", "offline_restored")
+            return
+        if "aside" not in self._node_sh(f"test -d {moved} && echo aside"):
             self._node_sh(
-                f"if [ -d {ETCD_DATA} ]; then mv {ETCD_DATA} {moved}; fi; mkdir -p {restore_dir}"
+                f"if [ -d {restore_dir} ]; then rm -rf {restore_dir}; fi; "
+                f"if [ -d {ETCD_DATA} ]; then mv {ETCD_DATA} {moved}; fi"
             )
+            rec["offline_substage"] = "live_data_aside"
+            self.inner.save()
+        if "restored" not in self._node_sh(f"test -d {restore_dir}/member && echo restored"):
+            self._node_sh(f"rm -rf {restore_dir}; mkdir -p {restore_dir}")
             node_snap = f"/tmp/etcd-restore-{uuid.uuid4().hex}.db"
             self.inner.run("docker", "cp", snapshot["path"], f"{self._node_id()}:{node_snap}")
             params = self._etcd_restore_params()
             flags = " ".join(f"--{k}={shlex.quote(params[k])}" for k in sorted(params))
-            self._node_sh(f"etcdutl snapshot restore {node_snap} --data-dir={restore_dir} {flags}")
-            self._node_sh(f"rm -rf {ETCD_DATA} && mv {restore_dir} {ETCD_DATA}")
+            self._node_sh(
+                f"etcdutl snapshot restore {shlex.quote(node_snap)} "
+                f"--data-dir={shlex.quote(restore_dir)} {flags}"
+            )
+            rec["offline_substage"] = "restored_dir_ready"
+            self.inner.save()
+        self._node_sh(f"rm -rf {ETCD_DATA} && mv {restore_dir} {ETCD_DATA}")
+        rec["offline_substage"] = "activated"
+        self.inner.save()
         self._advance_restore("offline_restore_requested", "offline_restored")
 
     def _return_etcd_pod(self):
@@ -344,12 +367,15 @@ class EtcdFixture:
     def _verify_restored_marker(self):
         marker, _snapshot = self._require_restore_inputs()
         rec = self._restore_rec()
+        stage = rec.get("stage")
+        if stage not in ("etcd_returned", "restore_verified"):
+            raise RuntimeError(f"Restore stage {stage!r} != expected etcd_returned")
         observed = self._marker_cm(marker["namespace"], marker["name"])
         if observed["data"]["value"] != marker["value"]:
             raise RuntimeError("Restored marker value does not match snapshot-era marker")
         rec["observed_marker_uid"] = observed["metadata"]["uid"]
         rec["marker_uid_may_differ"] = observed["metadata"]["uid"] != marker["uid"]
-        self._advance_restore("etcd_returned", "restore_verified")
+        rec["stage"] = "restore_verified"
         self.inner.state["etcd"]["restore_executed"] = True
         self.inner.save()
 
@@ -368,7 +394,10 @@ class EtcdFixture:
             self._return_etcd_pod()
         elif stage == "etcd_returned":
             self._verify_restored_marker()
-        elif stage != "restore_verified":
+        elif stage == "restore_verified":
+            if not self.inner.state["etcd"].get("restore_executed"):
+                self._verify_restored_marker()
+        else:
             raise RuntimeError(f"Unknown restore stage {stage!r}")
         return self.inner.state
 

--- a/scripts/tests/test_cka_etcd_fixture.py
+++ b/scripts/tests/test_cka_etcd_fixture.py
@@ -228,11 +228,11 @@ class TestEtcdFixture(unittest.TestCase):
                 return ""
             if tool == "docker" and args[0] == "exec" and args[2] == "sh":
                 shell = args[-1]
-                if "test -d /var/lib/etcd && test -d /var/lib/etcd-pre-abc" in shell:
+                if "echo ready" in shell:
                     return ""
-                if "test -d /var/lib/etcd-pre-abc && echo aside" in shell:
+                if "echo aside" in shell:
                     return "aside"
-                if "test -d /var/lib/etcd-restored-abc/member" in shell:
+                if "echo restored" in shell:
                     return ""
                 if "etcdutl snapshot restore" in shell:
                     seen["restore"] += 1
@@ -265,3 +265,33 @@ class TestEtcdFixture(unittest.TestCase):
         wrapper.restore_continue()
         self.assertTrue(fake.state["etcd"]["restore_executed"])
         self.assertEqual(fake.state["etcd"]["restore"]["stage"], "restore_verified")
+
+    def test_stop_probe_does_not_raise_when_manifest_still_present(self):
+        tmp_path = Path(tempfile.mkdtemp())
+        state = self._restore_state(tmp_path, stage="restore_requested")
+        manifest = "    - --name=etcd\n"
+        calls = []
+
+        def run(tool, *args):
+            if tool != "docker" or args[0] != "exec" or args[2] != "sh":
+                raise AssertionError(args)
+            shell = args[-1]
+            calls.append(shell)
+            if "cat " in shell:
+                return manifest
+            if "echo stopped" in shell:
+                return ""
+            if "cp -a" in shell and "rm -f" in shell:
+                raise InterruptedError("Signal 2")
+            if "mkdir -p" in shell:
+                return ""
+            raise AssertionError(shell)
+
+        wrapper, fake = self._wrapper([], directory=tmp_path)
+        fake.state = state
+        fake.run = mock.Mock(side_effect=run)
+        with self.assertRaises(InterruptedError):
+            wrapper.restore_continue()
+        self.assertFalse(fake.state["etcd"]["restore_executed"])
+        self.assertTrue(any("echo stopped" in c for c in calls))
+        self.assertTrue(any("if [ ! -f" in c for c in calls))

--- a/scripts/tests/test_cka_etcd_fixture.py
+++ b/scripts/tests/test_cka_etcd_fixture.py
@@ -116,3 +116,72 @@ class TestEtcdFixture(unittest.TestCase):
         fake.state = {"node": {"id": "abc"}}
         with self.assertRaisesRegex(RuntimeError, "etcdctl/etcdutl missing"):
             wrapper.snapshot_observe()
+
+    def _restore_state(self, tmp_path, stage=None, restore_executed=False):
+        snap_path = tmp_path / self.mod.SNAPSHOT_FILE
+        snap_path.write_bytes(b"snap")
+        state = {
+            "node": {"id": "node-abc"},
+            "etcd": {
+                "restore_executed": restore_executed,
+                "restore": {"direction": "restore", "stage": stage},
+            },
+            "etcd_marker": {
+                "namespace": "ns-marker",
+                "name": self.mod.MARKER_NAME,
+                "uid": "uid-original",
+                "value": "marker-original",
+            },
+            "etcd_baseline": {"revision": 1, "marker_etcd_key": "/registry/x", "authenticated": True},
+            "snapshot": {"path": str(snap_path), "sha256": "deadbeef"},
+            "post_snapshot_mutation": {"value": "mutated", "uid": "uid-original"},
+        }
+        return state
+
+    def test_restore_happy_path_sets_restore_executed(self):
+        tmp_path = Path(tempfile.mkdtemp())
+        state = self._restore_state(tmp_path, stage="etcd_returned")
+        cm = json.dumps({"metadata": {"uid": "uid-new"}, "data": {"value": "marker-original"}})
+
+        def run(tool, *args):
+            if tool == "docker" and args[0] == "exec" and args[2] == "sh":
+                return "ok"
+            raise AssertionError(args)
+
+        wrapper, fake = self._wrapper([], directory=tmp_path)
+        fake.state = state
+        fake.run = mock.Mock(side_effect=run)
+        wrapper._marker_cm = mock.Mock(return_value=json.loads(cm))
+        wrapper.restore_continue()
+        self.assertTrue(fake.state["etcd"]["restore_executed"])
+        self.assertEqual(fake.state["etcd"]["restore"]["stage"], "restore_verified")
+        self.assertTrue(fake.state["etcd"]["restore"]["marker_uid_may_differ"])
+
+    def test_restore_refuses_without_snapshot(self):
+        wrapper, fake = self._wrapper([])
+        fake.state = {
+            "node": {"id": "abc"},
+            "etcd": {"restore_executed": False},
+            "etcd_marker": {"namespace": "n", "name": "m", "uid": "u", "value": "v"},
+            "etcd_baseline": {"revision": 1},
+        }
+        with self.assertRaisesRegex(RuntimeError, "snapshot, etcd_marker, and etcd_baseline"):
+            wrapper.restore_begin()
+
+    def test_restore_interrupt_leaves_restore_executed_false(self):
+        tmp_path = Path(tempfile.mkdtemp())
+        state = self._restore_state(tmp_path, stage="restore_requested")
+
+        def run(tool, *args):
+            if tool == "docker" and args[0] == "exec" and "grep -oE" in args[-1]:
+                return "--name=etcd\n--initial-cluster=etcd=https://127.0.0.1:2380"
+            if tool == "docker" and args[0] == "exec" and args[2] == "sh":
+                raise InterruptedError("Signal 2")
+            raise AssertionError(args)
+
+        wrapper, fake = self._wrapper([], directory=tmp_path)
+        fake.state = state
+        fake.run = mock.Mock(side_effect=run)
+        with self.assertRaises(InterruptedError):
+            wrapper.restore_continue()
+        self.assertFalse(fake.state["etcd"]["restore_executed"])

--- a/scripts/tests/test_cka_etcd_fixture.py
+++ b/scripts/tests/test_cka_etcd_fixture.py
@@ -171,11 +171,18 @@ class TestEtcdFixture(unittest.TestCase):
     def test_restore_interrupt_leaves_restore_executed_false(self):
         tmp_path = Path(tempfile.mkdtemp())
         state = self._restore_state(tmp_path, stage="restore_requested")
+        manifest = (
+            "    - --name=etcd\n"
+            "    - --initial-cluster=etcd=https://127.0.0.1:2380\n"
+            "    - --initial-advertise-peer-urls=https://127.0.0.1:2380\n"
+            "    - --initial-cluster-token=tok\n"
+        )
 
         def run(tool, *args):
-            if tool == "docker" and args[0] == "exec" and "grep -oE" in args[-1]:
-                return "--name=etcd\n--initial-cluster=etcd=https://127.0.0.1:2380"
             if tool == "docker" and args[0] == "exec" and args[2] == "sh":
+                shell = args[-1]
+                if "cat " in shell:
+                    return manifest
                 raise InterruptedError("Signal 2")
             raise AssertionError(args)
 
@@ -185,3 +192,76 @@ class TestEtcdFixture(unittest.TestCase):
         with self.assertRaises(InterruptedError):
             wrapper.restore_continue()
         self.assertFalse(fake.state["etcd"]["restore_executed"])
+
+    def test_parse_etcd_restore_params_from_manifest(self):
+        wrapper, _fake = self._wrapper([])
+        params = wrapper._parse_etcd_restore_params(
+            "    - --name=etcd\n"
+            "    - --initial-cluster=etcd=https://127.0.0.1:2380\n"
+            "    - --initial-advertise-peer-urls=https://127.0.0.1:2380\n"
+            "    - --initial-cluster-token=tok\n"
+        )
+        self.assertEqual(params["name"], "etcd")
+        self.assertIn("2380", params["initial-cluster"])
+
+    def test_offline_restore_resumes_when_restore_dir_exists(self):
+        tmp_path = Path(tempfile.mkdtemp())
+        state = self._restore_state(tmp_path, stage="offline_restore_requested")
+        state["etcd"]["restore"].update(
+            {
+                "live_data_moved": "/var/lib/etcd-pre-abc",
+                "restore_data_dir": "/var/lib/etcd-restored-abc",
+                "restore_params": {
+                    "name": "etcd",
+                    "initial-cluster": "etcd=https://127.0.0.1:2380",
+                    "initial-advertise-peer-urls": "https://127.0.0.1:2380",
+                    "initial-cluster-token": "tok",
+                },
+                "offline_substage": "live_data_aside",
+            }
+        )
+        seen = {"cp": 0, "restore": 0, "activate": 0}
+
+        def run(tool, *args):
+            if tool == "docker" and args[0] == "cp":
+                seen["cp"] += 1
+                return ""
+            if tool == "docker" and args[0] == "exec" and args[2] == "sh":
+                shell = args[-1]
+                if "test -d /var/lib/etcd && test -d /var/lib/etcd-pre-abc" in shell:
+                    return ""
+                if "test -d /var/lib/etcd-pre-abc && echo aside" in shell:
+                    return "aside"
+                if "test -d /var/lib/etcd-restored-abc/member" in shell:
+                    return ""
+                if "etcdutl snapshot restore" in shell:
+                    seen["restore"] += 1
+                    return ""
+                if "mv /var/lib/etcd-restored-abc /var/lib/etcd" in shell:
+                    seen["activate"] += 1
+                    return ""
+                if "rm -rf /var/lib/etcd-restored-abc" in shell or "mkdir -p" in shell:
+                    return ""
+                raise AssertionError(shell)
+            raise AssertionError(args)
+
+        wrapper, fake = self._wrapper([], directory=tmp_path)
+        fake.state = state
+        fake.run = mock.Mock(side_effect=run)
+        wrapper.restore_continue()
+        self.assertEqual(fake.state["etcd"]["restore"]["stage"], "offline_restored")
+        self.assertEqual(seen["cp"], 1)
+        self.assertEqual(seen["restore"], 1)
+        self.assertEqual(seen["activate"], 1)
+        self.assertFalse(fake.state["etcd"]["restore_executed"])
+
+    def test_restore_verified_repairs_missing_executed_flag(self):
+        tmp_path = Path(tempfile.mkdtemp())
+        state = self._restore_state(tmp_path, stage="restore_verified", restore_executed=False)
+        cm = {"metadata": {"uid": "uid-new"}, "data": {"value": "marker-original"}}
+        wrapper, fake = self._wrapper([], directory=tmp_path)
+        fake.state = state
+        wrapper._marker_cm = mock.Mock(return_value=cm)
+        wrapper.restore_continue()
+        self.assertTrue(fake.state["etcd"]["restore_executed"])
+        self.assertEqual(fake.state["etcd"]["restore"]["stage"], "restore_verified")


### PR DESCRIPTION
## Summary

- Implements packet **E3** for #2479: offline `etcdutl snapshot restore` into clean node dirs (live `/var/lib/etcd` moved aside first), static-etcd stop/return, and marker+API verification before `restore_executed=true`.
- Adds labelled restore stages with `restore-continue` resume (mirrors certificate rollback discipline); refuses restore without `snapshot` + `etcd_marker` + `etcd_baseline`.
- Mock unit tests: happy path sets `restore_executed`, refuse without snapshot, interrupt leaves `restore_executed` false.

## Scope / budget

- **260 LOC** (+2 files only) — slightly over the ≤200 preference but minimal safe complete E3; no lesson edits (E4 deferred).
- HEAD: `771430c93` on `feat/2479-e3-restore` from `179839ae0`.

## Test plan

- [x] `.venv/bin/ruff check scripts/cka_etcd_fixture.py scripts/tests/test_cka_etcd_fixture.py`
- [x] `.venv/bin/python -m unittest scripts.tests.test_cka_etcd_fixture -v` (10/10)
- [ ] Live kind fixture restore (follow-up evidence on owned cluster)
- [ ] Cross-family review before merge


Made with [Cursor](https://cursor.com)