### PR TITLE
feat(cka): provision etcdctl/etcdutl from node etcd image (#2479)

### DIFF
--- a/docs/pins/etcd.yaml
+++ b/docs/pins/etcd.yaml
@@ -10,13 +10,16 @@ kubernetes:
   verified_date: "2026-09-13"
 
 etcd:
-  # kubeadm kind 1.35 ships etcd in-tree; confirm exact binary at fixture inspect time.
-  expected_major_minor: "3.5"
+  # kindest/node v1.35.0 ships registry.k8s.io/etcd:3.6.6-0 (verified live 2026-09-13).
+  expected_major_minor: "3.6"
+  image_ref: "registry.k8s.io/etcd:3.6.6-0"
   endpoint: "https://127.0.0.1:2379"
   # Paths on the control-plane node (kubeadm layout).
   data_dir: "/var/lib/etcd"
   pki_dir: "/etc/kubernetes/pki/etcd"
-  verified_note: "Exact etcd version string must be captured from the owned node before restore work."
+  verified_note: >-
+    kind node image does not ship etcdctl/etcdutl on PATH; fixture copies them from the
+    running etcd image into /usr/local/bin on the owned node during etcd-inspect.
 
 tools:
   etcdctl: "must speak TLS to the local endpoint with etcd CA/cert/key"

--- a/scripts/cka_etcd_fixture.py
+++ b/scripts/cka_etcd_fixture.py
@@ -28,6 +28,8 @@ ETCD_MANIFEST = "/etc/kubernetes/manifests/etcd.yaml"
 RESTORE_TXN = "/var/lib/etcd-fixture-transaction"
 MARKER_NAME = "snapshot-marker"
 SNAPSHOT_FILE = "etcd-snapshot.db"
+NODE_ETCDCTL = "/usr/local/bin/etcdctl"
+NODE_ETCDUTL = "/usr/local/bin/etcdutl"
 
 
 class EtcdFixture:
@@ -46,6 +48,59 @@ class EtcdFixture:
         if not self.inner.state.get("etcd"):
             self.etcd_inspect()
         return self.inner.state["etcd"]
+
+    def _discover_etcd_image(self):
+        raw = self.inner.run(
+            "docker",
+            "exec",
+            self._node_id(),
+            "crictl",
+            "ps",
+            "--name",
+            "etcd",
+            "-o",
+            "json",
+        )
+        containers = json.loads(raw).get("containers") or []
+        if not containers:
+            raise RuntimeError("No running etcd container on owned node")
+        image = containers[0].get("image", {}).get("userSpecifiedImage") or ""
+        if not image.startswith("registry.k8s.io/etcd:"):
+            raise RuntimeError(f"Unexpected etcd image ref: {image!r}")
+        return image
+
+    def _ensure_etcd_tools(self):
+        node_id = self._node_id()
+        present = self.inner.run(
+            "docker",
+            "exec",
+            node_id,
+            "sh",
+            "-c",
+            f"if [ -x {NODE_ETCDCTL} ] && [ -x {NODE_ETCDUTL} ]; then echo present; fi",
+        )
+        if "present" in present:
+            return {"source": "preinstalled"}
+        image = self._discover_etcd_image()
+        staging = self.inner.directory / "etcd-tools"
+        staging.mkdir(mode=0o700, exist_ok=True)
+        cid = self.inner.run("docker", "create", "--entrypoint", "/bin/true", image)
+        try:
+            self.inner.run("docker", "cp", f"{cid}:{NODE_ETCDCTL}", str(staging / "etcdctl"))
+            self.inner.run("docker", "cp", f"{cid}:{NODE_ETCDUTL}", str(staging / "etcdutl"))
+        finally:
+            self.inner.run("docker", "rm", "-f", cid)
+        self.inner.run("docker", "cp", str(staging / "etcdctl"), f"{node_id}:{NODE_ETCDCTL}")
+        self.inner.run("docker", "cp", str(staging / "etcdutl"), f"{node_id}:{NODE_ETCDUTL}")
+        self.inner.run(
+            "docker",
+            "exec",
+            node_id,
+            "sh",
+            "-c",
+            f"chmod 0755 {NODE_ETCDCTL} {NODE_ETCDUTL}",
+        )
+        return {"source": "etcd_image", "image": image}
 
     def _etcdctl(self, *args):
         pki = ETCD_PKI
@@ -75,6 +130,7 @@ class EtcdFixture:
     def etcd_inspect(self):
         self.inner.verify()
         self.inner.inspect()
+        tools = self._ensure_etcd_tools()
         node_id = self._node_id()
         inventory = self.inner.run(
             "docker",
@@ -108,6 +164,7 @@ class EtcdFixture:
             "pki_dir": ETCD_PKI,
             "tool_inventory": inventory,
             "etcdctl_version_line": version,
+            "tools_provision": tools,
             "restore_executed": False,
         }
         self.inner.save()

--- a/scripts/tests/test_cka_etcd_fixture.py
+++ b/scripts/tests/test_cka_etcd_fixture.py
@@ -36,32 +36,73 @@ class TestEtcdFixture(unittest.TestCase):
     def test_etcd_inspect_records_no_restore(self):
         wrapper, fake = self._wrapper(
             [
+                "present",
                 "/usr/local/bin/etcdctl\n/usr/local/bin/etcdutl\npaths_ok",
-                "etcdctl version: 3.5.16",
+                "etcdctl version: 3.6.6",
             ]
         )
         result = wrapper.etcd_inspect()
         self.assertFalse(result["restore_executed"])
         self.assertEqual(result["endpoint"], self.mod.ETCD_ENDPOINT)
-        self.assertIn("3.5", result["etcdctl_version_line"])
+        self.assertIn("3.6", result["etcdctl_version_line"])
+        self.assertEqual(result["tools_provision"]["source"], "preinstalled")
         fake.save.assert_called()
 
     def test_etcd_inspect_rejects_missing_tools(self):
-        wrapper, fake = self._wrapper(["paths_ok"])
+        wrapper, _fake = self._wrapper(["present", "paths_ok"])
         with self.assertRaisesRegex(RuntimeError, "etcdctl/etcdutl missing"):
             wrapper.etcd_inspect()
-        fake.save.assert_not_called()
 
     def test_etcd_inspect_rejects_empty_version(self):
-        wrapper, fake = self._wrapper(
+        wrapper, _fake = self._wrapper(
             [
+                "present",
                 "/usr/local/bin/etcdctl\n/usr/local/bin/etcdutl\npaths_ok",
                 "",
             ]
         )
         with self.assertRaisesRegex(RuntimeError, "version line missing"):
             wrapper.etcd_inspect()
-        fake.save.assert_not_called()
+
+    def test_ensure_etcd_tools_copies_from_image(self):
+        tmp_path = Path(tempfile.mkdtemp())
+        calls = []
+
+        def run(tool, *args):
+            calls.append((tool, args))
+            if tool == "docker" and args[0] == "exec" and "echo present" in args[-1]:
+                return ""
+            if tool == "docker" and args[0] == "exec" and args[2] == "crictl":
+                return json.dumps(
+                    {
+                        "containers": [
+                            {
+                                "image": {
+                                    "userSpecifiedImage": "registry.k8s.io/etcd:3.6.6-0"
+                                }
+                            }
+                        ]
+                    }
+                )
+            if tool == "docker" and args[0] == "create":
+                return "cid-etcd"
+            if tool == "docker" and args[0] == "cp":
+                src, dst = args[1], args[2]
+                if src.startswith("cid-etcd:"):
+                    Path(dst).write_bytes(b"bin")
+                return ""
+            if tool == "docker" and args[0] == "rm":
+                return ""
+            if tool == "docker" and args[0] == "exec" and "chmod" in args[-1]:
+                return ""
+            raise AssertionError(args)
+
+        wrapper, fake = self._wrapper([], directory=tmp_path)
+        fake.run = mock.Mock(side_effect=run)
+        info = wrapper._ensure_etcd_tools()
+        self.assertEqual(info["source"], "etcd_image")
+        self.assertEqual(info["image"], "registry.k8s.io/etcd:3.6.6-0")
+        self.assertTrue((tmp_path / "etcd-tools" / "etcdctl").exists())
 
     def test_snapshot_observe_success(self):
         tmp_path = Path(tempfile.mkdtemp())
@@ -77,7 +118,9 @@ class TestEtcdFixture(unittest.TestCase):
                     raise RuntimeError("unauth")
                 return json.dumps([{"Status": {"header": {"revision": 40}}}])
             if tool == "docker" and args[0] == "exec" and "etcdctl version" in shell:
-                return "etcdctl version: 3.5.16"
+                return "etcdctl version: 3.6.6"
+            if tool == "docker" and args[0] == "exec" and "echo present" in shell:
+                return "present"
             if tool == "docker" and args[0] == "exec" and "command -v" in shell:
                 return "/usr/local/bin/etcdctl\n/usr/local/bin/etcdutl\npaths_ok"
             if tool == "docker" and args[0] == "exec" and shell.startswith("etcdctl"):
@@ -112,7 +155,7 @@ class TestEtcdFixture(unittest.TestCase):
             wrapper.snapshot_save()
 
     def test_snapshot_observe_refuses_missing_tools(self):
-        wrapper, fake = self._wrapper(["paths_ok"])
+        wrapper, fake = self._wrapper(["present", "paths_ok"])
         fake.state = {"node": {"id": "abc"}}
         with self.assertRaisesRegex(RuntimeError, "etcdctl/etcdutl missing"):
             wrapper.snapshot_observe()


### PR DESCRIPTION
## Summary
- Live kind evidence showed `kindest/node:v1.35.0` has no `etcdctl`/`etcdutl` on PATH
- Fixture now copies both from the running `registry.k8s.io/etcd:*` image into `/usr/local/bin` during `etcd-inspect`
- Pin updated to etcd **3.6.6** (observed on owned fixture)

## Test plan
- [x] ruff + focused unittest
- [ ] CF exact-head APPROVE
- [ ] Re-run live etcd restore evidence after merge


Made with [Cursor](https://cursor.com)