### PR TITLE
fix(cka): use etcdctl --keys-only for marker baseline (#2479)

### DIFF
--- a/scripts/cka_etcd_fixture.py
+++ b/scripts/cka_etcd_fixture.py
@@ -197,7 +197,8 @@ class EtcdFixture:
         status = json.loads(self._etcdctl("endpoint", "status", "-w", "json"))[0]["Status"]
         revision = status["header"]["revision"]
         etcd_key = f"/registry/configmaps/{marker['namespace']}/{marker['name']}"
-        if not self._etcdctl("get", etcd_key):
+        # Prefer keys-only: raw ConfigMap values are protobuf and break text=True capture.
+        if not self._etcdctl("get", etcd_key, "--keys-only"):
             raise RuntimeError("Marker key missing in etcd")
         baseline = {"revision": revision, "marker_etcd_key": etcd_key, "authenticated": True}
         self.inner.state["etcd_baseline"] = baseline


### PR DESCRIPTION
## Summary
Live evidence failed: `etcdctl get` of a ConfigMap key returns protobuf bytes; `Fixture.run(..., text=True)` then raises UTF-8 decode errors. Use `--keys-only` for the existence check.

## Test plan
- [x] focused unittest
- [ ] CF APPROVE + merge
- [ ] re-run live `.agent/check-cka-etcd-restore.py`


Made with [Cursor](https://cursor.com)