### PR TITLE
docs(k8s): standing exam-pin vs latest-stable playbook (#2542)

### DIFF
--- a/.claude/rules/kubernetes-release-tracks.md
+++ b/.claude/rules/kubernetes-release-tracks.md
@@ -1,0 +1,39 @@
+---
+description: Dual-track Kubernetes versions — exam pin vs latest-stable Release Radar
+paths:
+  - "src/content/docs/k8s/**"
+  - "docs/pins/**"
+  - "docs/release-maintenance/**"
+  - "AGENTS.md"
+  - "scripts/prompts/module-writer.md"
+  - ".claude/rules/module-quality.md"
+---
+
+# Kubernetes release tracks
+
+KubeDojo runs **two** Kubernetes version tracks. Mixing them is a defect.
+
+| Track | SSOT | Content |
+|-------|------|---------|
+| **Exam pin** | `docs/pins/kubernetes.yaml` → `exam_pin` | CKA / CKAD / CKS / KCNA / KCSA |
+| **Latest-stable** | same file → `latest_stable_track` | `src/content/docs/k8s/releases/` only |
+
+Standing workflow: `docs/release-maintenance/kubernetes-minor-release-playbook.md`.  
+Learner policy: `/k8s/releases/exam-version-policy/`. Workstream: **#2542** (`Refs` only, never Resolves).
+
+## Must
+
+- Read the playbook before authoring a new minor or changing `exam_pin`.
+- Bump `exam_pin` only after the LF FAQ **and** CKA/CKAD/CKS product pages agree on a new exam environment version (cite URL + date).
+- Put new upstream minors on Release Radar. Update `latest_stable_track` and kind images there.
+- Prefer official release blogs + CHANGELOG over third-party roundups.
+
+## Must not
+
+- Rewrite cert modules because kubernetes.io shipped a minor.
+- Treat LF’s “4–8 weeks after GA” alignment note as proof the exam moved.
+- Treat `busybox:1.36` (image tag) as cluster version 1.36.
+- Teach every alpha as production guidance.
+- Close #2542 from a single currency packet.
+
+Parked on #2542 (do not sneak into a pin/playbook PR): teaching arcs on minor pages, executed kind diff labs, Killercoda polish.

--- a/.claude/rules/kubernetes-release-tracks.md
+++ b/.claude/rules/kubernetes-release-tracks.md
@@ -18,8 +18,9 @@ KubeDojo runs **two** Kubernetes version tracks. Mixing them is a defect.
 | **Exam pin** | `docs/pins/kubernetes.yaml` → `exam_pin` | CKA / CKAD / CKS / KCNA / KCSA |
 | **Latest-stable** | same file → `latest_stable_track` | `src/content/docs/k8s/releases/` only |
 
-Standing workflow: `docs/release-maintenance/kubernetes-minor-release-playbook.md`.  
-Learner policy: `/k8s/releases/exam-version-policy/`. Workstream: **#2542** (`Refs` only, never Resolves).
+- Standing workflow: `docs/release-maintenance/kubernetes-minor-release-playbook.md`
+- Learner policy: `/k8s/releases/exam-version-policy/`
+- Workstream: **#2542** (`Refs` only, never Resolves)
 
 ## Must
 

--- a/.claude/rules/module-quality.md
+++ b/.claude/rules/module-quality.md
@@ -55,7 +55,7 @@ paths:
 - Code blocks specify language (```bash, ```yaml, ```go)
 - YAML: 2-space indentation
 - kubectl alias: use `k` after explaining it once
-- K8s version: 1.35+ for exam-pinned cert content; Release Radar covers supported upstream minors (see `docs/pins/kubernetes.yaml`)
+- K8s version: 1.35+ for exam-pinned cert content; Release Radar covers supported upstream minors (see `docs/pins/kubernetes.yaml` and `docs/release-maintenance/kubernetes-minor-release-playbook.md`)
 - Do NOT repeat the number 47 (known LLM pattern)
 - Do NOT use emojis
 - Do NOT write "list of facts" modules — if sections are just bullets, it's a reference doc, not a lesson

--- a/.claude/rules/new-content-checklist.md
+++ b/.claude/rules/new-content-checklist.md
@@ -13,3 +13,4 @@ EVERY TIME new modules are added, do ALL of these BEFORE committing:
 5. **Build** — `npm run build` — verify no errors
 6. **Health check** — `python scripts/check_site_health.py` — 0 errors
 7. **changelog.md** — add entry for significant additions
+8. **K8s dual-track** — cert modules stay on `docs/pins/kubernetes.yaml` → `exam_pin`. New upstream minors go under `src/content/docs/k8s/releases/` per `docs/release-maintenance/kubernetes-minor-release-playbook.md`. Do not rewrite CKA/CKAD/CKS because kubernetes.io GA'd a minor.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,9 +166,12 @@ and final `git status --short --branch` for worktree and primary checkout.
 
 Published content lives in `src/content/docs/`; Ukrainian content mirrors it in
 `src/content/docs/uk/`. Navigation uses Starlight configuration and frontmatter,
-including `title:` and `sidebar.order:`. Kubernetes **exam-pinned** content targets 1.35 unless
-the task establishes a newer target. Pipeline v2 is the default; v1 remains for
-compatibility.
+including `title:` and `sidebar.order:`. Kubernetes **exam-pinned** content targets the
+minor in `docs/pins/kubernetes.yaml` → `exam_pin` (currently 1.35) unless a web-verified
+LF/CNCF exam-environment change establishes a newer target. Latest-stable Release Radar
+(`src/content/docs/k8s/releases/`) is a **separate** track — every new upstream minor
+starts at `docs/release-maintenance/kubernetes-minor-release-playbook.md`. Pipeline v2
+is the default; v1 remains for compatibility.
 
 Teach the reasons behind concepts and use worked examples. For mathematics,
 explain the purpose and use concrete demonstrations before formalism. Preserve

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,8 @@ npx astro preview          # preview built site
 | `docs/pedagogical-framework.md` | Educational research & guidelines |
 | `docs/quality-rubric.md` | 1-5 rubric for module/lab quality |
 | `scripts/prompts/module-writer.md` | Standard prompt for module creation |
+| `docs/pins/kubernetes.yaml` | Exam pin vs latest-stable minors + kind node images |
+| `docs/release-maintenance/kubernetes-minor-release-playbook.md` | Standing trigger for each new Kubernetes minor |
 | `scripts/dispatch.py` / `scripts/dispatch_smart.py` | CLI dispatchers |
 | `astro.config.mjs` | Starlight config (sidebar, i18n, theme) |
 

--- a/docs/pins/kubernetes.yaml
+++ b/docs/pins/kubernetes.yaml
@@ -5,8 +5,8 @@
 exam_pin:
   kubernetes_minor: "1.35"
   applies_to: ["cka", "ckad", "cks", "kcna", "kcsa"]
-  verified_date: "2026-09-12"
-  verified_note: "Curriculum remains exam-pinned at 1.35 until LF/CNCF exam docs show otherwise."
+  verified_date: "2026-09-13"
+  verified_note: "LF FAQ + CKA/CKAD/CKS product pages still state Kubernetes v1.35 (re-checked 2026-09-13). Do not bump until those pages move."
 
 latest_stable_track:
   policy: "tracks upstream supported minor branches (typically three)"

--- a/docs/pins/kubernetes.yaml
+++ b/docs/pins/kubernetes.yaml
@@ -6,7 +6,7 @@ exam_pin:
   kubernetes_minor: "1.35"
   applies_to: ["cka", "ckad", "cks", "kcna", "kcsa"]
   verified_date: "2026-09-13"
-  verified_note: "LF FAQ + CKA/CKAD/CKS product pages still state Kubernetes v1.35 (re-checked 2026-09-13). Do not bump until those pages move."
+  verified_note: "\"The CKA exam environment is currently running Kubernetes v1.35\" (LF FAQ, 2026-09-13). CKA/CKAD/CKS product pages agree. Do not bump until that sentence changes."
 
 latest_stable_track:
   policy: "tracks upstream supported minor branches (typically three)"

--- a/docs/release-maintenance/kubernetes-minor-release-playbook.md
+++ b/docs/release-maintenance/kubernetes-minor-release-playbook.md
@@ -44,7 +44,7 @@ All of the following must **agree on the same minor**, cited in the PR with a ve
 3. [CKAD product page](https://training.linuxfoundation.org/certification/certified-kubernetes-application-developer-ckad/)
 4. [CKS product page](https://training.linuxfoundation.org/certification/certified-kubernetes-security-specialist/)
 
-Write the verbatim product-page sentence into `exam_pin.verified_note`. If FAQ and product pages disagree, **do not bump** — report the contradiction on #2542.
+Write a **verbatim** LF FAQ or CKA product-page sentence into `exam_pin.verified_note` (plus source and date). Required for any `exam_pin` field edit, including re-verify-without-bump — a paraphrase alone is not enough. If FAQ and product pages disagree, **do not bump** — report the contradiction on #2542.
 
 Re-verified **2026-09-13**: CKA, CKAD, and CKS still state **Kubernetes v1.35**.
 
@@ -66,14 +66,25 @@ Re-verified **2026-09-13**: CKA, CKAD, and CKS still state **Kubernetes v1.35**.
 - `docs/pins/kubernetes.yaml` — `latest_stable_track` and `kind_node_images` only
 - `src/content/docs/changelog.md` — one What’s New bullet
 - `src/content/docs/k8s/index.md` — hub version list only if the supported set changed
-- this playbook / the bundle template, if the process itself changed
+
+**Process / playbook packet** (standing trigger and discovery hooks; may ship alone or with Track B) — allow:
+
+- `docs/release-maintenance/kubernetes-minor-release-playbook.md`
+- `docs/release-maintenance/kubernetes-release-bundle-template.md`
+- `.claude/rules/kubernetes-release-tracks.md`
+- `.claude/rules/new-content-checklist.md` — dual-track item only
+- `AGENTS.md` / `CLAUDE.md` — dual-track pointers only (not the exam-pin minor number)
+- `scripts/prompts/cold-start.md`
+- `scripts/agent_onboarding.md`
+- `scripts/prompts/module-writer.md` / `.claude/rules/module-quality.md` — playbook pointer only (not the exam-pin minor number)
+- `docs/pins/kubernetes.yaml` — `exam_pin.verified_date` / `verified_note` on re-verify-without-bump (`kubernetes_minor` unchanged)
 
 **Deny unless this is the rare Track A exam-pin bump PR:**
 
 - `src/content/docs/k8s/cka/**`, `ckad/**`, `cks/**`, `kcna/**`, `kcsa/**`
 - `src/content/docs/uk/**`
 - exam fixtures (`scripts/cka_certificate_fixture.py` and siblings)
-- version lines in `AGENTS.md`, `.claude/rules/module-quality.md`, `scripts/prompts/module-writer.md`
+- exam-pin **version-number** lines in `AGENTS.md`, `.claude/rules/module-quality.md`, `scripts/prompts/module-writer.md`
 
 **Never:**
 
@@ -126,7 +137,7 @@ When a minor leaves upstream support, add an “Archive” note on the Release R
 
 Only when the LF sources in **Verify exam pin** all show a new environment version:
 
-1. Update `exam_pin` in `docs/pins/kubernetes.yaml` (`kubernetes_minor`, `verified_date`, `verified_note` with the quoted sentence).
+1. Update `exam_pin` in `docs/pins/kubernetes.yaml` (`kubernetes_minor`, `verified_date`, `verified_note` with a verbatim LF FAQ or CKA sentence plus source and date).
 2. Update `AGENTS.md`, `.claude/rules/module-quality.md`, `scripts/prompts/module-writer.md` to the new pin.
 3. Grep `1.3N` / `v1-3N.docs` / `kindest/node:v1.3N` / fixture scripts — **surgical** patches only, driven by Release Radar migration notes.
 4. Separate PR from Track B authorship. Still `Refs #2542` (and #2280 if a cert-track upgrade issue is open). Never close #2542 from the bump PR alone.

--- a/docs/release-maintenance/kubernetes-minor-release-playbook.md
+++ b/docs/release-maintenance/kubernetes-minor-release-playbook.md
@@ -1,54 +1,138 @@
 # Kubernetes minor-release playbook (agents)
 
-Standing workflow for X06 (#2542). Humans may run the same steps.
+Standing trigger for X06 (#2542). Humans may run the same steps.
 
-## Rules
+**Read this before** writing cert modules, bumping a Kubernetes version, or authoring a Release Radar page. Dual-track mix-ups are how learners fail exams and how agents rewrite the wrong files.
 
-1. **Do not rewrite CKA/CKAD/CKS modules** when upstream ships a minor.
-2. **Exam pin** (`docs/pins/kubernetes.yaml` → `exam_pin`) moves only after web-verified LF/CNCF exam / curriculum PDF change.
-3. **Latest-stable track** always mirrors upstream’s supported minors (~3).
-4. Prefer **official** release blogs + CHANGELOG + docs version paths as sources. Third-party roundups are secondary.
-5. Ignore most **alpha** unless paradigm-shifting; teach beta (esp. on-by-default) and GA deeply.
-6. Never confuse **busybox:1.36** (image tag) with cluster version **1.36**.
+- Learner policy: [`/k8s/releases/exam-version-policy/`](../../src/content/docs/k8s/releases/exam-version-policy.md)
+- Machine pins: [`docs/pins/kubernetes.yaml`](../pins/kubernetes.yaml)
+- Page template: [`kubernetes-release-bundle-template.md`](./kubernetes-release-bundle-template.md)
+- Agent rule: [`.claude/rules/kubernetes-release-tracks.md`](../../.claude/rules/kubernetes-release-tracks.md)
+
+## Dual-track (do not mix)
+
+| Track | Source of truth | Update when | Typical paths |
+|-------|-----------------|-------------|----------------|
+| **A — Exam pin** | `exam_pin` in `docs/pins/kubernetes.yaml` | LF/CNCF exam environment version changes (web-verified the same day) | Cert modules stay pinned; bump PR is separate |
+| **B — Latest-stable** | `latest_stable_track` in the same YAML | Upstream’s supported-minor window changes (~3 minors) | `src/content/docs/k8s/releases/` only |
+
+Upstream GA of 1.36 or 1.37 does **not** authorize a CKA/CKAD/CKS rewrite. LF’s “aligns within approximately 4 to 8 weeks of the K8s release date” is a **forecast**, not evidence the exam moved.
+
+## When to run (triggers)
+
+Run this playbook when **any** of these are true:
+
+1. [kubernetes.io/releases/](https://kubernetes.io/releases/) shows a GA minor missing under `src/content/docs/k8s/releases/`.
+2. A minor left the upstream three-branch window and is still listed as “supported now”.
+3. A task says “update certs to latest Kubernetes”, “bump CKA to 1.3X”, or similar.
+4. A #2542 currency packet asks to re-verify the exam pin.
+
+**Do not** treat these as this playbook’s job (parked or other issues):
+
+- Teaching arcs / worked Stable features on existing minor pages (parked 2026-09-12 on #2542).
+- Executed kind diff labs beyond the [kind practice matrix](../../src/content/docs/k8s/releases/practice-kind-matrix.md) (same).
+- Killercoda polish; Ukrainian (#2291); generic freshness (#2294).
+
+PRs that advance #2542 must say **`Refs #2542`** only. Never `Resolves` / `Closes` — the workstream stays open.
+
+## Verify exam pin (required before any `exam_pin` edit)
+
+All of the following must **agree on the same minor**, cited in the PR with a verification date:
+
+1. [LF FAQ — exam environment version](https://docs.linuxfoundation.org/tc-docs/certification/faq-cka-ckad-cks) (“What application version is running in the Exam Environment?”)
+2. [CKA product page](https://training.linuxfoundation.org/certification/certified-kubernetes-administrator-cka/) (“The exam is based on Kubernetes v…”)
+3. [CKAD product page](https://training.linuxfoundation.org/certification/certified-kubernetes-application-developer-ckad/)
+4. [CKS product page](https://training.linuxfoundation.org/certification/certified-kubernetes-security-specialist/)
+
+Write the verbatim product-page sentence into `exam_pin.verified_note`. If FAQ and product pages disagree, **do not bump** — report the contradiction on #2542.
+
+Re-verified **2026-09-13**: CKA, CKAD, and CKS still state **Kubernetes v1.35**.
+
+## Decision tree
+
+| You observed | Do this | Do **not** |
+|--------------|---------|------------|
+| New upstream GA, no Radar page | Author a Track B bundle from the template; update `latest_stable_track` + kind image | Touch cert lesson bodies; bump `exam_pin` |
+| Minor left upstream support | Archive note on the Release Radar index; drop it from `supported_minors`; keep the page | Delete history or rewrite certs |
+| LF FAQ **and** product pages show a new exam minor | Track A bump PR (see below) | Combine with a new-Radar-page PR |
+| Cert module says “GA in 1.36 / future” for something already Stable | Surgical one-line fix + link to the Radar page | Full cert rewrite |
+| “Update CKA to latest” with no LF page change | Refuse. Point at the policy page and this playbook | Rewrite modules “to be current” |
+
+## File allow / deny
+
+**Track B (new or retired minor)** — allow:
+
+- `src/content/docs/k8s/releases/**`
+- `docs/pins/kubernetes.yaml` — `latest_stable_track` and `kind_node_images` only
+- `src/content/docs/changelog.md` — one What’s New bullet
+- `src/content/docs/k8s/index.md` — hub version list only if the supported set changed
+- this playbook / the bundle template, if the process itself changed
+
+**Deny unless this is the rare Track A exam-pin bump PR:**
+
+- `src/content/docs/k8s/cka/**`, `ckad/**`, `cks/**`, `kcna/**`, `kcsa/**`
+- `src/content/docs/uk/**`
+- exam fixtures (`scripts/cka_certificate_fixture.py` and siblings)
+- version lines in `AGENTS.md`, `.claude/rules/module-quality.md`, `scripts/prompts/module-writer.md`
+
+**Never:**
+
+- Confuse `busybox:1.36` (image tag) with cluster **1.36**
+- Document every alpha as production guidance
+- Silently edit `exam_pin` because kubernetes.io shipped a minor
 
 ## Detect
 
-1. Open https://kubernetes.io/releases/ — note the three supported minors.
-2. If a new GA minor appears that is missing under `src/content/docs/k8s/releases/`, open/update the X06 child issue and proceed.
+1. Open https://kubernetes.io/releases/ — record the three supported minors and the date.
+2. Diff against `latest_stable_track.supported_minors` and files under `src/content/docs/k8s/releases/`.
+3. Confirm kindest node tags on Docker Hub before writing `kind_node_images` (example: `v1.36.0` was unpublished; `v1.36.1` was the pin).
 
 ## Inventory
 
-1. Read the official release blog (`kubernetes.io/blog/.../kubernetes-v1-XX-release/`).
-2. Skim `CHANGELOG/CHANGELOG-1.XX.md` for removals/deprecations.
-3. Classify: Stable / Beta / Alpha / Deprecated / Removed.
-4. Set **cert impact**: `none` | `watch` | `bump-needed` (bump-needed only when exam pin moves).
+1. Official release blog: `https://kubernetes.io/blog/YYYY/MM/DD/kubernetes-v1-XX-release/`.
+2. `CHANGELOG/CHANGELOG-1.XX.md` — removals and deprecations first.
+3. Classify: Stable / Beta (esp. on-by-default) / Alpha / Deprecated / Removed.
+4. Set **cert impact**: `none` | `watch` | `bump-needed`.
+   - `bump-needed` **only** when the exam pin is moving in a separate Track A PR.
+   - `watch` = exam still pinned, but cert prose may have stale “coming in 1.XX” callouts (fix surgically, later).
 
-## Author
+## Author (Track B)
 
-Copy the structure of an existing `v1.XX.md` Release Radar page:
+Copy [`kubernetes-release-bundle-template.md`](./kubernetes-release-bundle-template.md) into `src/content/docs/k8s/releases/v1.XX.md` (keep existing `v1.35.md` / `v1.36.md` / `v1.37.md` as the pattern):
 
 - Executive summary + theme name
-- Learner-visible Stable table (who cares)
+- Learner-visible Stable table (who cares — not the full CHANGELOG)
 - Deprecations / removals
 - Cert impact box
 - Practice pointers (kind image from `docs/pins/kubernetes.yaml`)
 - Sources (official links + verification date)
 
-Update `latest_stable_track.supported_minors` and sidebar order (newest first). Add a What’s New (`changelog.md`) bullet.
+Then:
+
+1. Update `latest_stable_track.supported_minors` and `as_of`.
+2. Sidebar order: newest first (current convention: 1.37 = 3, 1.36 = 4, 1.35 = 5).
+3. Add a What’s New (`src/content/docs/changelog.md`) bullet.
+4. English only. One minor (or one retire) per PR when possible.
 
 ## Review / merge
 
-Cross-family review on exact head. Build from **primary** checkout, not a worktree.
+Cross-family review on exact head. Build from the **primary** checkout, not a worktree. Do not claim a main-checkout build validates unmerged worktree edits.
 
 ## Retire
 
-When a minor leaves upstream support, move its page to an “Archive” note on the Release Radar index; keep the page for history but remove it from “supported now”.
+When a minor leaves upstream support, add an “Archive” note on the Release Radar index; keep the page for history; remove it from “supported now” and from `supported_minors`.
 
-## Exam-pin bump (rare)
+## Exam-pin bump (Track A, rare)
 
-Only when LF/CNCF exam environment version changes:
+Only when the LF sources in **Verify exam pin** all show a new environment version:
 
-1. Update `exam_pin` in `docs/pins/kubernetes.yaml` with new `verified_date`.
-2. Update `AGENTS.md`, `.claude/rules/module-quality.md`, `scripts/prompts/module-writer.md`.
-3. Grep `1.3N` / `v1-3N.docs` / `kindest/node:v1.3N` / fixture scripts — surgical patches only, driven by Release Radar migration notes.
-4. Separate PR from Release Radar delta authorship.
+1. Update `exam_pin` in `docs/pins/kubernetes.yaml` (`kubernetes_minor`, `verified_date`, `verified_note` with the quoted sentence).
+2. Update `AGENTS.md`, `.claude/rules/module-quality.md`, `scripts/prompts/module-writer.md` to the new pin.
+3. Grep `1.3N` / `v1-3N.docs` / `kindest/node:v1.3N` / fixture scripts — **surgical** patches only, driven by Release Radar migration notes.
+4. Separate PR from Track B authorship. Still `Refs #2542` (and #2280 if a cert-track upgrade issue is open). Never close #2542 from the bump PR alone.
+
+## Packet hygiene
+
+- One concern, fewer than 20 files.
+- No generated artifacts (`.pipeline/`, `dist/`, `node_modules/`).
+- After merge, the next #2542 packet is whatever AC remains — do not reopen closed children #2543–#2548 unless a real gap appears.

--- a/scripts/agent_onboarding.md
+++ b/scripts/agent_onboarding.md
@@ -20,6 +20,9 @@ bash scripts/cold-start.sh --manifest
 Emits labeled sections: `workspace`, `pending-decisions`, `briefing`, `orient`, `session`.
 On API failure: `STATUS.md` excerpt + handoff path, exit 0. Copy-paste ritual:
 [`scripts/prompts/cold-start.md`](prompts/cold-start.md).
+If the issue is a Kubernetes minor or exam-pin question, read
+[`docs/release-maintenance/kubernetes-minor-release-playbook.md`](../docs/release-maintenance/kubernetes-minor-release-playbook.md)
+before editing (exam pin ≠ latest-stable Release Radar).
 
 Individual endpoints (when you need one call without the full ritual):
 

--- a/scripts/prompts/cold-start.md
+++ b/scripts/prompts/cold-start.md
@@ -13,6 +13,9 @@ and the relevant files; no service startup or full handoff is needed.
 ```
 1. Read GitHub issue #N verbatim (parent task).
    gh issue view N --repo kube-dojo/kube-dojo.github.io
+   If the issue is a Kubernetes minor, exam-version bump, or “update certs to latest K8s”:
+   read docs/release-maintenance/kubernetes-minor-release-playbook.md before editing.
+   Dual-track: exam_pin ≠ latest_stable_track. Refs #2542 only (never Resolves).
 
 2. Orient (services-up + workspace + API):
    KUBEDOJO_ISSUE=N bash scripts/cold-start.sh

--- a/scripts/prompts/module-writer.md
+++ b/scripts/prompts/module-writer.md
@@ -88,7 +88,7 @@ TASK: Write a complete KubeDojo educational module.
 - YAML: 2-space indentation, valid syntax
 - Code blocks must specify the language (```bash, ```yaml, ```go, etc.)
 - Do NOT rely on shell aliases in runnable Bash examples. Do not define a short alias for `kubectl`, and do not use the `k` shorthand for get/describe/apply-style commands inside fenced ```bash / ```sh / ```shell / ```zsh blocks. Aliases do not expand in non-interactive shells, so use the full `kubectl` binary name in copy-paste examples. Prose like "many engineers use a short kubectl alias interactively" is fine.
-- Kubernetes version: 1.35+ for exam-pinned cert modules; use Release Radar (`/k8s/releases/`) for 1.36/1.37+ deltas
+- Kubernetes version: 1.35+ for exam-pinned cert modules; use Release Radar (`/k8s/releases/`) for 1.36/1.37+ deltas. Standing trigger for a new minor: `docs/release-maintenance/kubernetes-minor-release-playbook.md`. Do not rewrite cert tracks on upstream GA.
 
 **PEDAGOGICAL REQUIREMENTS** (from `docs/pedagogical-framework.md`):
 - Every module must operate at Bloom's Taxonomy Level 3 (Apply) or above

--- a/src/content/docs/changelog.md
+++ b/src/content/docs/changelog.md
@@ -8,6 +8,7 @@ sidebar:
 
 ## September 2026
 
+- **Exam-pin verification sources.** The [exam version policy](/k8s/releases/exam-version-policy/) now names the official LF FAQ and CKA/CKAD/CKS product pages to re-check before any exam-pin bump, and the agent playbook is the standing trigger for each new upstream minor. Re-verified 2026-09-13: exam environment still **v1.35**. Workstream #2542.
 - **Kubernetes Release Radar (1.35 / 1.36 / 1.37).** New [Release Radar](/k8s/releases/) under Certifications: dual-track [exam version policy](/k8s/releases/exam-version-policy/) (exam pin stays **1.35** until LF moves), per-minor pages for [1.37 Garhwal](/k8s/releases/v1.37/), [1.36 Haru](/k8s/releases/v1.36/), and [1.35 Timbernetes](/k8s/releases/v1.35/), plus a [kind practice matrix](/k8s/releases/practice-kind-matrix/). Machine pins in `docs/pins/kubernetes.yaml`; agent playbook in `docs/release-maintenance/`. Workstream #2542 (X06).
 
 ## June 2026

--- a/src/content/docs/k8s/releases/exam-version-policy.md
+++ b/src/content/docs/k8s/releases/exam-version-policy.md
@@ -14,7 +14,7 @@ KubeDojo runs **two tracks** on purpose. Mixing them is how learners fail exams 
 |-------|-------|
 | Current pin | **Kubernetes 1.35** |
 | Applies to | CKA, CKAD, CKS, and associate tracks that declare the same target |
-| Verified | 2026-09-12 (re-check LF/CNCF exam docs before any bump) |
+| Verified | 2026-09-13 (LF FAQ + CKA/CKAD/CKS product pages still say v1.35) |
 | Source of truth | `docs/pins/kubernetes.yaml` → `exam_pin` |
 
 **Rules**
@@ -22,6 +22,20 @@ KubeDojo runs **two tracks** on purpose. Mixing them is how learners fail exams 
 - Cert modules teach the **exam environment** version, not “whatever is newest on kubernetes.io”.
 - Upstream GA of 1.36 or 1.37 does **not** by itself authorize a cert-corpus rewrite.
 - Bump the pin only after web-verified evidence that the Linux Foundation / CNCF exam (or published curriculum PDF) moved.
+- The LF note that exam environments “align with the most recent K8s minor version within approximately 4 to 8 weeks” is a **forecast**. It is not proof that today’s exam already moved.
+
+### How to verify the exam pin
+
+Agents and editors must re-check these official pages on the same day before changing `exam_pin` (all must agree):
+
+| Source | What to read |
+|--------|----------------|
+| [LF FAQ — exam environment](https://docs.linuxfoundation.org/tc-docs/certification/faq-cka-ckad-cks) | “What application version is running in the Exam Environment?” |
+| [CKA](https://training.linuxfoundation.org/certification/certified-kubernetes-administrator-cka/) | “The exam is based on Kubernetes v…” |
+| [CKAD](https://training.linuxfoundation.org/certification/certified-kubernetes-application-developer-ckad/) | same sentence |
+| [CKS](https://training.linuxfoundation.org/certification/certified-kubernetes-security-specialist/) | same sentence |
+
+Re-verified **2026-09-13**: CKA, CKAD, and CKS still state **Kubernetes v1.35**. Record the date and a verbatim quote in `docs/pins/kubernetes.yaml` when the pin moves.
 
 Look for the inline target callouts already used in cert part-0 modules (for example CKA exam strategy). Prefer linking here rather than inventing a second story per lesson.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Next **#2542** currency packet after #2550. Inspected main: Release Radar IA, 1.35–1.37 bundles, policy stub, kind matrix, and a short playbook **already exist**. The kind matrix page is not missing; teaching arcs / executed diff labs stay parked.

This slice completes the incomplete AC **“policy + agent rules make exam-pin vs latest-stable unambiguous”** and **“agent playbook is the standing trigger for every future minor”**:

- Expand `docs/release-maintenance/kubernetes-minor-release-playbook.md` with triggers, LF verification URLs, decision tree, file allow/deny, and `Refs #2542` (never Resolves).
- Add `.claude/rules/kubernetes-release-tracks.md` and hook discovery from `AGENTS.md`, cold-start, onboarding, and the new-content checklist.
- Name official exam-pin sources on the learner [exam version policy](/k8s/releases/exam-version-policy/) page.
- Re-verified **2026-09-13**: LF FAQ + CKA/CKAD/CKS product pages still say **Kubernetes v1.35**. Pin minor unchanged.

## CF:CHANGES follow-up (`fdc85508` on `c01fd36`)

1. **Allow/deny** — added an explicit **Process / playbook packet** allow for the discovery hooks this PR installed (dual-track rule, AGENTS/CLAUDE pointers, cold-start, onboarding, new-content checklist, playbook/template, re-verify-without-bump note). Track A still owns exam-pin **version-number** lines.
2. **`verified_note`** — now quotes the LF FAQ verbatim: `The CKA exam environment is currently running Kubernetes v1.35`. Playbook requires that verbatim sentence (plus source/date) on any `exam_pin` field edit.

No teaching arcs / diff labs. CF re-review left for the CF seat.

## Out of scope

- No CKA/CKAD/CKS pedagogy rewrite
- No new kind lab / Killercoda polish
- No Ukrainian

## Verification

- [x] `git diff --check` clean on the CF-fix commit
- [x] 12 files on the original packet; CF fix is playbook + pins only
- [x] Primary checkout remains on `main`
- [x] CI on `fdc85508`: 11/11 checks green
- [ ] Cross-family re-review on exact head (not this seat)

Refs #2542

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2828e895-ab43-4f33-b48d-1ece0bd0a6b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2828e895-ab43-4f33-b48d-1ece0bd0a6b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

