### PR TITLE
fix(prereq): honest time bands for zero-to-terminal 0.1–0.5 (#2570)

### DIFF
--- a/src/content/docs/prerequisites/zero-to-terminal/module-0.1-what-is-a-computer.md
+++ b/src/content/docs/prerequisites/zero-to-terminal/module-0.1-what-is-a-computer.md
@@ -7,7 +7,7 @@ revision_pending: false
 ---
 > **Complexity**: `[QUICK]` - No technical experience needed
 >
-> **Time to Complete**: 35 minutes
+> **Time to Complete**: 90–120 minutes (long-form beginner read + inventory practice)
 >
 > **Prerequisites**: None. Seriously, none. If you can read this, you're ready.
 

--- a/src/content/docs/prerequisites/zero-to-terminal/module-0.2-what-is-a-terminal.md
+++ b/src/content/docs/prerequisites/zero-to-terminal/module-0.2-what-is-a-terminal.md
@@ -7,7 +7,7 @@ revision_pending: false
 ---
 > **Complexity**: `[QUICK]` - Absolute beginner
 >
-> **Time to Complete**: 25-35 minutes
+> **Time to Complete**: 90–120 minutes (long-form beginner read + hands-on prompts)
 >
 > **Prerequisites**: None. Seriously, none. If you can read this sentence, you're ready.
 

--- a/src/content/docs/prerequisites/zero-to-terminal/module-0.3-first-commands.md
+++ b/src/content/docs/prerequisites/zero-to-terminal/module-0.3-first-commands.md
@@ -13,7 +13,7 @@ lab:
 ---
 > **Complexity**: `[QUICK]` - Follow along and type what you see
 >
-> **Time to Complete**: 25 minutes
+> **Time to Complete**: 80–100 minutes (read + Killercoda lab)
 >
 > **Prerequisites**: [Module 0.2: What is a Terminal?](../module-0.2-what-is-a-terminal/) — You should be able to open a terminal and type commands.
 

--- a/src/content/docs/prerequisites/zero-to-terminal/module-0.4-files-and-directories.md
+++ b/src/content/docs/prerequisites/zero-to-terminal/module-0.4-files-and-directories.md
@@ -13,7 +13,7 @@ lab:
 ---
 > **Complexity**: `[QUICK]` - Absolute beginner
 >
-> **Time to Complete**: 25-30 minutes
+> **Time to Complete**: 90–120 minutes (long-form beginner read + practice)
 >
 > **Prerequisites**: [Module 0.2: What is a Terminal?](../module-0.2-what-is-a-terminal/) — You should be able to open a terminal and type commands.
 

--- a/src/content/docs/prerequisites/zero-to-terminal/module-0.5-editing-files.md
+++ b/src/content/docs/prerequisites/zero-to-terminal/module-0.5-editing-files.md
@@ -13,7 +13,7 @@ lab:
 ---
 > **Complexity**: `[QUICK]` - Type what you see, save, verify, and run a tiny script
 >
-> **Time to Complete**: 35 minutes
+> **Time to Complete**: 80–100 minutes (read + editor drills)
 >
 > **Prerequisites**: [Module 0.3 - First Terminal Commands](../module-0.3-first-commands/)
 


### PR DESCRIPTION
## Summary
- T01 packet **#2570** under **#2278** / epic **#2272**
- Disposition (evidence = word count vs claimed wall-clock):

| Path | Disposition | Evidence |
|------|-------------|----------|
| `module-0.1-what-is-a-computer.md` | **revise** | ~7660 words tagged QUICK/35m → time **90–120m** |
| `module-0.2-what-is-a-terminal.md` | **revise** | ~7981 words / 25–35m → **90–120m** |
| `module-0.3-first-commands.md` | **revise** | ~7489 words + lab / 25m → **80–100m** |
| `module-0.4-files-and-directories.md` | **revise** | ~8337 words / 25–30m → **90–120m** |
| `module-0.5-editing-files.md` | **revise** | ~7011 words / 35m → **80–100m** |

QUICK kept as beginner audience tier (rubric). Content body retained; load-bearing fix is honest time bands only (+5/−5). Lab URLs for 0.3–0.5 match labs dirs.

Refs #2570 #2278 #2272 — does not close parent T01.

## Test plan
- [ ] `git diff --check`
- [ ] Exact-head CF comment
- [ ] Astro/content CI green

Made with [Cursor](https://cursor.com)