### PR TITLE
fix(prereq): honest time bands for zero-to-terminal 0.6–0.9 (#2572)

### DIFF
--- a/src/content/docs/prerequisites/zero-to-terminal/module-0.6-git-basics.md
+++ b/src/content/docs/prerequisites/zero-to-terminal/module-0.6-git-basics.md
@@ -8,7 +8,7 @@ sidebar:
 
 > **Complexity**: `[QUICK]`
 >
-> **Time to Complete**: 60 minutes
+> **Time to Complete**: 90–120 minutes (long-form beginner read + git drills)
 >
 > **Prerequisites**: Module 0.5 (Editing Files)
 

--- a/src/content/docs/prerequisites/zero-to-terminal/module-0.7-what-is-networking.md
+++ b/src/content/docs/prerequisites/zero-to-terminal/module-0.7-what-is-networking.md
@@ -7,7 +7,7 @@ revision_pending: false
 ---
 > **Complexity**: `[QUICK]` - Absolute beginner
 >
-> **Time to Complete**: 35-45 minutes
+> **Time to Complete**: 90–120 minutes (long-form beginner read)
 >
 > **Prerequisites**: [Module 0.4: Files and Directories](../module-0.4-files-and-directories/) - You should be comfortable running commands and navigating directories.
 

--- a/src/content/docs/prerequisites/zero-to-terminal/module-0.8-servers-and-ssh.md
+++ b/src/content/docs/prerequisites/zero-to-terminal/module-0.8-servers-and-ssh.md
@@ -13,7 +13,7 @@ lab:
 ---
 > **Complexity**: `[QUICK]` - Concepts and a hands-on connection
 >
-> **Time to Complete**: 25 minutes
+> **Time to Complete**: 80–100 minutes (read + Killercoda lab)
 >
 > **Prerequisites**: [Module 0.5 - Editing Files](../module-0.5-editing-files/)
 

--- a/src/content/docs/prerequisites/zero-to-terminal/module-0.9-software-and-packages.md
+++ b/src/content/docs/prerequisites/zero-to-terminal/module-0.9-software-and-packages.md
@@ -13,7 +13,7 @@ lab:
 ---
 > **Complexity**: `[QUICK]` - Absolute beginner
 >
-> **Time to Complete**: 25-30 minutes
+> **Time to Complete**: 80–100 minutes (read + Killercoda lab)
 >
 > **Prerequisites**: [Module 0.7: What is Networking?](/prerequisites/zero-to-terminal/module-0.7-what-is-networking/) - You should be comfortable with the terminal, files, and basic networking concepts.
 


### PR DESCRIPTION
## Summary
T01 packet **#2572** under **#2278** / epic **#2272** (disjoint from #2571).

| Path | Disposition | Evidence |
|------|-------------|----------|
| `module-0.6-git-basics.md` | revise | ~7504w / 60m → 90–120m |
| `module-0.7-what-is-networking.md` | revise | ~7909w / 35–45m → 90–120m |
| `module-0.8-servers-and-ssh.md` | revise | ~7301w / 25m → 80–100m |
| `module-0.9-software-and-packages.md` | revise | ~7318w / 25–30m → 80–100m |

Refs #2572 #2278 #2272

## Test plan
- [ ] CF exact-head + CI green

Made with [Cursor](https://cursor.com)